### PR TITLE
ECO-118: add human readable market name to markets table

### DIFF
--- a/src/rust/api/sqlx-data.json
+++ b/src/rust/api/sqlx-data.json
@@ -1,6 +1,33 @@
 {
   "db": "PostgreSQL",
-  "2dbdefb8d899d757e1df1e5c9bff7004395f69e8c70af2c3d95ca73e526f0e32": {
+  "2015247b0c3cae8f90715a5fa1f9d682f8ddc3dc67097599a7c0ddccf73eb75c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "price",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "size!",
+          "ordinal": 1,
+          "type_info": "Numeric"
+        }
+      ],
+      "nullable": [
+        false,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Numeric",
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n        select\n            price,\n            sum(size) as \"size!\"\n        from orders where\n            market_id = $1 and\n            order_state = 'open' and\n            side = 'bid'\n        group by price order by price desc limit $2;\n        "
+  },
+  "2a38e3095c7b4c79aaea71cb1e3a59feeb2502cf6bae6ebe9bd076c77c9cc8c4": {
     "describe": {
       "columns": [
         {
@@ -56,104 +83,76 @@
         ]
       }
     },
-    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_1m where market_id = $1 and start_time >= $2 and start_time < $3;\n                "
+    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_30m where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;\n                "
   },
-  "47951b4ce2b744a6b9da1a5980b538cf1ab8bb2bc5f5c132d9d0162e99edcb60": {
+  "30cd7a70a416616a09ecd5565d6c76c945a3c6875bbcc236a4b8f0c4569bb513": {
     "describe": {
       "columns": [
         {
-          "name": "market_id",
+          "name": "market_order_id",
           "ordinal": 0,
           "type_info": "Numeric"
         },
         {
-          "name": "base_name?",
+          "name": "market_id",
           "ordinal": 1,
-          "type_info": "Text"
+          "type_info": "Numeric"
         },
         {
-          "name": "base_symbol?",
+          "name": "side: db::models::order::Side",
           "ordinal": 2,
-          "type_info": "Varchar"
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "bid",
+                  "ask"
+                ]
+              },
+              "name": "side"
+            }
+          }
         },
         {
-          "name": "base_decimals?",
+          "name": "size",
           "ordinal": 3,
-          "type_info": "Int2"
+          "type_info": "Numeric"
         },
         {
-          "name": "base_account_address",
+          "name": "price",
           "ordinal": 4,
-          "type_info": "Varchar"
+          "type_info": "Numeric"
         },
         {
-          "name": "base_module_name",
+          "name": "user_address",
           "ordinal": 5,
-          "type_info": "Text"
+          "type_info": "Varchar"
         },
         {
-          "name": "base_struct_name",
+          "name": "custodian_id",
           "ordinal": 6,
-          "type_info": "Text"
+          "type_info": "Numeric"
         },
         {
-          "name": "base_name_generic",
+          "name": "order_state: db::models::order::OrderState",
           "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "quote_name",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "quote_symbol",
-          "ordinal": 9,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "quote_decimals",
-          "ordinal": 10,
-          "type_info": "Int2"
-        },
-        {
-          "name": "quote_account_address",
-          "ordinal": 11,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "quote_module_name",
-          "ordinal": 12,
-          "type_info": "Text"
-        },
-        {
-          "name": "quote_struct_name",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "lot_size",
-          "ordinal": 14,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "tick_size",
-          "ordinal": 15,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "min_size",
-          "ordinal": 16,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "underwriter_id",
-          "ordinal": 17,
-          "type_info": "Numeric"
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "open",
+                  "filled",
+                  "cancelled",
+                  "evicted"
+                ]
+              },
+              "name": "order_state"
+            }
+          }
         },
         {
           "name": "created_at",
-          "ordinal": 18,
+          "ordinal": 8,
           "type_info": "Timestamptz"
         }
       ],
@@ -162,29 +161,124 @@
         false,
         false,
         false,
+        false,
+        false,
         true,
-        true,
-        true,
-        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        select\n            market_order_id,\n            market_id,\n            side as \"side: db::models::order::Side\",\n            size,\n            price,\n            user_address,\n            custodian_id,\n            order_state as \"order_state: db::models::order::OrderState\",\n            created_at\n        from orders where user_address = $1 and order_state = 'open'\n        order by created_at;\n        "
+  },
+  "5b29eac9a1e308e5e4e9045118d5bba91469bf47ae8d716016d1931bf33bde6e": {
+    "describe": {
+      "columns": [
+        {
+          "name": "market_id",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "start_time",
+          "ordinal": 1,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "open",
+          "ordinal": 2,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "high",
+          "ordinal": 3,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "low",
+          "ordinal": 4,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "close",
+          "ordinal": 5,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "volume",
+          "ordinal": 6,
+          "type_info": "Numeric"
+        }
+      ],
+      "nullable": [
         false,
         false,
         false,
         false,
         false,
         false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Numeric",
+          "Timestamptz",
+          "Timestamptz"
+        ]
+      }
+    },
+    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_1m where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;\n                "
+  },
+  "8b13d24afeefc62bea2992669ef596a81a4e955b8d6f2b0f3e6fff9b34dc7d02": {
+    "describe": {
+      "columns": [
+        {
+          "name": "price",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "size!",
+          "ordinal": 1,
+          "type_info": "Numeric"
+        }
+      ],
+      "nullable": [
         false,
-        false,
-        false,
-        false,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Numeric",
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n        select\n            price,\n            sum(size) as \"size!\"\n        from orders where\n            market_id = $1 and\n            order_state = 'open' and\n            side = 'ask'\n        group by price order by price limit $2;\n        "
+  },
+  "a65c6cd1719b1dfdf608c71366e0086b5eaa068f392296a6c98a506570b68a0d": {
+    "describe": {
+      "columns": [
+        {
+          "name": "market_id",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        }
+      ],
+      "nullable": [
         false
       ],
       "parameters": {
         "Left": []
       }
     },
-    "query": "\n        select\n            market_id,\n            base.name as \"base_name?\",\n            base.symbol as \"base_symbol?\",\n            base.decimals as \"base_decimals?\",\n            base_account_address,\n            base_module_name,\n            base_struct_name,\n            base_name_generic,\n            quote.name as quote_name,\n            quote.symbol as quote_symbol,\n            quote.decimals as quote_decimals,\n            quote_account_address,\n            quote_module_name,\n            quote_struct_name,\n            lot_size,\n            tick_size,\n            min_size,\n            underwriter_id,\n            created_at\n        from markets\n            left join coins base on markets.base_account_address = base.account_address\n                                and markets.base_module_name = base.module_name\n                                and markets.base_struct_name = base.struct_name\n            join coins quote on markets.quote_account_address = quote.account_address\n                                and markets.quote_module_name = quote.module_name\n                                and markets.quote_struct_name = quote.struct_name;\n        "
+    "query": "select market_id from markets;"
   },
-  "52b2ffea64aea2b3743e1c4f2c69e9a0ee4f2f8099de88c8dcc28543ca07f8fd": {
+  "a78bc2aa43f9e0709032bedfe0cc9d4b88832ad7714e546bf1829c32da9d910e": {
     "describe": {
       "columns": [
         {
@@ -240,9 +334,9 @@
         ]
       }
     },
-    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_5m where market_id = $1 and start_time >= $2 and start_time < $3;\n                "
+    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_1h where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;\n                "
   },
-  "670cbc9cb8307928e5f840d794277b881388288b0cc715af35283be73e09727c": {
+  "c6b852662de33f8151d8a2d8fedc1a59d474da1d71fd70bd8ad9ccfe4580e12c": {
     "describe": {
       "columns": [
         {
@@ -298,9 +392,99 @@
         ]
       }
     },
-    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_1h where market_id = $1 and start_time >= $2 and start_time < $3;\n                "
+    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_5m where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;;\n                "
   },
-  "9b6957a0c7fbf019627926acde84f5dbe9715dfe47984b1dc0cff46778220ee1": {
+  "d2281b8cf774e2357abc187626bcd150c7cdd7d54edb1d1d5ecb5c29f90eb0e8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "market_order_id",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "market_id",
+          "ordinal": 1,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "side: db::models::order::Side",
+          "ordinal": 2,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "bid",
+                  "ask"
+                ]
+              },
+              "name": "side"
+            }
+          }
+        },
+        {
+          "name": "size",
+          "ordinal": 3,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "price",
+          "ordinal": 4,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "user_address",
+          "ordinal": 5,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "custodian_id",
+          "ordinal": 6,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "order_state: db::models::order::OrderState",
+          "ordinal": 7,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "open",
+                  "filled",
+                  "cancelled",
+                  "evicted"
+                ]
+              },
+              "name": "order_state"
+            }
+          }
+        },
+        {
+          "name": "created_at",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        select\n            market_order_id,\n            market_id,\n            side as \"side: db::models::order::Side\",\n            size,\n            price,\n            user_address,\n            custodian_id,\n            order_state as \"order_state: db::models::order::OrderState\",\n            created_at\n        from orders where user_address = $1 order by created_at;\n        "
+  },
+  "d49006409169708b35213dcc1d0bcd20a0d385618ba5fc3b6f8c6e67f578703f": {
     "describe": {
       "columns": [
         {
@@ -356,9 +540,9 @@
         ]
       }
     },
-    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_30m where market_id = $1 and start_time >= $2 and start_time < $3;\n                "
+    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_15m where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;;\n                "
   },
-  "a182c31a8505d94233a599c907ca3666f195671cf7dece182a508bff83028e97": {
+  "d9eee3402cd0275d7bea3b9f82e66e866172338c7c1c772eddafe41c44abdf31": {
     "describe": {
       "columns": [
         {
@@ -430,76 +614,109 @@
         ]
       }
     },
-    "query": "\n        select\n            market_id,\n            maker_order_id,\n            maker,\n            maker_side as \"maker_side: db::models::order::Side\",\n            custodian_id,\n            size,\n            price,\n            time\n        from fills where market_id = $1 and time >= $2 and time < $3;\n        "
+    "query": "\n        select\n            market_id,\n            maker_order_id,\n            maker,\n            maker_side as \"maker_side: db::models::order::Side\",\n            custodian_id,\n            size,\n            price,\n            time\n        from fills where market_id = $1 and time >= $2 and time < $3 order by time;\n        "
   },
-  "a39eafd185d90b2f3f88804dad6764bc900a09c838c3a5080c82a7586523a111": {
+  "f701355ff460ca4de725f64611233c00ab2505ba0ecbd394ab37cc02f204a87c": {
     "describe": {
       "columns": [
         {
-          "name": "market_order_id",
+          "name": "market_id",
           "ordinal": 0,
           "type_info": "Numeric"
         },
         {
-          "name": "market_id",
+          "name": "name",
           "ordinal": 1,
-          "type_info": "Numeric"
+          "type_info": "Text"
         },
         {
-          "name": "side: db::models::order::Side",
+          "name": "base_name?",
           "ordinal": 2,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "bid",
-                  "ask"
-                ]
-              },
-              "name": "side"
-            }
-          }
+          "type_info": "Text"
         },
         {
-          "name": "size",
+          "name": "base_symbol?",
           "ordinal": 3,
-          "type_info": "Numeric"
+          "type_info": "Varchar"
         },
         {
-          "name": "price",
+          "name": "base_decimals?",
           "ordinal": 4,
-          "type_info": "Numeric"
+          "type_info": "Int2"
         },
         {
-          "name": "user_address",
+          "name": "base_account_address",
           "ordinal": 5,
           "type_info": "Varchar"
         },
         {
-          "name": "custodian_id",
+          "name": "base_module_name",
           "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "base_struct_name",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "base_name_generic",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "quote_name",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "quote_symbol",
+          "ordinal": 10,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "quote_decimals",
+          "ordinal": 11,
+          "type_info": "Int2"
+        },
+        {
+          "name": "quote_account_address",
+          "ordinal": 12,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "quote_module_name",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "quote_struct_name",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "lot_size",
+          "ordinal": 15,
           "type_info": "Numeric"
         },
         {
-          "name": "order_state: db::models::order::OrderState",
-          "ordinal": 7,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "open",
-                  "filled",
-                  "cancelled",
-                  "evicted"
-                ]
-              },
-              "name": "order_state"
-            }
-          }
+          "name": "tick_size",
+          "ordinal": 16,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "min_size",
+          "ordinal": 17,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "underwriter_id",
+          "ordinal": 18,
+          "type_info": "Numeric"
         },
         {
           "name": "created_at",
-          "ordinal": 8,
+          "ordinal": 19,
           "type_info": "Timestamptz"
         }
       ],
@@ -509,183 +726,26 @@
         false,
         false,
         false,
-        false,
+        true,
+        true,
+        true,
         true,
         false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        select\n            market_order_id,\n            market_id,\n            side as \"side: db::models::order::Side\",\n            size,\n            price,\n            user_address,\n            custodian_id,\n            order_state as \"order_state: db::models::order::OrderState\",\n            created_at\n        from orders where user_address = $1;\n        "
-  },
-  "a65c6cd1719b1dfdf608c71366e0086b5eaa068f392296a6c98a506570b68a0d": {
-    "describe": {
-      "columns": [
-        {
-          "name": "market_id",
-          "ordinal": 0,
-          "type_info": "Numeric"
-        }
-      ],
-      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
         false
       ],
       "parameters": {
         "Left": []
       }
     },
-    "query": "select market_id from markets;"
-  },
-  "b3ac61f46746d3991bb3ec4221f434a55fbd8917f803b6cdf220308bf1459218": {
-    "describe": {
-      "columns": [
-        {
-          "name": "market_id",
-          "ordinal": 0,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "start_time",
-          "ordinal": 1,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "open",
-          "ordinal": 2,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "high",
-          "ordinal": 3,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "low",
-          "ordinal": 4,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "close",
-          "ordinal": 5,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "volume",
-          "ordinal": 6,
-          "type_info": "Numeric"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Numeric",
-          "Timestamptz",
-          "Timestamptz"
-        ]
-      }
-    },
-    "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_15m where market_id = $1 and start_time >= $2 and start_time < $3;\n                "
-  },
-  "f32d53a691323ee26f27236fc3a27524312afb9bbbef53eb7ed08fcddd591668": {
-    "describe": {
-      "columns": [
-        {
-          "name": "market_order_id",
-          "ordinal": 0,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "market_id",
-          "ordinal": 1,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "side: db::models::order::Side",
-          "ordinal": 2,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "bid",
-                  "ask"
-                ]
-              },
-              "name": "side"
-            }
-          }
-        },
-        {
-          "name": "size",
-          "ordinal": 3,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "price",
-          "ordinal": 4,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "user_address",
-          "ordinal": 5,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "custodian_id",
-          "ordinal": 6,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "order_state: db::models::order::OrderState",
-          "ordinal": 7,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "open",
-                  "filled",
-                  "cancelled",
-                  "evicted"
-                ]
-              },
-              "name": "order_state"
-            }
-          }
-        },
-        {
-          "name": "created_at",
-          "ordinal": 8,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        select\n            market_order_id,\n            market_id,\n            side as \"side: db::models::order::Side\",\n            size,\n            price,\n            user_address,\n            custodian_id,\n            order_state as \"order_state: db::models::order::OrderState\",\n            created_at\n        from orders where user_address = $1 and order_state = 'open';\n        "
+    "query": "\n        select\n            market_id,\n            markets.name as name,\n            base.name as \"base_name?\",\n            base.symbol as \"base_symbol?\",\n            base.decimals as \"base_decimals?\",\n            base_account_address,\n            base_module_name,\n            base_struct_name,\n            base_name_generic,\n            quote.name as quote_name,\n            quote.symbol as quote_symbol,\n            quote.decimals as quote_decimals,\n            quote_account_address,\n            quote_module_name,\n            quote_struct_name,\n            lot_size,\n            tick_size,\n            min_size,\n            underwriter_id,\n            created_at\n        from markets\n            left join coins base on markets.base_account_address = base.account_address\n                                and markets.base_module_name = base.module_name\n                                and markets.base_struct_name = base.struct_name\n            join coins quote on markets.quote_account_address = quote.account_address\n                                and markets.quote_module_name = quote.module_name\n                                and markets.quote_struct_name = quote.struct_name\n            order by market_id;\n        "
   }
 }

--- a/src/rust/api/src/routes.rs
+++ b/src/rust/api/src/routes.rs
@@ -55,6 +55,7 @@ async fn markets(State(state): State<AppState>) -> Result<Json<Vec<types::Market
         r#"
         select
             market_id,
+            markets.name as name,
             base.name as "base_name?",
             base.symbol as "base_symbol?",
             base.decimals as "base_decimals?",
@@ -79,7 +80,8 @@ async fn markets(State(state): State<AppState>) -> Result<Json<Vec<types::Market
                                 and markets.base_struct_name = base.struct_name
             join coins quote on markets.quote_account_address = quote.account_address
                                 and markets.quote_module_name = quote.module_name
-                                and markets.quote_struct_name = quote.struct_name;
+                                and markets.quote_struct_name = quote.struct_name
+            order by market_id;
         "#
     )
     .fetch_all(&state.pool)

--- a/src/rust/api/src/routes/account.rs
+++ b/src/rust/api/src/routes/account.rs
@@ -23,7 +23,7 @@ pub async fn order_history_by_account(
             custodian_id,
             order_state as "order_state: db::models::order::OrderState",
             created_at
-        from orders where user_address = $1;
+        from orders where user_address = $1 order by created_at;
         "#,
         account_address
     )
@@ -59,7 +59,8 @@ pub async fn open_orders_by_account(
             custodian_id,
             order_state as "order_state: db::models::order::OrderState",
             created_at
-        from orders where user_address = $1 and order_state = 'open';
+        from orders where user_address = $1 and order_state = 'open'
+        order by created_at;
         "#,
         account_address
     )

--- a/src/rust/api/src/routes/market.rs
+++ b/src/rust/api/src/routes/market.rs
@@ -130,7 +130,8 @@ pub async fn get_market_history(
                     low,
                     close,
                     volume
-                from bars_1m where market_id = $1 and start_time >= $2 and start_time < $3;
+                from bars_1m where market_id = $1 and start_time >= $2 and start_time < $3
+                order by start_time;
                 "#,
                 market_id,
                 from,
@@ -151,7 +152,8 @@ pub async fn get_market_history(
                     low,
                     close,
                     volume
-                from bars_5m where market_id = $1 and start_time >= $2 and start_time < $3;
+                from bars_5m where market_id = $1 and start_time >= $2 and start_time < $3
+                order by start_time;;
                 "#,
                 market_id,
                 from,
@@ -172,7 +174,8 @@ pub async fn get_market_history(
                     low,
                     close,
                     volume
-                from bars_15m where market_id = $1 and start_time >= $2 and start_time < $3;
+                from bars_15m where market_id = $1 and start_time >= $2 and start_time < $3
+                order by start_time;;
                 "#,
                 market_id,
                 from,
@@ -193,7 +196,8 @@ pub async fn get_market_history(
                     low,
                     close,
                     volume
-                from bars_30m where market_id = $1 and start_time >= $2 and start_time < $3;
+                from bars_30m where market_id = $1 and start_time >= $2 and start_time < $3
+                order by start_time;
                 "#,
                 market_id,
                 from,
@@ -214,7 +218,8 @@ pub async fn get_market_history(
                     low,
                     close,
                     volume
-                from bars_1h where market_id = $1 and start_time >= $2 and start_time < $3;
+                from bars_1h where market_id = $1 and start_time >= $2 and start_time < $3
+                order by start_time;
                 "#,
                 market_id,
                 from,
@@ -274,7 +279,7 @@ pub async fn get_fills(
             size,
             price,
             time
-        from fills where market_id = $1 and time >= $2 and time < $3;
+        from fills where market_id = $1 and time >= $2 and time < $3 order by time;
         "#,
         market_id,
         from,

--- a/src/rust/db/migrations/2023-03-16-025536_create_markets/up.sql
+++ b/src/rust/db/migrations/2023-03-16-025536_create_markets/up.sql
@@ -14,6 +14,7 @@ create table coins (
 -- Only recognized markets should be stored in the api database.
 create table markets (
     market_id numeric (20) not null primary key,
+    name text not null unique,
     base_account_address varchar (70),
     base_module_name text,
     base_struct_name text,
@@ -52,10 +53,24 @@ create table market_registration_events (
     foreign key (market_id) references markets (market_id)
 );
 
-create function register_market() returns trigger as $register_market$ begin
-insert into markets
-values (
-        NEW.market_id,
+create function register_market() returns trigger as $register_market$
+declare
+    base_symbol varchar (8);
+    quote_symbol varchar (8);
+begin
+if new.base_name_generic is null then
+	select symbol from coins where account_address = NEW.base_account_address
+		and module_name = NEW.base_module_name and struct_name = NEW.base_struct_name
+		into base_symbol;
+
+	select symbol from coins where account_address = NEW.quote_account_address
+		and module_name = NEW.quote_module_name and struct_name = NEW.quote_struct_name
+		into quote_symbol;
+
+	insert into markets
+	values (
+       NEW.market_id,
+        base_symbol || '-' || quote_symbol,
         NEW.base_account_address,
         NEW.base_module_name,
         NEW.base_struct_name,
@@ -70,6 +85,25 @@ values (
         NEW.time
     );
 
+else
+    insert into markets
+	values (
+       NEW.market_id,
+        NEW.base_name_generic,
+        NEW.base_account_address,
+        NEW.base_module_name,
+        NEW.base_struct_name,
+        NEW.base_name_generic,
+        NEW.quote_account_address,
+        NEW.quote_module_name,
+        NEW.quote_struct_name,
+        NEW.lot_size,
+        NEW.tick_size,
+        NEW.min_size,
+        NEW.underwriter_id,
+        NEW.time
+    );
+end if;
 return NEW;
 
 end;

--- a/src/rust/db/src/models/market.rs
+++ b/src/rust/db/src/models/market.rs
@@ -12,6 +12,7 @@ use super::IntoInsertable;
 #[derive(Clone, Debug, Queryable)]
 pub struct Market {
     pub market_id: BigDecimal,
+    pub name: String,
     pub base_account_address: Option<String>,
     pub base_module_name: Option<String>,
     pub base_struct_name: Option<String>,

--- a/src/rust/db/src/schema.rs
+++ b/src/rust/db/src/schema.rs
@@ -144,6 +144,7 @@ diesel::table! {
 diesel::table! {
     markets (market_id) {
         market_id -> Numeric,
+        name -> Text,
         base_account_address -> Nullable<Varchar>,
         base_module_name -> Nullable<Text>,
         base_struct_name -> Nullable<Text>,

--- a/src/rust/types/src/lib.rs
+++ b/src/rust/types/src/lib.rs
@@ -23,6 +23,7 @@ pub struct Coin {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Market {
     pub market_id: u64,
+    pub name: String,
     pub base: Option<Coin>,
     pub base_name_generic: Option<String>,
     pub quote: Coin,

--- a/src/rust/types/src/query.rs
+++ b/src/rust/types/src/query.rs
@@ -7,6 +7,7 @@ use crate::{error::TypeError, Coin, Market};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryMarket {
     pub market_id: BigDecimal,
+    pub name: String,
     pub base_symbol: Option<String>,
     pub base_name: Option<String>,
     pub base_decimals: Option<i16>,
@@ -96,6 +97,7 @@ impl TryFrom<QueryMarket> for Market {
 
             let market = Market {
                 market_id,
+                name: value.name,
                 base: Some(base),
                 base_name_generic: value.base_name_generic,
                 quote,
@@ -127,6 +129,7 @@ impl TryFrom<QueryMarket> for Market {
             };
             let market = Market {
                 market_id,
+                name: value.name,
                 base: None,
                 base_name_generic: value.base_name_generic,
                 quote,


### PR DESCRIPTION
Adds `name` field to `/markets` endpoint so that Next.js can generate URLs that look like `https://econia.exchange/trade/APT-USDC` instead of `https://econia.exchange/trade/123`.