### PR TITLE
Layout when order switch

### DIFF
--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -88,7 +88,7 @@ export default function Market({ allMarketData, marketData }: Props) {
         <StatsBar selectedMarket={marketData} />
         <main className="flex w-full space-x-3 px-3 py-3">
           <div className="flex flex-1 flex-col space-y-3">
-            <ChartCard className="flex flex-1 flex-col">
+            <ChartCard className="flex min-h-[590px] flex-1 flex-col">
               {isScriptReady && <TVChartContainer {...defaultTVChartProps} />}
               <DepthChart marketData={marketData} />
             </ChartCard>
@@ -104,10 +104,10 @@ export default function Market({ allMarketData, marketData }: Props) {
           </div>
           <div className="flex min-w-[268px] flex-initial flex-col gap-4 border-neutral-600">
             <div className="flex flex-1 flex-col space-y-3">
-              <ChartCard className="flex-1">
+              <ChartCard>
                 <OrderEntry marketData={marketData} />
               </ChartCard>
-              <ChartCard>
+              <ChartCard className="flex-1">
                 <ChartName className="mb-3 mt-3 font-bold">
                   Trade History
                 </ChartName>


### PR DESCRIPTION
this was the only way i could think of to consistently keep a "set" chart height.
Because the chart inherently does not have any height, it's height depended on the limit order component.
to keep the chart a consistent size, added a min height according to spec.

though now I think the page will overflow vertically regularly, so take a look into this w/ kiki
row 28 in bugs spreadsheet