### PR TITLE
Eco 168: Both the Hover & Blur do not match the Figma reference

### DIFF
--- a/src/typescript/frontend/src/components/icons/ArrowIcon.tsx
+++ b/src/typescript/frontend/src/components/icons/ArrowIcon.tsx
@@ -1,0 +1,27 @@
+export const ArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
+  className,
+}) => {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 13 13"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M6.229 2.01317L10.6882 6.47241L6.229 10.9316"
+        stroke="white"
+        stroke-width="2"
+        stroke-linecap="square"
+      />
+      <path
+        d="M10.3184 6.4724L1.20117 6.4724"
+        stroke="white"
+        stroke-width="2"
+        stroke-linecap="square"
+      />
+    </svg>
+  );
+};

--- a/src/typescript/frontend/src/components/icons/ArrowIcon.tsx
+++ b/src/typescript/frontend/src/components/icons/ArrowIcon.tsx
@@ -1,5 +1,6 @@
 export const ArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
   className,
+  id,
 }) => {
   return (
     <svg
@@ -9,6 +10,7 @@ export const ArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
+      id={id}
     >
       <path
         d="M6.229 2.01317L10.6882 6.47241L6.229 10.9316"

--- a/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
+++ b/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import { BaseModal } from "@/components/BaseModal";
+import { ArrowIcon } from "@/components/icons/ArrowIcon";
 
 export type ConnectWalletContextState = {
   connectWallet: () => void;
@@ -42,7 +43,7 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
           {wallets.map((wallet) => (
             <div
               key={wallet.adapter.name}
-              className="flex w-full cursor-pointer items-center gap-2 border border-neutral-600 p-4 font-jost text-lg font-medium text-neutral-500 hover:text-white"
+              className="relative flex w-full cursor-pointer items-center gap-2 border border-neutral-600 p-4 font-jost text-lg font-medium text-neutral-500  [&:hover>#arrow-wrapper]:text-red"
               onClick={() => {
                 select(wallet.adapter.name);
                 setOpen(false);
@@ -53,12 +54,21 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
                 height={36}
                 width={36}
                 className=""
+                alt={"Wallet Icon"}
               />
               <p>
                 {wallet.readyState === WalletReadyState.NotDetected
                   ? `Install ${wallet.adapter.name} Wallet`
                   : `${wallet.adapter.name} Wallet`}
               </p>
+              {/* unsure if i'm doing something wrong, but some tailwind classes do not render, but intellisense shows that it should work */}
+              <div
+                className={"absolute border border-neutral-600"}
+                id={"arrow-wrapper"}
+                style={{ bottom: "-1px", right: "-1px", padding: "7px" }}
+              >
+                <ArrowIcon />
+              </div>
             </div>
           ))}
         </div>

--- a/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
+++ b/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
@@ -43,7 +43,7 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
           {wallets.map((wallet) => (
             <div
               key={wallet.adapter.name}
-              className="relative flex w-full cursor-pointer items-center gap-2 border border-neutral-600 p-4 font-jost text-lg font-medium text-neutral-500  [&:hover>#arrow-wrapper]:text-red"
+              className="relative flex w-full cursor-pointer items-center gap-2 border border-neutral-600 p-4 font-jost text-lg font-medium  text-neutral-500 transition-all hover:border-blue [&:hover>#arrow-wrapper]:border-blue [&:hover>#arrow-wrapper]:bg-blue [&:hover>#token-icon]:border-blue [&:hover>div>#arrow]:rotate-[-45deg]"
               onClick={() => {
                 select(wallet.adapter.name);
                 setOpen(false);
@@ -55,6 +55,7 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
                 width={36}
                 className=""
                 alt={"Wallet Icon"}
+                id={"token-icon"}
               />
               <p>
                 {wallet.readyState === WalletReadyState.NotDetected
@@ -62,12 +63,14 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
                   : `${wallet.adapter.name} Wallet`}
               </p>
               {/* unsure if i'm doing something wrong, but some tailwind classes do not render, but intellisense shows that it should work */}
+
               <div
-                className={"absolute border border-neutral-600"}
+                className={
+                  "absolute bottom-[-1px] right-[-1px] border border-neutral-600 p-[7px] transition-all"
+                }
                 id={"arrow-wrapper"}
-                style={{ bottom: "-1px", right: "-1px", padding: "7px" }}
               >
-                <ArrowIcon />
+                <ArrowIcon id={"arrow"} className={"transition-all"} />
               </div>
             </div>
           ))}

--- a/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
+++ b/src/typescript/frontend/src/contexts/ConnectWalletContext.tsx
@@ -62,8 +62,6 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
                   ? `Install ${wallet.adapter.name} Wallet`
                   : `${wallet.adapter.name} Wallet`}
               </p>
-              {/* unsure if i'm doing something wrong, but some tailwind classes do not render, but intellisense shows that it should work */}
-
               <div
                 className={
                   "absolute bottom-[-1px] right-[-1px] border border-neutral-600 p-[7px] transition-all"

--- a/src/typescript/frontend/tailwind.config.ts
+++ b/src/typescript/frontend/tailwind.config.ts
@@ -7,6 +7,7 @@ const config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/contexts/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
i believe background blur is already fixed, so just hover for now

super weird behavior that i was struggling to figure out - some tailwind classes were applying and some were not...
fixed it by updating the paths in tailwind config? see: 6ed8e33d2247ea9bf4f98978cad688775da2cf2c
https://stackoverflow.com/a/75428250


