### PR TITLE
Eco 162: When opening a narrowed down window, the stat bar appears to be cut short to the right.

### DIFF
--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -86,36 +86,38 @@ export default function Market({ allMarketData, marketData }: Props) {
     <OrderEntryContextProvider>
       <Page>
         <StatsBar selectedMarket={marketData} />
-        <main className="flex w-full space-x-3 px-3 py-3">
-          <div className="flex flex-1 flex-col space-y-3">
-            <ChartCard className="flex min-h-[590px] flex-1 flex-col">
-              {isScriptReady && <TVChartContainer {...defaultTVChartProps} />}
-              <DepthChart marketData={marketData} />
-            </ChartCard>
-            <ChartCard>
-              <ChartName className="mb-4">Orders</ChartName>
-              <OrdersTable allMarketData={allMarketData} />
-            </ChartCard>
-          </div>
-          <div className="flex min-w-[268px] flex-initial flex-col border-neutral-600">
-            <ChartCard className="flex flex-1 flex-col">
-              <OrderBook marketData={marketData} />
-            </ChartCard>
-          </div>
-          <div className="flex min-w-[268px] flex-initial flex-col gap-4 border-neutral-600">
+        <div className="overflow-hidden">
+          <main className="flex w-full space-x-3 overflow-auto px-3 py-3">
             <div className="flex flex-1 flex-col space-y-3">
-              <ChartCard>
-                <OrderEntry marketData={marketData} />
+              <ChartCard className="flex min-h-[590px] flex-1 flex-col">
+                {isScriptReady && <TVChartContainer {...defaultTVChartProps} />}
+                <DepthChart marketData={marketData} />
               </ChartCard>
-              <ChartCard className="flex-1">
-                <ChartName className="mb-3 mt-3 font-bold">
-                  Trade History
-                </ChartName>
-                <TradeHistoryTable marketData={marketData} />
+              <ChartCard>
+                <ChartName className="mb-4">Orders</ChartName>
+                <OrdersTable allMarketData={allMarketData} />
               </ChartCard>
             </div>
-          </div>
-        </main>
+            <div className="flex min-w-[268px] flex-initial flex-col border-neutral-600">
+              <ChartCard className="flex flex-1 flex-col">
+                <OrderBook marketData={marketData} />
+              </ChartCard>
+            </div>
+            <div className="flex min-w-[268px] flex-initial flex-col gap-4 border-neutral-600">
+              <div className="flex flex-1 flex-col space-y-3">
+                <ChartCard>
+                  <OrderEntry marketData={marketData} />
+                </ChartCard>
+                <ChartCard className="flex-1">
+                  <ChartName className="mb-3 mt-3 font-bold">
+                    Trade History
+                  </ChartName>
+                  <TradeHistoryTable marketData={marketData} />
+                </ChartCard>
+              </div>
+            </div>
+          </main>
+        </div>
         <Script
           src="/static/datafeeds/udf/dist/bundle.js"
           strategy="lazyOnload"


### PR DESCRIPTION
test at 780px
mimic coinbase overflow when exchange elements don't fit on screen but not narrow enough to proc mobile view