### PR TITLE
Eco 134: orderbook price level Flash animation when updated

### DIFF
--- a/src/typescript/frontend/src/components/OrderBook.tsx
+++ b/src/typescript/frontend/src/components/OrderBook.tsx
@@ -2,12 +2,12 @@ import { Listbox } from "@headlessui/react";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useOrderEntry } from "@/contexts/OrderEntryContext";
 import { useOrderBook } from "@/hooks/useOrderbook";
 import { type ApiMarket } from "@/types/api";
-import { type Precision } from "@/types/global";
+import { type Precision, type UpdatedPriceLevel } from "@/types/global";
 import { type OrderBook, type PriceLevel } from "@/types/global";
 import { averageOrOtherPriceLevel } from "@/utils/formatter";
-import { useOrderEntry } from "@/contexts/OrderEntryContext";
 
 const precisionOptions: Precision[] = [
   "0.01",
@@ -21,14 +21,17 @@ const precisionOptions: Precision[] = [
 ];
 
 const Row: React.FC<{
-  order: PriceLevel;
+  order: UpdatedPriceLevel;
   type: "bid" | "ask";
   highestSize: number;
 }> = ({ order, type, highestSize }) => {
   const { setType, setPrice } = useOrderEntry();
   return (
     <div
-      className="relative my-[1px] flex min-h-[16px] min-w-full items-center justify-between hover:font-bold hover:outline hover:outline-neutral-600"
+      className={`relative my-[1px] flex min-h-[16px] min-w-full items-center justify-between hover:font-bold hover:outline hover:outline-neutral-600 ${
+        order.didUpdate &&
+        `pulse-bg-once ${type === "ask" ? "bg-red" : "bg-green"}`
+      }`}
       onClick={() => {
         setType(type === "ask" ? "buy" : "sell");
         setPrice(order.price.toString());

--- a/src/typescript/frontend/src/components/OrderBook.tsx
+++ b/src/typescript/frontend/src/components/OrderBook.tsx
@@ -27,13 +27,23 @@ const Row: React.FC<{
   updatedLevel: PriceLevel | undefined;
 }> = ({ order, type, highestSize, updatedLevel }) => {
   const { setType, setPrice } = useOrderEntry();
+  const [flash, setFlash] = useState<string>("");
+
+  useEffect(() => {
+    if (updatedLevel == null) {
+      return;
+    }
+    if (updatedLevel.price == order.price) {
+      setFlash(type === "ask" ? "flash-red" : "flash-green");
+      setTimeout(() => {
+        setFlash("");
+      }, 100);
+    }
+  }, [order, type, updatedLevel]);
+
   return (
     <div
-      className={`relative my-[1px] flex min-h-[16px] min-w-full items-center justify-between transition-all hover:font-bold hover:outline hover:outline-neutral-600 ${
-        updatedLevel?.price == order.price &&
-        // using 50% opacity to make it more visible, as price levels with high volume
-        `flash-bg-once ${type === "ask" ? "bg-red/50" : "bg-green/50"}`
-      }`}
+      className={`flash-bg-once relative my-[1px] flex min-h-[16px] min-w-full items-center justify-between hover:font-bold hover:outline hover:outline-neutral-600 ${flash}`}
       onClick={() => {
         setType(type === "ask" ? "buy" : "sell");
         setPrice(order.price.toString());

--- a/src/typescript/frontend/src/hooks/useOrderbook.ts
+++ b/src/typescript/frontend/src/hooks/useOrderbook.ts
@@ -7,15 +7,19 @@ import {
 import { useEffect } from "react";
 
 import { API_URL } from "@/env";
-import { type OrderBook, type Precision } from "@/types/global";
-import { PriceLevel } from "@/types/global";
+import {
+  type OrderBook,
+  type OrderBookWithUpdatedLevel,
+  type Precision,
+} from "@/types/global";
+import { type PriceLevel } from "@/types/global";
 
 // TODO: precision not yet implemented in API yet, so does nothing as of now
 export const useOrderBook = (
   market_id: number,
   precision: Precision = "0.01",
   depth = 60
-): UseQueryResult<OrderBook> => {
+): UseQueryResult<OrderBookWithUpdatedLevel> => {
   const QUERY_KEY = ["orderBook", market_id, precision];
 
   /**
@@ -71,42 +75,72 @@ export const useOrderBook = (
     // testing
     setTimeout(() => {
       console.log("sending message");
-      queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
-        if (oldData) {
-          const newData: OrderBook = {
-            bids: [...oldData.bids],
-            asks: [...oldData.asks],
-          };
-          newData.bids[0] = { ...newData.bids[0], size: 100 };
-          return newData;
+      queryClient.setQueryData(
+        QUERY_KEY,
+        (oldData: OrderBookWithUpdatedLevel | undefined) => {
+          if (oldData) {
+            const newData: OrderBookWithUpdatedLevel = {
+              bids: [...oldData.bids],
+              asks: [...oldData.asks],
+              updatedLevel: {
+                price: oldData.bids[0].price,
+                size: 100,
+              },
+            };
+            newData.bids[0] = { ...newData.bids[0], size: 100 };
+            console.log(newData);
+            return newData;
+          }
+          return oldData;
         }
-        return oldData;
-      });
+      );
     }, 5000);
+    setTimeout(() => {
+      console.log("sending message");
+      queryClient.setQueryData(
+        QUERY_KEY,
+        (oldData: OrderBookWithUpdatedLevel | undefined) => {
+          if (oldData) {
+            const newData: OrderBookWithUpdatedLevel = {
+              bids: [...oldData.bids],
+              asks: [...oldData.asks],
+              updatedLevel: {
+                price: oldData.bids[1].price,
+                size: 300,
+              },
+            };
+            newData.bids[1] = { ...newData.bids[1], size: 300 };
+            console.log(newData);
+            return newData;
+          }
+          return oldData;
+        }
+      );
+    }, 5200);
 
     // we wanna test
     /**
-     * 1. update animation
-     * 2. same level getting updated twice
-     * 3. levels getting updated in quick succession before animation ends
-     * 4. same level getting updated in quick succession before animation ends
+     * 1. update animation - this works
+     * 2. same level getting updated twice - this works
+     * 3. levels getting updated in quick succession before animation ends - this does not work yet
+     * 4. same level getting updated in quick succession before animation ends - this works
      */
     //  TODO: Remove after RR
     // 1
-    setTimeout(() => {
-      console.log("sending message");
-      queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
-        if (oldData) {
-          const newData: OrderBook = {
-            bids: [...oldData.bids],
-            asks: [...oldData.asks],
-          };
-          newData.bids[0] = { ...newData.bids[0], size: 100, didUpdate: true };
-          return newData;
-        }
-        return oldData;
-      });
-    }, 5000);
+    // setTimeout(() => {
+    //   console.log("sending message");
+    //   queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
+    //     if (oldData) {
+    //       const newData: OrderBook = {
+    //         bids: [...oldData.bids],
+    //         asks: [...oldData.asks],
+    //       };
+    //       newData.bids[0] = { ...newData.bids[0], size: 100, didUpdate: true };
+    //       return newData;
+    //     }
+    //     return oldData;
+    //   });
+    // }, 5000);
 
     // 2
 

--- a/src/typescript/frontend/src/hooks/useOrderbook.ts
+++ b/src/typescript/frontend/src/hooks/useOrderbook.ts
@@ -75,7 +75,6 @@ export const useOrderBook = (
     // testing
     //  TODO: Remove after RR
     setTimeout(() => {
-      console.log("sending message");
       queryClient.setQueryData(
         QUERY_KEY,
         (oldData: OrderBookWithUpdatedLevel | undefined) => {
@@ -97,7 +96,6 @@ export const useOrderBook = (
       );
     }, 5000);
     setTimeout(() => {
-      console.log("sending message");
       queryClient.setQueryData(
         QUERY_KEY,
         (oldData: OrderBookWithUpdatedLevel | undefined) => {

--- a/src/typescript/frontend/src/hooks/useOrderbook.ts
+++ b/src/typescript/frontend/src/hooks/useOrderbook.ts
@@ -73,6 +73,7 @@ export const useOrderBook = (
     };
 
     // testing
+    //  TODO: Remove after RR
     setTimeout(() => {
       console.log("sending message");
       queryClient.setQueryData(
@@ -117,32 +118,6 @@ export const useOrderBook = (
         }
       );
     }, 5200);
-
-    // we wanna test
-    /**
-     * 1. update animation - this works
-     * 2. same level getting updated twice - this works
-     * 3. levels getting updated in quick succession before animation ends - this does not work yet
-     * 4. same level getting updated in quick succession before animation ends - this works
-     */
-    //  TODO: Remove after RR
-    // 1
-    // setTimeout(() => {
-    //   console.log("sending message");
-    //   queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
-    //     if (oldData) {
-    //       const newData: OrderBook = {
-    //         bids: [...oldData.bids],
-    //         asks: [...oldData.asks],
-    //       };
-    //       newData.bids[0] = { ...newData.bids[0], size: 100, didUpdate: true };
-    //       return newData;
-    //     }
-    //     return oldData;
-    //   });
-    // }, 5000);
-
-    // 2
 
     // cleanup
     return () => {

--- a/src/typescript/frontend/src/hooks/useOrderbook.ts
+++ b/src/typescript/frontend/src/hooks/useOrderbook.ts
@@ -48,7 +48,7 @@ export const useOrderBook = (
 
     websocket.onmessage = (event) => {
       const data: PriceLevel = JSON.parse(event.data).data;
-      updateOrderBook(data);
+      // updateOrderBook(data);
       console.log("websocket message", data);
       // queryClient.invalidateQueries({ queryKey });
     };
@@ -69,20 +69,46 @@ export const useOrderBook = (
     };
 
     // testing
-    // setTimeout(() => {
-    //   console.log("sending message");
-    //   queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
-    //     if (oldData) {
-    //       const newData: OrderBook = {
-    //         bids: [...oldData.bids],
-    //         asks: [...oldData.asks],
-    //       };
-    //       newData.bids[0] = { ...newData.bids[0], size: 100 };
-    //       return newData;
-    //     }
-    //     return oldData;
-    //   });
-    // }, 5000);
+    setTimeout(() => {
+      console.log("sending message");
+      queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
+        if (oldData) {
+          const newData: OrderBook = {
+            bids: [...oldData.bids],
+            asks: [...oldData.asks],
+          };
+          newData.bids[0] = { ...newData.bids[0], size: 100 };
+          return newData;
+        }
+        return oldData;
+      });
+    }, 5000);
+
+    // we wanna test
+    /**
+     * 1. update animation
+     * 2. same level getting updated twice
+     * 3. levels getting updated in quick succession before animation ends
+     * 4. same level getting updated in quick succession before animation ends
+     */
+    //  TODO: Remove after RR
+    // 1
+    setTimeout(() => {
+      console.log("sending message");
+      queryClient.setQueryData(QUERY_KEY, (oldData: OrderBook | undefined) => {
+        if (oldData) {
+          const newData: OrderBook = {
+            bids: [...oldData.bids],
+            asks: [...oldData.asks],
+          };
+          newData.bids[0] = { ...newData.bids[0], size: 100, didUpdate: true };
+          return newData;
+        }
+        return oldData;
+      });
+    }, 5000);
+
+    // 2
 
     // cleanup
     return () => {

--- a/src/typescript/frontend/src/styles/globals.css
+++ b/src/typescript/frontend/src/styles/globals.css
@@ -7,7 +7,7 @@
     width: 0px;
   }
   .flash-bg-once {
-    animation: flash-bg-once 0.3s ease-out forwards;
+    animation: flash-bg-once 0.5s ease-out forwards;
   }
 
   @keyframes flash-bg-once {

--- a/src/typescript/frontend/src/styles/globals.css
+++ b/src/typescript/frontend/src/styles/globals.css
@@ -7,10 +7,18 @@
     width: 0px;
   }
   .flash-bg-once {
-    animation: flash-bg-once 0.5s ease-out forwards;
+    background-color: transparent;
+    transition: 0.5s linear background-color;
   }
-
-  @keyframes flash-bg-once {
+  .flash-green {
+    transition: none;
+    @apply bg-green/50;
+  }
+  .flash-red {
+    transition: none;
+    @apply bg-red/50;
+  }
+  @keyframes flash-bg {
     to {
       background-color: transparent;
     }

--- a/src/typescript/frontend/src/styles/globals.css
+++ b/src/typescript/frontend/src/styles/globals.css
@@ -7,7 +7,7 @@
     width: 0px;
   }
   .flash-bg-once {
-    animation: pulse-bg-once 0.5s ease-out forwards;
+    animation: flash-bg-once 0.5s ease-out forwards;
   }
 
   @keyframes flash-bg-once {

--- a/src/typescript/frontend/src/styles/globals.css
+++ b/src/typescript/frontend/src/styles/globals.css
@@ -6,6 +6,15 @@
   .scrollbar-none::-webkit-scrollbar {
     width: 0px;
   }
+  .flash-bg-once {
+    animation: pulse-bg-once 0.5s ease-out forwards;
+  }
+
+  @keyframes flash-bg-once {
+    to {
+      background-color: transparent;
+    }
+  }
 }
 @layer base {
   input[type="number"]::-webkit-outer-spin-button,

--- a/src/typescript/frontend/src/styles/globals.css
+++ b/src/typescript/frontend/src/styles/globals.css
@@ -7,7 +7,7 @@
     width: 0px;
   }
   .flash-bg-once {
-    animation: flash-bg-once 0.5s ease-out forwards;
+    animation: flash-bg-once 0.3s ease-out forwards;
   }
 
   @keyframes flash-bg-once {

--- a/src/typescript/frontend/src/types/global.ts
+++ b/src/typescript/frontend/src/types/global.ts
@@ -5,13 +5,13 @@ export type PriceLevel = {
   size: number;
 };
 
-export type UpdatedPriceLevel = PriceLevel & {
-  didUpdate?: boolean;
+export type OrderBook = {
+  bids: PriceLevel[];
+  asks: PriceLevel[];
 };
 
-export type OrderBook = {
-  bids: PriceLevel[] | UpdatedPriceLevel[];
-  asks: PriceLevel[] | UpdatedPriceLevel[];
+export type OrderBookWithUpdatedLevel = OrderBook & {
+  updatedLevel?: PriceLevel;
 };
 export type Precision =
   | "0.01"

--- a/src/typescript/frontend/src/types/global.ts
+++ b/src/typescript/frontend/src/types/global.ts
@@ -22,13 +22,3 @@ export type Precision =
   | "2.5"
   | "5"
   | "10";
-
-/**
- * putting down some thoughts here
- * initially thought itd be better to extend PriceLevel, but then realized that there's no good way to remove the didUpdate prop without really keeping track of the orderbook
- * thinking it might be better to extend orderbook to keep track of the most updated pricelevel
- * ---
- * issue is if the animation is 2s long in duration
- * and updates come in 1s within each other, then that means that the prev css class will be removed before it ends
- * but does this necessarily cancel the css animation?
- */

--- a/src/typescript/frontend/src/types/global.ts
+++ b/src/typescript/frontend/src/types/global.ts
@@ -5,9 +5,13 @@ export type PriceLevel = {
   size: number;
 };
 
+export type UpdatedPriceLevel = PriceLevel & {
+  didUpdate?: boolean;
+};
+
 export type OrderBook = {
-  bids: PriceLevel[];
-  asks: PriceLevel[];
+  bids: PriceLevel[] | UpdatedPriceLevel[];
+  asks: PriceLevel[] | UpdatedPriceLevel[];
 };
 export type Precision =
   | "0.01"
@@ -18,3 +22,13 @@ export type Precision =
   | "2.5"
   | "5"
   | "10";
+
+/**
+ * putting down some thoughts here
+ * initially thought itd be better to extend PriceLevel, but then realized that there's no good way to remove the didUpdate prop without really keeping track of the orderbook
+ * thinking it might be better to extend orderbook to keep track of the most updated pricelevel
+ * ---
+ * issue is if the animation is 2s long in duration
+ * and updates come in 1s within each other, then that means that the prev css class will be removed before it ends
+ * but does this necessarily cancel the css animation?
+ */


### PR DESCRIPTION
before the last commit, with how animations are being applied, the flash animation will get interrupted if there are "simultaneous" updates. this is more apparent when setting the flash duration to be longer.
please take a look, it might be expensive for the frontend to do this?

depends on #265 




==== not important ===
 
Some thoughts + considerations:
1. maybe the animations are short enough to not notice? I did testing myself and personally could tell that it looked a bit glitchy.
2. the solution to this would be

```
/**
 * putting down some thoughts here
 * initially thought itd be better to extend PriceLevel, but then realized that there's no good way to remove the didUpdate prop without really keeping track of the orderbook
 * thinking it might be better to extend orderbook to keep track of the most updated pricelevel
 * ---
 * issue is if the animation is 2s long in duration
 * and updates come in 1s within each other, then that means that the prev css class will be removed before it ends
 * but does this necessarily cancel the css animation?
 */

/**
     * 1. update animation - this works
     * 2. same level getting updated twice - this works
     * 3. levels getting updated in quick succession before animation ends - this does not work yet
     * 4. same level getting updated in quick succession before animation ends - this works
     */
```

depends on orderbook-websocket