### PR TITLE
Deprecate move-to-ts attributes

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -11,9 +11,10 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 ### Deprecated
 
 - [`market::index_orders_sdk()`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L3362) ([#287])
-- [`move-to-ts`](https://github.com/hippospace/move-to-ts) attributes
+- [`move-to-ts`](https://github.com/hippospace/move-to-ts) attributes ([#292])
 
 [#287]: https://github.com/econia-labs/econia/pull/287
+[#292]: https://github.com/econia-labs/econia/pull/292
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [unreleased]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...HEAD

--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -11,6 +11,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 ### Deprecated
 
 - [`market::index_orders_sdk()`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L3362) ([#287])
+- [`move-to-ts`](https://github.com/hippospace/move-to-ts) attributes
 
 [#287]: https://github.com/econia-labs/econia/pull/287
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/

--- a/doc/doc-site/docs/off-chain.md
+++ b/doc/doc-site/docs/off-chain.md
@@ -98,15 +98,9 @@ This sequence results in the same final order book depth chart state as in examp
 
 :::
 
-## `move-to-ts` hooks
-
-Econia was originally designed for use with [Hippo's `move-to-ts` tool], which auto-generates a TypeScript software development kit (SDK) from Move source code.
-As such, Econia's Move source code contains assorted  `#[cmd]` attributes on public entry functions and `#[app]` attributes on public getter functions for SDK generation.
-
 [econia api reference]: https://docs.econia.exchange/#introduction
 [events by creation number api]: https://fullnode.testnet.aptoslabs.com/v1/spec#/operations/get_events_by_creation_number
 [events by event handle api]: https://fullnode.testnet.aptoslabs.com/v1/spec#/operations/get_events_by_event_handle
-[hippo's `move-to-ts` tool]: https://github.com/hippospace/move-to-ts
 [`change_order_size_user()`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/market.md#0xc0deb00c_market_change_order_size_user
 [`makerevent`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/market.md#0xc0deb00c_market_MakerEvent
 [`marketregistrationevent`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/registry.md#0xc0deb00c_registry_MarketRegistrationEvent

--- a/src/move/econia/sources/incentives.move
+++ b/src/move/econia/sources/incentives.move
@@ -868,7 +868,6 @@ module econia::incentives {
         integrator_fee_store_ref_mut.tier = new_tier;
     }
 
-    #[app]
     /// Assert `T` is utility coin type.
     ///
     /// # Aborts
@@ -1018,7 +1017,6 @@ module econia::incentives {
 
     // Public entry functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    #[cmd]
     /// Wrapped call to `set_incentive_parameters()`, when calling after
     /// initialization.
     ///
@@ -1044,7 +1042,6 @@ module econia::incentives {
             &integrator_fee_store_tiers, true);
     }
 
-    #[cmd]
     /// Wrapped call to `upgrade_integrator_fee_store()`, for paying
     /// utility coins from an `aptos_framework::Coin::CoinStore`.
     ///
@@ -1074,7 +1071,6 @@ module econia::incentives {
                 integrator, cost));
     }
 
-    #[cmd]
     /// Wrapped call to `withdraw_econia_fees_to_coin_store_internal()`,
     /// similar to `withdraw_econia_fees_all()`.
     ///
@@ -1091,7 +1087,6 @@ module econia::incentives {
             econia, market_id, true, 0);
     }
 
-    #[cmd]
     /// Wrapped call to `withdraw_econia_fees_to_coin_store_internal()`,
     /// similar to `withdraw_econia_fees()`.
     ///
@@ -1109,7 +1104,6 @@ module econia::incentives {
             econia, market_id, false, amount);
     }
 
-    #[cmd]
     /// Wrapped call to `get_withdraw_integrator_fees()`, for paying
     /// utility coins from an `aptos_framework::Coin::CoinStore` and
     /// depositing quote coins to one too.
@@ -1158,7 +1152,6 @@ module econia::incentives {
         coin::deposit(address_of(integrator), quote_coins);
     }
 
-    #[cmd]
     /// Wrapped `withdraw_utility_coins_to_coin_store_internal()` call,
     /// similar to `withdraw_utility_coins_all()`.
     ///
@@ -1174,7 +1167,6 @@ module econia::incentives {
             econia, true, 0);
     }
 
-    #[cmd]
     /// Wrapped `withdraw_utility_coins_to_coin_store_internal()` call,
     /// similar to `withdraw_utility_coins()`.
     ///

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -1884,7 +1884,6 @@ module econia::market {
 
     // Public entry functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    #[cmd]
     /// Public entry function wrapper for `cancel_all_orders()` for
     /// cancelling orders under authority of signing user.
     ///
@@ -1903,7 +1902,6 @@ module econia::market {
             side);
     }
 
-    #[cmd]
     /// Public entry function wrapper for `cancel_order()` for
     /// cancelling order under authority of signing user.
     ///
@@ -1924,7 +1922,6 @@ module econia::market {
             market_order_id);
     }
 
-    #[cmd]
     /// Public entry function wrapper for `change_order_size()` for
     /// changing order size under authority of signing user.
     ///
@@ -1947,7 +1944,6 @@ module econia::market {
             new_size);
     }
 
-    #[cmd]
     /// Public entry function wrapper for
     /// `place_limit_order_passive_advance_user()`.
     ///
@@ -1979,7 +1975,6 @@ module econia::market {
             target_advance_amount);
     }
 
-    #[cmd]
     /// Public entry function wrapper for `place_limit_order_user()`.
     ///
     /// # Invocation testing
@@ -2003,7 +1998,6 @@ module econia::market {
             self_match_behavior);
     }
 
-    #[cmd]
     /// Public entry function wrapper for `place_market_order_user()`.
     ///
     /// # Invocation testing
@@ -2024,7 +2018,6 @@ module econia::market {
             user, market_id, integrator, direction, size, self_match_behavior);
     }
 
-    #[cmd]
     /// Wrapped call to `register_market_base_coin()` for paying utility
     /// coins from an `aptos_framework::coin::CoinStore`.
     ///
@@ -2048,7 +2041,6 @@ module econia::market {
             lot_size, tick_size, min_size, coin::withdraw(user, fee));
     }
 
-    #[cmd]
     /// Public entry function wrapper for `swap_between_coinstores()`.
     ///
     /// # Invocation testing

--- a/src/move/econia/sources/registry.move
+++ b/src/move/econia/sources/registry.move
@@ -662,7 +662,6 @@ module econia::registry {
 
     // Public functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    #[app]
     /// Return serial ID of given `CustodianCapability`.
     ///
     /// # Testing
@@ -674,7 +673,6 @@ module econia::registry {
         custodian_capability_ref.custodian_id
     }
 
-    #[app]
     /// Wrapper for `get_recognized_market_info()` for coin base asset.
     ///
     /// # Parameters
@@ -703,7 +701,6 @@ module econia::registry {
         get_recognized_market_info(trading_pair)
     }
 
-    #[app]
     /// Wrapper for `get_recognized_market_info_base_coin()` with
     /// type parameters.
     ///
@@ -730,7 +727,6 @@ module econia::registry {
             type_info::type_of<QuoteCoinType>())
     }
 
-    #[app]
     /// Wrapper for `get_recognized_market_info()` for generic base
     /// asset.
     ///
@@ -760,7 +756,6 @@ module econia::registry {
         get_recognized_market_info(trading_pair)
     }
 
-    #[app]
     /// Wrapper for `get_recognized_market_info_base_generic()` with
     /// quote type parameter.
     ///
@@ -791,7 +786,6 @@ module econia::registry {
             type_info::type_of<QuoteCoinType>())
     }
 
-    #[app]
     /// Return serial ID of given `UnderwriterCapability`.
     ///
     /// # Testing
@@ -803,7 +797,6 @@ module econia::registry {
         underwriter_capability_ref.underwriter_id
     }
 
-    #[app]
     /// Wrapper for `has_recognized_market()` for coin base asset.
     ///
     /// # Parameters
@@ -827,7 +820,6 @@ module econia::registry {
         has_recognized_market(trading_pair)
     }
 
-    #[app]
     /// Wrapper for `has_recognized_market()` for generic base asset.
     ///
     /// # Parameters
@@ -954,7 +946,6 @@ module econia::registry {
 
     // Public entry functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    #[cmd]
     /// Wrapped call to `register_integrator_fee_store()` for activating
     /// to base tier, which does not require utility coins.
     ///
@@ -972,7 +963,6 @@ module econia::registry {
             integrator, market_id, 0, coin::zero<UtilityCoinType>());
     }
 
-    #[cmd]
     /// Wrapped call to `register_integrator_fee_store()` for paying
     /// utility coins from an `aptos_framework::coin::CoinStore`.
     ///
@@ -992,7 +982,6 @@ module econia::registry {
                 integrator, incentives::get_tier_activation_fee(tier)));
     }
 
-    #[cmd]
     /// Remove market having given ID from recognized markets list.
     ///
     /// # Parameters
@@ -1065,7 +1054,6 @@ module econia::registry {
             trading_pair, recognized_market_info: option::none()});
     }
 
-    #[cmd]
     /// Wrapper for `remove_recognized_market()` with market IDs vector.
     ///
     /// # Testing
@@ -1090,7 +1078,6 @@ module econia::registry {
         }
     }
 
-    #[cmd]
     /// Set market having given ID as recognized market.
     ///
     /// # Parameters
@@ -1164,7 +1151,6 @@ module econia::registry {
             trading_pair, recognized_market_info: optional_market_info});
     }
 
-    #[cmd]
     /// Wrapper for `set_recognized_market()` with market IDs vector.
     ///
     /// # Testing

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -1053,7 +1053,6 @@ module econia::user {
 
     // Public entry functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    #[cmd]
     /// Wrapped call to `deposit_coins()` for depositing from an
     /// `aptos_framework::coin::CoinStore`.
     ///
@@ -1078,7 +1077,6 @@ module econia::user {
             coin::withdraw<CoinType>(user, amount));
     }
 
-    #[cmd]
     /// Register market account for indicated market and custodian.
     ///
     /// Verifies market ID and asset types via internal call to
@@ -1139,7 +1137,6 @@ module econia::user {
             user, market_account_id);
     }
 
-    #[cmd]
     /// Wrapped `register_market_account()` call for generic base asset.
     ///
     /// # Testing
@@ -1159,7 +1156,6 @@ module econia::user {
             user, market_id, custodian_id);
     }
 
-    #[cmd]
     /// Wrapped call to `withdraw_coins_user()` for withdrawing from
     /// market account to user's `aptos_framework::coin::CoinStore`.
     ///


### PR DESCRIPTION
`move-to-ts` is not official Aptos tooling, nor is it maintained by Econia developers.

If devs wish to use `move-to-ts` with Econia, they can always fork the Econia repo and add attributes themselves.