### PR TITLE
ECO-201: add order status by market and order id endpoint

### DIFF
--- a/src/rust/api/sqlx-data.json
+++ b/src/rust/api/sqlx-data.json
@@ -583,6 +583,97 @@
     },
     "query": "\n                select\n                    market_id,\n                    start_time,\n                    open,\n                    high,\n                    low,\n                    close,\n                    volume\n                from bars_1h where market_id = $1 and start_time >= $2 and start_time < $3\n                order by start_time;\n                "
   },
+  "b4109cc796a1f78a5db4dc529677a99b28b468c5a1a470686367fd900c62e4c9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "market_order_id",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "market_id",
+          "ordinal": 1,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "side: db::models::order::Side",
+          "ordinal": 2,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "bid",
+                  "ask"
+                ]
+              },
+              "name": "side"
+            }
+          }
+        },
+        {
+          "name": "size",
+          "ordinal": 3,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "price",
+          "ordinal": 4,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "user_address",
+          "ordinal": 5,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "custodian_id",
+          "ordinal": 6,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "order_state: db::models::order::OrderState",
+          "ordinal": 7,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "open",
+                  "filled",
+                  "cancelled",
+                  "evicted"
+                ]
+              },
+              "name": "order_state"
+            }
+          }
+        },
+        {
+          "name": "created_at",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Numeric",
+          "Numeric"
+        ]
+      }
+    },
+    "query": "\n        select\n            market_order_id,\n            market_id,\n            side as \"side: db::models::order::Side\",\n            size,\n            price,\n            user_address,\n            custodian_id,\n            order_state as \"order_state: db::models::order::OrderState\",\n            created_at\n        from orders where market_id = $1 and market_order_id = $2;\n        "
+  },
   "c6b852662de33f8151d8a2d8fedc1a59d474da1d71fd70bd8ad9ccfe4580e12c": {
     "describe": {
       "columns": [

--- a/src/rust/api/src/routes.rs
+++ b/src/rust/api/src/routes.rs
@@ -27,9 +27,18 @@ pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/markets", get(market::get_markets))
-        .route("/market/:market_id", get(market::get_market_by_id))
-        .route("/stats", get(market::get_stats))
-        .route("/market/:market_id/stats", get(market::get_stats_by_id))
+        .route("/markets/:market_id", get(market::get_market_by_id))
+        .route("/markets/:market_id/orderbook", get(market::get_orderbook))
+        .route("/markets/:market_id/stats", get(market::get_stats_by_id))
+        .route("/markets/:market_id/fills", get(market::get_fills))
+        .route(
+            "/markets/:market_id/order/:market_order_id",
+            get(market::get_order_by_market_order_id),
+        )
+        .route(
+            "/markets/:market_id/history",
+            get(market::get_market_history),
+        )
         .route(
             "/account/:account_address/order-history",
             get(account::order_history_by_account),
@@ -38,12 +47,7 @@ pub fn router(state: Arc<AppState>) -> Router {
             "/account/:account_address/open-orders",
             get(account::open_orders_by_account),
         )
-        .route("/market/:market_id/orderbook", get(market::get_orderbook))
-        .route(
-            "/market/:market_id/history",
-            get(market::get_market_history),
-        )
-        .route("/market/:market_id/fills", get(market::get_fills))
+        .route("/stats", get(market::get_stats))
         .route("/ws", get(ws_handler))
         .with_state(state)
         .layer(middleware_stack)

--- a/src/rust/api/src/routes/market.rs
+++ b/src/rust/api/src/routes/market.rs
@@ -633,7 +633,7 @@ mod tests {
     /// Test that the market history endpoint returns market data with a
     /// resolution of 1 minute.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/history`
+    /// This test sends a GET request to the `/markets/{market_id}/history`
     /// endpoint with the `resolution` parameter set to `1h`. The response is
     /// then checked to ensure that it has a `200 OK` status code, and the
     /// response body is checked to ensure that it is a JSON response in the
@@ -677,7 +677,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/market/{}/history?resolution={}&from={}&to={}",
+                        "/markets/{}/history?resolution={}&from={}&to={}",
                         market_id, resolution, from, to
                     ))
                     .body(Body::empty())
@@ -699,7 +699,7 @@ mod tests {
     /// Test that the market history endpoint returns market data with a
     /// resolution of 1 hour.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/history`
+    /// This test sends a GET request to the `/markets/{market_id}/history`
     /// endpoint with the `resolution` parameter set to `1h`. The response is
     /// then checked to ensure that it has a `200 OK` status code, and the
     /// response body is checked to ensure that it is a JSON response in the
@@ -743,7 +743,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/market/{}/history?resolution={}&from={}&to={}",
+                        "/markets/{}/history?resolution={}&from={}&to={}",
                         market_id, resolution, from, to
                     ))
                     .body(Body::empty())
@@ -765,7 +765,7 @@ mod tests {
     /// Test that the market history endpoint returns a `400 Bad Request` error
     /// when the resolution parameter is set to an unsupported value.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/history`
+    /// This test sends a GET request to the `/markets/{market_id}/history`
     /// endpoint with the `resolution` parameter set to `3m`, which is not
     /// supported by the API. The response is then checked to ensure that it
     /// has a `400 Bad Request` status code.
@@ -807,7 +807,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/market/{}/history?resolution=3m&from={}&to={}",
+                        "/markets/{}/history?resolution=3m&from={}&to={}",
                         market_id, from, to
                     ))
                     .body(Body::empty())
@@ -822,7 +822,7 @@ mod tests {
     /// Test that the market history endpoint returns a `400 Bad Request` error
     /// when the `to` timestamp comes before the `from` timestamp.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/history`
+    /// This test sends a GET request to the `/markets/{market_id}/history`
     /// endpoint with the `resolution` parameter set to `1m`, and with the `to`
     /// timestamp set to a value that is before the `from` timestamp. The
     /// response is then checked to ensure that it has a `400 Bad Request`
@@ -866,7 +866,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/market/{}/history?resolution={}&from={}&to={}",
+                        "/markets/{}/history?resolution={}&from={}&to={}",
                         market_id, resolution, from, to
                     ))
                     .body(Body::empty())
@@ -882,7 +882,7 @@ mod tests {
     /// with depth set to 1 is sent. Only the best bid and ask prices and the
     /// size available at those prices should be returned.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/orderbook`
+    /// This test sends a GET request to the `/markets/{market_id}/orderbook`
     /// endpoint with the `depth` parameter set to `1`. The response is
     /// then checked to ensure that it has a `200 OK` status code, and the
     /// response body is checked to ensure that it is a JSON response in the
@@ -898,7 +898,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/market/{}/orderbook?depth={}", market_id, depth))
+                    .uri(format!("/markets/{}/orderbook?depth={}", market_id, depth))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -919,7 +919,7 @@ mod tests {
     /// Test that the orderbook endpoint returns L2 market data when a request
     /// with depth set to 10 is sent.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/orderbook`
+    /// This test sends a GET request to the `/markets/{market_id}/orderbook`
     /// endpoint with the `depth` parameter set to `10`. The response is
     /// then checked to ensure that it has a `200 OK` status code, and the
     /// response body is checked to ensure that it is a JSON response in the
@@ -935,7 +935,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/market/{}/orderbook?depth={}", market_id, depth))
+                    .uri(format!("/markets/{}/orderbook?depth={}", market_id, depth))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -952,7 +952,7 @@ mod tests {
     /// Test that the orderbook endpoint returns a `400 Bad Request` error
     /// when the depth parameter is not set.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/orderbook`
+    /// This test sends a GET request to the `/markets/{market_id}/orderbook`
     /// endpoint without the `depth` parameter. The response is then checked to
     /// ensure that it has a `400 Bad Request` status code.
     #[tokio::test]
@@ -964,7 +964,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/market/{}/orderbook", market_id))
+                    .uri(format!("/markets/{}/orderbook", market_id))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -977,7 +977,7 @@ mod tests {
     /// Test that the orderbook endpoint returns a `400 Bad Request` error
     /// when the depth parameter is set to a negative number.
     ///
-    /// This test sends a GET request to the `/market/{market_id}/orderbook`
+    /// This test sends a GET request to the `/markets/{market_id}/orderbook`
     /// endpoint with the `depth` parameter of `-1`. The response is then
     /// checked to ensure that it has a `400 Bad Request` status code.
     #[tokio::test]
@@ -991,7 +991,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/market/{}/orderbook?depth={}", market_id, depth))
+                    .uri(format!("/markets/{}/orderbook?depth={}", market_id, depth))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -999,5 +999,39 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Test that the order by market ID and market order ID returns values
+    /// representing the current status of the order when a request is sent.
+    ///
+    /// This test sends a GET request to the `/markets/{market_id}/order/{order_id}`
+    /// endpoint with the `market_id` path parameter set to `1` and the
+    /// `market_order_id` path parameter set to `1000`. The response is
+    /// then checked to ensure that it has a `200 OK` status code, and the
+    /// response body is checked to ensure that it is a JSON response in the
+    /// correct format.
+    #[tokio::test]
+    async fn test_get_order_by_market_order_id() {
+        let market_id = 1;
+        let market_order_id = 1000;
+
+        let config = load_config();
+        let app = make_test_server(config).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/markets/{}/order/{}", market_id, market_order_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let res = serde_json::from_slice::<types::order::Order>(&body);
+        assert!(res.is_ok());
     }
 }

--- a/src/rust/api/src/routes/market.rs
+++ b/src/rust/api/src/routes/market.rs
@@ -1034,4 +1034,32 @@ mod tests {
         let res = serde_json::from_slice::<types::order::Order>(&body);
         assert!(res.is_ok());
     }
+
+    /// Test that the order by market ID and market order ID returns a
+    /// `404 Not Found` error when a request is sent for a nonexistent order.
+    ///
+    /// This test sends a GET request to the `/markets/{market_id}/order/{order_id}`
+    /// endpoint with the `market_id` path parameter set to `1` and the
+    /// `market_order_id` path parameter set to `999999`. The response is
+    /// then checked to ensure that it has a `404 Not Found` status code.
+    #[tokio::test]
+    async fn test_get_order_by_market_order_id_not_found() {
+        let market_id = 1;
+        let market_order_id = 999999;
+
+        let config = load_config();
+        let app = make_test_server(config).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/markets/{}/order/{}", market_id, market_order_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 }


### PR DESCRIPTION
Adds `/markets/:market_id/order/:market_order_id` endpoint for retrieving order status of an individual order.