### PR TITLE
Add aptos-core to dependencies, remove econia

### DIFF
--- a/src/move/faucet/Move.toml
+++ b/src/move/faucet/Move.toml
@@ -6,5 +6,7 @@ upgrade_policy = 'compatible'
 [addresses]
 econia_faucet = "_"
 
-[dependencies.Econia]
-local = "../econia"
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"


### PR DESCRIPTION
The faucet does not need all of Econia as a dependency, and this is causing problems. Instead let's just import the aptos-core framework directly.

Tested by publishing it to `0x4334ed72a7037abfd05bb7b846fa4535cc3d2cb31b7565939817de15551a6c03` on devnet.