### PR TITLE
Remove extra arg in place_limit_order_user_entry

### DIFF
--- a/src/python/sdk/econia_sdk/entry/market.py
+++ b/src/python/sdk/econia_sdk/entry/market.py
@@ -166,7 +166,6 @@ def place_limit_order_user_entry(
             encoder(side, Serializer.u8),
             encoder(size, Serializer.u64),
             encoder(price, Serializer.u64),
-            encoder(size, Serializer.u64),
             encoder(restriction, Serializer.u8),
             encoder(self_match_behavior, Serializer.u8),
         ],


### PR DESCRIPTION
This function is right now broken. Using it will result in an error: `"Transaction Executed and Committed with Error NUMBER_OF_ARGUMENTS_MISMATCH"` due to the inclusion of an erroneous size argument (likely a victim of copy/paste here). Let's get rid of it.

I tested this by calling the function in a separate script I'm working on, and it works--the error is cleared.