### PR TITLE
ECO-227: Hide depth chart when viewing on short screen

### DIFF
--- a/src/typescript/frontend/src/components/DepthChart.tsx
+++ b/src/typescript/frontend/src/components/DepthChart.tsx
@@ -122,7 +122,7 @@ export const DepthChart: React.FC<{
   }, [marketData, baseCoinInfo, quoteCoinInfo, data, isFetching]);
 
   return (
-    <div className="relative h-1/5 flex-[1_1_0%]">
+    <>
       <p className={"absolute ml-4 mt-2 font-jost text-white"}>Depth</p>
       <div
         className={
@@ -271,7 +271,7 @@ export const DepthChart: React.FC<{
           }}
         />
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/typescript/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/typescript/frontend/src/components/trade/TVChartContainer.tsx
@@ -339,5 +339,5 @@ export const TVChartContainer: React.FC<
     props.libraryPath,
   ]);
 
-  return <div ref={ref} className="h-4/5 flex-[4_1_0%]" />;
+  return <div ref={ref} className="w-full" />;
 };

--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -307,8 +307,13 @@ export default function Market({ allMarketData, marketData }: Props) {
         <main className="flex h-full w-full">
           <div className="flex grow flex-col p-3">
             <div className="mb-3 flex grow flex-col border border-neutral-600">
-              {isScriptReady && <TVChartContainer {...defaultTVChartProps} />}
-              <DepthChart marketData={marketData} />
+              <div className="flex h-full">
+                {isScriptReady && <TVChartContainer {...defaultTVChartProps} />}
+              </div>
+
+              <div className="hidden h-[140px] tall:block">
+                <DepthChart marketData={marketData} />
+              </div>
             </div>
             <div className="border border-neutral-600">
               <p className="my-3 ml-4 font-jost font-bold text-white">Orders</p>

--- a/src/typescript/frontend/tailwind.config.ts
+++ b/src/typescript/frontend/tailwind.config.ts
@@ -15,6 +15,9 @@ const config = {
         jost: ["var(--font-jost)", ...fontFamily.sans],
         "roboto-mono": ["var(--font-roboto-mono)", ...fontFamily.sans],
       },
+      screens: {
+        tall: { raw: "(min-height: 960px)" },
+      },
     },
     colors: {
       ...colors,


### PR DESCRIPTION
Also fixes the layout shift that used to occur while the site was waiting for TradingView to load.