### PR TITLE
ECO-237: faucet page match figma + default faucet wallet value

### DIFF
--- a/src/typescript/frontend/src/components/Page.tsx
+++ b/src/typescript/frontend/src/components/Page.tsx
@@ -13,7 +13,7 @@ export const Page: React.FC<PropsWithChildren<{ title?: string }>> = ({
       <Head>
         <title>{title ?? "Econia"}</title>
       </Head>
-      <div className="flex min-h-screen w-full flex-col font-roboto-mono">
+      <div className="flex h-screen min-h-screen w-full flex-col font-roboto-mono">
         <Header logoHref="/" />
         {children}
       </div>

--- a/src/typescript/frontend/src/components/Page.tsx
+++ b/src/typescript/frontend/src/components/Page.tsx
@@ -13,7 +13,7 @@ export const Page: React.FC<PropsWithChildren<{ title?: string }>> = ({
       <Head>
         <title>{title ?? "Econia"}</title>
       </Head>
-      <div className="flex h-screen min-h-screen w-full flex-col font-roboto-mono">
+      <div className="flex h-screen w-full flex-col font-roboto-mono">
         <Header logoHref="/" />
         {children}
       </div>

--- a/src/typescript/frontend/src/pages/faucet/index.tsx
+++ b/src/typescript/frontend/src/pages/faucet/index.tsx
@@ -39,7 +39,7 @@ const FaucetCard: React.FC<{ coinTypeTag: TypeTag; amount: number }> = ({
         {coinInfo.data?.symbol}
       </h1>
       <p className="mt-2 font-roboto-mono uppercase text-gray-400">
-        Balance: {coinBalance.data || "-"} {coinInfo.data?.symbol}
+        Balance: {coinBalance.data ?? "-"} {coinInfo.data?.symbol}
       </p>
       <ConnectedButton className="mt-5 w-full">
         <Button

--- a/src/typescript/frontend/src/pages/faucet/index.tsx
+++ b/src/typescript/frontend/src/pages/faucet/index.tsx
@@ -39,7 +39,7 @@ const FaucetCard: React.FC<{ coinTypeTag: TypeTag; amount: number }> = ({
         {coinInfo.data?.symbol}
       </h1>
       <p className="mt-2 font-roboto-mono uppercase text-gray-400">
-        Balance: {coinBalance.data || 0} {coinInfo.data?.symbol}
+        Balance: {coinBalance.data || "-"} {coinInfo.data?.symbol}
       </p>
       <ConnectedButton className="mt-5 w-full">
         <Button

--- a/src/typescript/frontend/src/pages/faucet/index.tsx
+++ b/src/typescript/frontend/src/pages/faucet/index.tsx
@@ -34,14 +34,14 @@ const FaucetCard: React.FC<{ coinTypeTag: TypeTag; amount: number }> = ({
   }, [account, signAndSubmitTransaction]);
 
   return (
-    <div className="flex h-48 w-96 flex-col items-center justify-center border p-8">
-      <h1 className="font-jost text-xl font-bold text-white">
+    <div className="m-3 flex h-60 w-96 flex-col items-center  justify-center border border-neutral-600 p-8">
+      <h1 className="font-jost text-6xl font-bold text-white">
         {coinInfo.data?.symbol}
       </h1>
-      <p className="font-jost text-gray-400">
-        Balance: {coinBalance.data} {coinInfo.data?.symbol}
+      <p className="mt-2 font-roboto-mono uppercase text-gray-400">
+        Balance: {coinBalance.data || 0} {coinInfo.data?.symbol}
       </p>
-      <ConnectedButton className="mt-4 w-full">
+      <ConnectedButton className="mt-5 w-full">
         <Button
           variant="primary"
           className="mt-4 w-full"
@@ -70,7 +70,7 @@ const FaucetCard: React.FC<{ coinTypeTag: TypeTag; amount: number }> = ({
 export default function Faucet({ marketData: _ }: { marketData: ApiMarket[] }) {
   return (
     <Page>
-      <main className="mt-96 flex items-center justify-center gap-8">
+      <main className="flex h-full items-center justify-center gap-8">
         <FaucetCard
           coinTypeTag={TypeTag.fromString(
             "0x7c36a610d1cde8853a692c057e7bd2479ba9d5eeaeceafa24f125c23d2abf942::test_eth::TestETHCoin",


### PR DESCRIPTION
changes:
- faucet page match figma
- remove hardcoded positioning, centered vertically but updated `Page` with `h-screen` as `h-full` in child does not work if parent's height is set with `min-height`
- added default faucet wallet value if `undefined` or `null` to 0

screenshot:
<img width="1756" alt="image" src="https://github.com/econia-labs/econia/assets/28949652/fbeccab2-819d-49f0-b07c-eb7d8611b147">
![Uploading image.png…]()
