### PR TITLE
[ECO-256] Correct equality comparator for internal cancel event logic

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -7,7 +7,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 ### Added
 
 - Assorted view functions ([#287], [#301], [#321], [#334]).
-- Assorted user- and market-level events with common order ID ([#321], [#347]).
+- Assorted user- and market-level events with common order ID ([#321], [#347], [#360]).
 
 ### Changed
 
@@ -31,6 +31,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#321]: https://github.com/econia-labs/econia/pull/321
 [#334]: https://github.com/econia-labs/econia/pull/334
 [#347]: https://github.com/econia-labs/econia/pull/347
+[#360]: https://github.com/econia-labs/econia/pull/360
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [unreleased]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...HEAD

--- a/src/move/econia/doc/user.md
+++ b/src/move/econia/doc/user.md
@@ -3623,7 +3623,7 @@ order if market order ID is not <code><a href="user.md#0xc0deb00c_user_NIL">NIL<
         *in_ceiling_ref_mut - ceiling_decrement_amount;
     // If order is actually being cancelled and <a href="user.md#0xc0deb00c_user">user</a> <b>has</b> <a href="market.md#0xc0deb00c_market">market</a>
     // <a href="">event</a> handles for the <a href="market.md#0xc0deb00c_market">market</a> <a href="">account</a>, emit a cancel <a href="">event</a>.
-    <b>let</b> changing_size = reason != <a href="user.md#0xc0deb00c_user_CANCEL_REASON_SIZE_CHANGE_INTERNAL">CANCEL_REASON_SIZE_CHANGE_INTERNAL</a>;
+    <b>let</b> changing_size = reason == <a href="user.md#0xc0deb00c_user_CANCEL_REASON_SIZE_CHANGE_INTERNAL">CANCEL_REASON_SIZE_CHANGE_INTERNAL</a>;
     <b>if</b> (!changing_size && <b>exists</b>&lt;<a href="user.md#0xc0deb00c_user_MarketEventHandles">MarketEventHandles</a>&gt;(user_address)) {
         <b>let</b> market_event_handles_map_ref_mut =
             &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="user.md#0xc0deb00c_user_MarketEventHandles">MarketEventHandles</a>&gt;(user_address).map;

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -1737,7 +1737,7 @@ module econia::user {
             *in_ceiling_ref_mut - ceiling_decrement_amount;
         // If order is actually being cancelled and user has market
         // event handles for the market account, emit a cancel event.
-        let changing_size = reason != CANCEL_REASON_SIZE_CHANGE_INTERNAL;
+        let changing_size = reason == CANCEL_REASON_SIZE_CHANGE_INTERNAL;
         if (!changing_size && exists<MarketEventHandles>(user_address)) {
             let market_event_handles_map_ref_mut =
                 &mut borrow_global_mut<MarketEventHandles>(user_address).map;


### PR DESCRIPTION
Like #347 , the change in this PR would ideally have been included in #321 , but it was overlooked because the Move unit testing framework at the time did not include event assertion. The functionality addressed in this PR was uncovered while writing end-to-end testing functionality.

Now that https://github.com/aptos-labs/aptos-core/pull/9181 is available, it is suggested that all event cases be tested in a unit testing context.