### PR TITLE
[ECO-247] Add event emission unit tests, with uncovered cancel reasons

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -16,6 +16,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 - Default self match behavior for swaps (signing swapper self match against signing market account) changed from `ABORT` to `CANCEL_TAKER` ([#321]).
 - Started using `order_id` instead of `market_order_id` for new implementations ([#321]).
 - Replaced `market::NO_MARKET_ACCOUNT` with `market::NO_TAKER_ADDRESS` to account for signing swappers ([#321]).
+- Allow limit orders to post less than minimum size if they first fill across the spread ([#347]).
 
 ### Deprecated
 

--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -7,7 +7,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 ### Added
 
 - Assorted view functions ([#287], [#301], [#321], [#334]).
-- Assorted user- and market-level events with common order ID ([#321], [#347], [#360]).
+- Assorted user- and market-level events with common order ID ([#321], [#347], [#360], [#366]).
 
 ### Changed
 
@@ -32,6 +32,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#334]: https://github.com/econia-labs/econia/pull/334
 [#347]: https://github.com/econia-labs/econia/pull/347
 [#360]: https://github.com/econia-labs/econia/pull/360
+[#366]: https://github.com/econia-labs/econia/pull/366
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [unreleased]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...HEAD

--- a/doc/doc-site/docs/off-chain/events.md
+++ b/doc/doc-site/docs/off-chain/events.md
@@ -82,7 +82,11 @@ When a signing swapper places a swap order, a [`market::PlaceSwapOrderEvent`] is
 
 For each fill a [`user::FillEvent`] is emitted to the [`user::MarketEventHandlesForMarketAccount`] for the maker side, and to the [`market::SwapperEventHandlesForMarket`] for the taker side.
 
-If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::SwapperEventHandlesForMarket`] with the same reasons as for a [market order].
+If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::SwapperEventHandlesForMarket`] with the same reasons as for a [market order], as well as an additional cancel reason that only applies to swaps:
+
+| Cancel reason                           | Description                                                                            |
+| --------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`] | No more base asset can be traded because the amount left to trade is less than one lot |
 
 ### Placing a swap order (non-signing swapper)
 
@@ -90,7 +94,7 @@ When a swap order is not placed by a signing swapper, a [`market::PlaceSwapOrder
 
 For each fill a [`user::FillEvent`] is emitted to the [`user::MarketEventHandlesForMarketAccount`] for the maker side only.
 
-If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::MarketEventHandlesForMarket`] with the same reasons as for a [market order].
+If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::MarketEventHandlesForMarket`] with the same reasons as for a [swap order with a signing swapper].
 
 ### Maker self cancel
 
@@ -112,6 +116,7 @@ When a [signing user or a custodian][market account] manually cancels an open or
 [market order]: #placing-a-market-order
 [market orders]: ../overview/matching.md#market-orders
 [markets]: ../overview/registry.md
+[swap order with a signing swapper]: #placing-a-swap-order-signing-swapper
 [swaps]: ../overview/matching.md#swaps
 [`cancel_reason_eviction`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_EVICTION
 [`cancel_reason_immediate_or_cancel`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_IMMEDIATE_OR_CANCEL
@@ -120,6 +125,7 @@ When a [signing user or a custodian][market account] manually cancels an open or
 [`cancel_reason_not_enough_liquidity`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_NOT_ENOUGH_LIQUIDITY
 [`cancel_reason_self_match_maker`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_SELF_MATCH_MAKER
 [`cancel_reason_self_match_taker`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_SELF_MATCH_TAKER
+[`cancel_reason_too_small_to_fill_lot`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT
 [`market::get_market_event_handle_creation_info`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-get_market_event_handle_creation_info
 [`market::get_swapper_event_handle_creation_numbers`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-get_swapper_event_handle_creation_numbers
 [`market::marketeventhandlesformarket`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#struct-marketeventhandlesformarket

--- a/doc/doc-site/docs/off-chain/events.md
+++ b/doc/doc-site/docs/off-chain/events.md
@@ -82,11 +82,12 @@ When a signing swapper places a swap order, a [`market::PlaceSwapOrderEvent`] is
 
 For each fill a [`user::FillEvent`] is emitted to the [`user::MarketEventHandlesForMarketAccount`] for the maker side, and to the [`market::SwapperEventHandlesForMarket`] for the taker side.
 
-If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::SwapperEventHandlesForMarket`] with the same reasons as for a [market order], as well as an additional cancel reason that only applies to swaps:
+If the swap order does not fill the maximum specified base amount during the function call in which it was placed, a [`user::CancelOrderEvent`] is emitted to the associated [`market::SwapperEventHandlesForMarket`] with the same reasons as for a [market order], as well as two additional cancel reasons that only apply to swaps:
 
 | Cancel reason                           | Description                                                                            |
 | --------------------------------------- | -------------------------------------------------------------------------------------- |
 | [`CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`] | No more base asset can be traded because the amount left to trade is less than one lot |
+| [`CANCEL_REASON_VIOLATED_LIMIT_PRICE`]  | The next order on the book to match against violated the swap order limit price        |
 
 ### Placing a swap order (non-signing swapper)
 
@@ -126,6 +127,7 @@ When a [signing user or a custodian][market account] manually cancels an open or
 [`cancel_reason_self_match_maker`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_SELF_MATCH_MAKER
 [`cancel_reason_self_match_taker`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_SELF_MATCH_TAKER
 [`cancel_reason_too_small_to_fill_lot`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT
+[`cancel_reason_violated_limit_price`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#0xc0deb00c_user_CANCEL_REASON_VIOLATED_LIMIT_PRICE
 [`market::get_market_event_handle_creation_info`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-get_market_event_handle_creation_info
 [`market::get_swapper_event_handle_creation_numbers`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-get_swapper_event_handle_creation_numbers
 [`market::marketeventhandlesformarket`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#struct-marketeventhandlesformarket

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -13,5 +13,5 @@ integrator = "0x4567"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "mainnet"
+rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -13,7 +13,8 @@ integrator = "0x4567"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-# You may need to change this to `main` to run event unit tests per
-# https://github.com/aptos-labs/aptos-core/pull/9181
-rev = "main"
+# You may need to change this to `main` to run event unit tests, pending
+# https://github.com/aptos-labs/aptos-core/pull/9181 merging from `main`
+# into `mainnet`.
+rev = "mainnet"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -13,5 +13,7 @@ integrator = "0x4567"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
+# You may need to change this to `main` to run event unit tests per
+# https://github.com/aptos-labs/aptos-core/pull/9181
 rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/doc/user.md
+++ b/src/move/econia/doc/user.md
@@ -131,6 +131,8 @@ Constant getters:
 * <code><a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_NOT_ENOUGH_LIQUIDITY">get_CANCEL_REASON_NOT_ENOUGH_LIQUIDITY</a>()</code>
 * <code><a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_SELF_MATCH_MAKER">get_CANCEL_REASON_SELF_MATCH_MAKER</a>()</code>
 * <code><a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_SELF_MATCH_TAKER">get_CANCEL_REASON_SELF_MATCH_TAKER</a>()</code>
+* <code><a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a>()</code>
+* <code><a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_VIOLATED_LIMIT_PRICE">get_CANCEL_REASON_VIOLATED_LIMIT_PRICE</a>()</code>
 * <code><a href="user.md#0xc0deb00c_user_get_NO_CUSTODIAN">get_NO_CUSTODIAN</a>()</code>
 
 Market account lookup:
@@ -416,170 +418,174 @@ The below index is automatically generated from source code:
     -  [Testing](#@Testing_21)
 -  [Function `get_CANCEL_REASON_SELF_MATCH_TAKER`](#0xc0deb00c_user_get_CANCEL_REASON_SELF_MATCH_TAKER)
     -  [Testing](#@Testing_22)
--  [Function `get_NO_CUSTODIAN`](#0xc0deb00c_user_get_NO_CUSTODIAN)
+-  [Function `get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`](#0xc0deb00c_user_get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT)
     -  [Testing](#@Testing_23)
+-  [Function `get_CANCEL_REASON_VIOLATED_LIMIT_PRICE`](#0xc0deb00c_user_get_CANCEL_REASON_VIOLATED_LIMIT_PRICE)
+    -  [Testing](#@Testing_24)
+-  [Function `get_NO_CUSTODIAN`](#0xc0deb00c_user_get_NO_CUSTODIAN)
+    -  [Testing](#@Testing_25)
 -  [Function `get_all_market_account_ids_for_market_id`](#0xc0deb00c_user_get_all_market_account_ids_for_market_id)
-    -  [Parameters](#@Parameters_24)
-    -  [Returns](#@Returns_25)
-    -  [Gas considerations](#@Gas_considerations_26)
-    -  [Testing](#@Testing_27)
+    -  [Parameters](#@Parameters_26)
+    -  [Returns](#@Returns_27)
+    -  [Gas considerations](#@Gas_considerations_28)
+    -  [Testing](#@Testing_29)
 -  [Function `get_all_market_account_ids_for_user`](#0xc0deb00c_user_get_all_market_account_ids_for_user)
-    -  [Parameters](#@Parameters_28)
-    -  [Returns](#@Returns_29)
-    -  [Gas considerations](#@Gas_considerations_30)
-    -  [Testing](#@Testing_31)
+    -  [Parameters](#@Parameters_30)
+    -  [Returns](#@Returns_31)
+    -  [Gas considerations](#@Gas_considerations_32)
+    -  [Testing](#@Testing_33)
 -  [Function `get_custodian_id`](#0xc0deb00c_user_get_custodian_id)
-    -  [Testing](#@Testing_32)
--  [Function `get_market_account`](#0xc0deb00c_user_get_market_account)
-    -  [Aborts](#@Aborts_33)
     -  [Testing](#@Testing_34)
--  [Function `get_market_account_id`](#0xc0deb00c_user_get_market_account_id)
-    -  [Testing](#@Testing_35)
--  [Function `get_market_accounts`](#0xc0deb00c_user_get_market_accounts)
+-  [Function `get_market_account`](#0xc0deb00c_user_get_market_account)
+    -  [Aborts](#@Aborts_35)
     -  [Testing](#@Testing_36)
--  [Function `get_market_event_handle_creation_numbers`](#0xc0deb00c_user_get_market_event_handle_creation_numbers)
+-  [Function `get_market_account_id`](#0xc0deb00c_user_get_market_account_id)
     -  [Testing](#@Testing_37)
--  [Function `get_market_id`](#0xc0deb00c_user_get_market_id)
+-  [Function `get_market_accounts`](#0xc0deb00c_user_get_market_accounts)
     -  [Testing](#@Testing_38)
--  [Function `has_market_account`](#0xc0deb00c_user_has_market_account)
+-  [Function `get_market_event_handle_creation_numbers`](#0xc0deb00c_user_get_market_event_handle_creation_numbers)
     -  [Testing](#@Testing_39)
--  [Function `has_market_account_by_market_account_id`](#0xc0deb00c_user_has_market_account_by_market_account_id)
+-  [Function `get_market_id`](#0xc0deb00c_user_get_market_id)
     -  [Testing](#@Testing_40)
--  [Function `has_market_account_by_market_id`](#0xc0deb00c_user_has_market_account_by_market_id)
+-  [Function `has_market_account`](#0xc0deb00c_user_has_market_account)
     -  [Testing](#@Testing_41)
--  [Function `deposit_coins`](#0xc0deb00c_user_deposit_coins)
-    -  [Aborts](#@Aborts_42)
+-  [Function `has_market_account_by_market_account_id`](#0xc0deb00c_user_has_market_account_by_market_account_id)
+    -  [Testing](#@Testing_42)
+-  [Function `has_market_account_by_market_id`](#0xc0deb00c_user_has_market_account_by_market_id)
     -  [Testing](#@Testing_43)
--  [Function `deposit_generic_asset`](#0xc0deb00c_user_deposit_generic_asset)
-    -  [Testing](#@Testing_44)
--  [Function `get_asset_counts_custodian`](#0xc0deb00c_user_get_asset_counts_custodian)
+-  [Function `deposit_coins`](#0xc0deb00c_user_deposit_coins)
+    -  [Aborts](#@Aborts_44)
     -  [Testing](#@Testing_45)
--  [Function `get_asset_counts_user`](#0xc0deb00c_user_get_asset_counts_user)
+-  [Function `deposit_generic_asset`](#0xc0deb00c_user_deposit_generic_asset)
     -  [Testing](#@Testing_46)
--  [Function `get_market_account_market_info_custodian`](#0xc0deb00c_user_get_market_account_market_info_custodian)
+-  [Function `get_asset_counts_custodian`](#0xc0deb00c_user_get_asset_counts_custodian)
     -  [Testing](#@Testing_47)
--  [Function `get_market_account_market_info_user`](#0xc0deb00c_user_get_market_account_market_info_user)
+-  [Function `get_asset_counts_user`](#0xc0deb00c_user_get_asset_counts_user)
     -  [Testing](#@Testing_48)
--  [Function `withdraw_coins_custodian`](#0xc0deb00c_user_withdraw_coins_custodian)
+-  [Function `get_market_account_market_info_custodian`](#0xc0deb00c_user_get_market_account_market_info_custodian)
     -  [Testing](#@Testing_49)
--  [Function `withdraw_coins_user`](#0xc0deb00c_user_withdraw_coins_user)
+-  [Function `get_market_account_market_info_user`](#0xc0deb00c_user_get_market_account_market_info_user)
     -  [Testing](#@Testing_50)
--  [Function `withdraw_generic_asset_custodian`](#0xc0deb00c_user_withdraw_generic_asset_custodian)
+-  [Function `withdraw_coins_custodian`](#0xc0deb00c_user_withdraw_coins_custodian)
     -  [Testing](#@Testing_51)
--  [Function `withdraw_generic_asset_user`](#0xc0deb00c_user_withdraw_generic_asset_user)
+-  [Function `withdraw_coins_user`](#0xc0deb00c_user_withdraw_coins_user)
     -  [Testing](#@Testing_52)
--  [Function `deposit_from_coinstore`](#0xc0deb00c_user_deposit_from_coinstore)
+-  [Function `withdraw_generic_asset_custodian`](#0xc0deb00c_user_withdraw_generic_asset_custodian)
     -  [Testing](#@Testing_53)
+-  [Function `withdraw_generic_asset_user`](#0xc0deb00c_user_withdraw_generic_asset_user)
+    -  [Testing](#@Testing_54)
+-  [Function `deposit_from_coinstore`](#0xc0deb00c_user_deposit_from_coinstore)
+    -  [Testing](#@Testing_55)
 -  [Function `init_market_event_handles_if_missing`](#0xc0deb00c_user_init_market_event_handles_if_missing)
-    -  [Parameters](#@Parameters_54)
-    -  [Aborts](#@Aborts_55)
-    -  [Testing](#@Testing_56)
+    -  [Parameters](#@Parameters_56)
+    -  [Aborts](#@Aborts_57)
+    -  [Testing](#@Testing_58)
 -  [Function `register_market_account`](#0xc0deb00c_user_register_market_account)
-    -  [Type parameters](#@Type_parameters_57)
-    -  [Parameters](#@Parameters_58)
-    -  [Aborts](#@Aborts_59)
-    -  [Testing](#@Testing_60)
--  [Function `register_market_account_generic_base`](#0xc0deb00c_user_register_market_account_generic_base)
-    -  [Testing](#@Testing_61)
--  [Function `withdraw_to_coinstore`](#0xc0deb00c_user_withdraw_to_coinstore)
+    -  [Type parameters](#@Type_parameters_59)
+    -  [Parameters](#@Parameters_60)
+    -  [Aborts](#@Aborts_61)
     -  [Testing](#@Testing_62)
+-  [Function `register_market_account_generic_base`](#0xc0deb00c_user_register_market_account_generic_base)
+    -  [Testing](#@Testing_63)
+-  [Function `withdraw_to_coinstore`](#0xc0deb00c_user_withdraw_to_coinstore)
+    -  [Testing](#@Testing_64)
 -  [Function `cancel_order_internal`](#0xc0deb00c_user_cancel_order_internal)
-    -  [Parameters](#@Parameters_63)
-    -  [Returns](#@Returns_64)
-    -  [Terminology](#@Terminology_65)
-    -  [Aborts](#@Aborts_66)
-    -  [Emits](#@Emits_67)
-    -  [Assumptions](#@Assumptions_68)
-    -  [Expected value testing](#@Expected_value_testing_69)
-    -  [Failure testing](#@Failure_testing_70)
+    -  [Parameters](#@Parameters_65)
+    -  [Returns](#@Returns_66)
+    -  [Terminology](#@Terminology_67)
+    -  [Aborts](#@Aborts_68)
+    -  [Emits](#@Emits_69)
+    -  [Assumptions](#@Assumptions_70)
+    -  [Expected value testing](#@Expected_value_testing_71)
+    -  [Failure testing](#@Failure_testing_72)
 -  [Function `change_order_size_internal`](#0xc0deb00c_user_change_order_size_internal)
-    -  [Parameters](#@Parameters_71)
-    -  [Aborts](#@Aborts_72)
-    -  [Emits](#@Emits_73)
-    -  [Assumptions](#@Assumptions_74)
-    -  [Testing](#@Testing_75)
+    -  [Parameters](#@Parameters_73)
+    -  [Aborts](#@Aborts_74)
+    -  [Emits](#@Emits_75)
+    -  [Assumptions](#@Assumptions_76)
+    -  [Testing](#@Testing_77)
 -  [Function `create_cancel_order_event_internal`](#0xc0deb00c_user_create_cancel_order_event_internal)
 -  [Function `create_fill_event_internal`](#0xc0deb00c_user_create_fill_event_internal)
 -  [Function `deposit_assets_internal`](#0xc0deb00c_user_deposit_assets_internal)
-    -  [Type parameters](#@Type_parameters_76)
-    -  [Parameters](#@Parameters_77)
-    -  [Testing](#@Testing_78)
--  [Function `emit_limit_order_events_internal`](#0xc0deb00c_user_emit_limit_order_events_internal)
+    -  [Type parameters](#@Type_parameters_78)
     -  [Parameters](#@Parameters_79)
-    -  [Emits](#@Emits_80)
--  [Function `emit_market_order_events_internal`](#0xc0deb00c_user_emit_market_order_events_internal)
+    -  [Testing](#@Testing_80)
+-  [Function `emit_limit_order_events_internal`](#0xc0deb00c_user_emit_limit_order_events_internal)
     -  [Parameters](#@Parameters_81)
     -  [Emits](#@Emits_82)
+-  [Function `emit_market_order_events_internal`](#0xc0deb00c_user_emit_market_order_events_internal)
+    -  [Parameters](#@Parameters_83)
+    -  [Emits](#@Emits_84)
 -  [Function `emit_swap_maker_fill_events_internal`](#0xc0deb00c_user_emit_swap_maker_fill_events_internal)
 -  [Function `fill_order_internal`](#0xc0deb00c_user_fill_order_internal)
-    -  [Type parameters](#@Type_parameters_83)
-    -  [Parameters](#@Parameters_84)
-    -  [Returns](#@Returns_85)
-    -  [Aborts](#@Aborts_86)
-    -  [Assumptions](#@Assumptions_87)
-    -  [Testing](#@Testing_88)
+    -  [Type parameters](#@Type_parameters_85)
+    -  [Parameters](#@Parameters_86)
+    -  [Returns](#@Returns_87)
+    -  [Aborts](#@Aborts_88)
+    -  [Assumptions](#@Assumptions_89)
+    -  [Testing](#@Testing_90)
 -  [Function `get_asset_counts_internal`](#0xc0deb00c_user_get_asset_counts_internal)
-    -  [Parameters](#@Parameters_89)
-    -  [Returns](#@Returns_90)
-    -  [Aborts](#@Aborts_91)
-    -  [Testing](#@Testing_92)
+    -  [Parameters](#@Parameters_91)
+    -  [Returns](#@Returns_92)
+    -  [Aborts](#@Aborts_93)
+    -  [Testing](#@Testing_94)
 -  [Function `get_active_market_order_ids_internal`](#0xc0deb00c_user_get_active_market_order_ids_internal)
-    -  [Parameters](#@Parameters_93)
-    -  [Returns](#@Returns_94)
-    -  [Aborts](#@Aborts_95)
-    -  [Testing](#@Testing_96)
+    -  [Parameters](#@Parameters_95)
+    -  [Returns](#@Returns_96)
+    -  [Aborts](#@Aborts_97)
+    -  [Testing](#@Testing_98)
 -  [Function `get_next_order_access_key_internal`](#0xc0deb00c_user_get_next_order_access_key_internal)
-    -  [Parameters](#@Parameters_97)
-    -  [Returns](#@Returns_98)
-    -  [Aborts](#@Aborts_99)
-    -  [Testing](#@Testing_100)
+    -  [Parameters](#@Parameters_99)
+    -  [Returns](#@Returns_100)
+    -  [Aborts](#@Aborts_101)
+    -  [Testing](#@Testing_102)
 -  [Function `get_open_order_id_internal`](#0xc0deb00c_user_get_open_order_id_internal)
-    -  [Testing](#@Testing_101)
+    -  [Testing](#@Testing_103)
 -  [Function `place_order_internal`](#0xc0deb00c_user_place_order_internal)
-    -  [Parameters](#@Parameters_102)
-    -  [Terminology](#@Terminology_103)
-    -  [Assumptions](#@Assumptions_104)
-    -  [Aborts](#@Aborts_105)
-    -  [Expected value testing](#@Expected_value_testing_106)
-    -  [Failure testing](#@Failure_testing_107)
+    -  [Parameters](#@Parameters_104)
+    -  [Terminology](#@Terminology_105)
+    -  [Assumptions](#@Assumptions_106)
+    -  [Aborts](#@Aborts_107)
+    -  [Expected value testing](#@Expected_value_testing_108)
+    -  [Failure testing](#@Failure_testing_109)
 -  [Function `withdraw_assets_internal`](#0xc0deb00c_user_withdraw_assets_internal)
-    -  [Type parameters](#@Type_parameters_108)
-    -  [Parameters](#@Parameters_109)
-    -  [Returns](#@Returns_110)
-    -  [Testing](#@Testing_111)
+    -  [Type parameters](#@Type_parameters_110)
+    -  [Parameters](#@Parameters_111)
+    -  [Returns](#@Returns_112)
+    -  [Testing](#@Testing_113)
 -  [Function `deposit_asset`](#0xc0deb00c_user_deposit_asset)
-    -  [Type parameters](#@Type_parameters_112)
-    -  [Parameters](#@Parameters_113)
-    -  [Aborts](#@Aborts_114)
-    -  [Assumptions](#@Assumptions_115)
-    -  [Testing](#@Testing_116)
+    -  [Type parameters](#@Type_parameters_114)
+    -  [Parameters](#@Parameters_115)
+    -  [Aborts](#@Aborts_116)
+    -  [Assumptions](#@Assumptions_117)
+    -  [Testing](#@Testing_118)
 -  [Function `emit_maker_fill_event`](#0xc0deb00c_user_emit_maker_fill_event)
 -  [Function `get_market_account_market_info`](#0xc0deb00c_user_get_market_account_market_info)
-    -  [Parameters](#@Parameters_117)
-    -  [Returns](#@Returns_118)
-    -  [Aborts](#@Aborts_119)
-    -  [Testing](#@Testing_120)
+    -  [Parameters](#@Parameters_119)
+    -  [Returns](#@Returns_120)
+    -  [Aborts](#@Aborts_121)
+    -  [Testing](#@Testing_122)
 -  [Function `register_market_account_account_entries`](#0xc0deb00c_user_register_market_account_account_entries)
-    -  [Type parameters](#@Type_parameters_121)
-    -  [Parameters](#@Parameters_122)
-    -  [Aborts](#@Aborts_123)
-    -  [Testing](#@Testing_124)
+    -  [Type parameters](#@Type_parameters_123)
+    -  [Parameters](#@Parameters_124)
+    -  [Aborts](#@Aborts_125)
+    -  [Testing](#@Testing_126)
 -  [Function `register_market_account_collateral_entry`](#0xc0deb00c_user_register_market_account_collateral_entry)
-    -  [Type parameters](#@Type_parameters_125)
-    -  [Parameters](#@Parameters_126)
-    -  [Testing](#@Testing_127)
+    -  [Type parameters](#@Type_parameters_127)
+    -  [Parameters](#@Parameters_128)
+    -  [Testing](#@Testing_129)
 -  [Function `vectorize_open_orders`](#0xc0deb00c_user_vectorize_open_orders)
-    -  [Testing](#@Testing_128)
+    -  [Testing](#@Testing_130)
 -  [Function `withdraw_asset`](#0xc0deb00c_user_withdraw_asset)
-    -  [Type parameters](#@Type_parameters_129)
-    -  [Parameters](#@Parameters_130)
-    -  [Returns](#@Returns_131)
-    -  [Aborts](#@Aborts_132)
-    -  [Testing](#@Testing_133)
--  [Function `withdraw_coins`](#0xc0deb00c_user_withdraw_coins)
-    -  [Testing](#@Testing_134)
--  [Function `withdraw_generic_asset`](#0xc0deb00c_user_withdraw_generic_asset)
+    -  [Type parameters](#@Type_parameters_131)
+    -  [Parameters](#@Parameters_132)
+    -  [Returns](#@Returns_133)
+    -  [Aborts](#@Aborts_134)
     -  [Testing](#@Testing_135)
+-  [Function `withdraw_coins`](#0xc0deb00c_user_withdraw_coins)
+    -  [Testing](#@Testing_136)
+-  [Function `withdraw_generic_asset`](#0xc0deb00c_user_withdraw_generic_asset)
+    -  [Testing](#@Testing_137)
 
 
 <pre><code><b>use</b> <a href="">0x1::account</a>;
@@ -1555,6 +1561,28 @@ as part of a size change.
 
 
 
+<a name="0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT"></a>
+
+Swap order cancelled because the remaining base asset amount to
+match was too small to fill a single lot.
+
+
+<pre><code><b>const</b> <a href="user.md#0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a>: u8 = 8;
+</code></pre>
+
+
+
+<a name="0xc0deb00c_user_CANCEL_REASON_VIOLATED_LIMIT_PRICE"></a>
+
+Swap order cancelled because the next order on the book to match
+against violated the swap order limit price.
+
+
+<pre><code><b>const</b> <a href="user.md#0xc0deb00c_user_CANCEL_REASON_VIOLATED_LIMIT_PRICE">CANCEL_REASON_VIOLATED_LIMIT_PRICE</a>: u8 = 9;
+</code></pre>
+
+
+
 <a name="0xc0deb00c_user_E_ACCESS_KEY_MISMATCH"></a>
 
 Expected order access key does not match assigned order access
@@ -2034,6 +2062,67 @@ Public constant getter for <code><a href="user.md#0xc0deb00c_user_CANCEL_REASON_
 
 
 
+<a name="0xc0deb00c_user_get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT"></a>
+
+## Function `get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`
+
+Public constant getter for
+<code><a href="user.md#0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a></code>.
+
+
+<a name="@Testing_23"></a>
+
+### Testing
+
+
+* <code>test_get_cancel_reasons()</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a>(): u8
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a>(): u8 {
+    <a href="user.md#0xc0deb00c_user_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT">CANCEL_REASON_TOO_SMALL_TO_FILL_LOT</a>
+}
+</code></pre>
+
+
+
+<a name="0xc0deb00c_user_get_CANCEL_REASON_VIOLATED_LIMIT_PRICE"></a>
+
+## Function `get_CANCEL_REASON_VIOLATED_LIMIT_PRICE`
+
+Public constant getter for <code><a href="user.md#0xc0deb00c_user_CANCEL_REASON_VIOLATED_LIMIT_PRICE">CANCEL_REASON_VIOLATED_LIMIT_PRICE</a></code>.
+
+
+<a name="@Testing_24"></a>
+
+### Testing
+
+
+* <code>test_get_cancel_reasons()</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_VIOLATED_LIMIT_PRICE">get_CANCEL_REASON_VIOLATED_LIMIT_PRICE</a>(): u8
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user.md#0xc0deb00c_user_get_CANCEL_REASON_VIOLATED_LIMIT_PRICE">get_CANCEL_REASON_VIOLATED_LIMIT_PRICE</a>(): u8 {
+    <a href="user.md#0xc0deb00c_user_CANCEL_REASON_VIOLATED_LIMIT_PRICE">CANCEL_REASON_VIOLATED_LIMIT_PRICE</a>
+}
+</code></pre>
+
+
+
 <a name="0xc0deb00c_user_get_NO_CUSTODIAN"></a>
 
 ## Function `get_NO_CUSTODIAN`
@@ -2041,7 +2130,7 @@ Public constant getter for <code><a href="user.md#0xc0deb00c_user_CANCEL_REASON_
 Public constant getter for <code><a href="user.md#0xc0deb00c_user_NO_CUSTODIAN">NO_CUSTODIAN</a></code>.
 
 
-<a name="@Testing_23"></a>
+<a name="@Testing_25"></a>
 
 ### Testing
 
@@ -2069,7 +2158,7 @@ Public constant getter for <code><a href="user.md#0xc0deb00c_user_NO_CUSTODIAN">
 Return all market account IDs associated with market ID.
 
 
-<a name="@Parameters_24"></a>
+<a name="@Parameters_26"></a>
 
 ### Parameters
 
@@ -2078,7 +2167,7 @@ Return all market account IDs associated with market ID.
 * <code>market_id</code>: Market ID to check market accounts for.
 
 
-<a name="@Returns_25"></a>
+<a name="@Returns_27"></a>
 
 ### Returns
 
@@ -2087,7 +2176,7 @@ Return all market account IDs associated with market ID.
 market, empty if no market accounts.
 
 
-<a name="@Gas_considerations_26"></a>
+<a name="@Gas_considerations_28"></a>
 
 ### Gas considerations
 
@@ -2096,7 +2185,7 @@ Loops over all elements within a vector that is itself a single
 item in global storage, and returns a vector via pass-by-value.
 
 
-<a name="@Testing_27"></a>
+<a name="@Testing_29"></a>
 
 ### Testing
 
@@ -2152,7 +2241,7 @@ item in global storage, and returns a vector via pass-by-value.
 Return all of a user's market account IDs.
 
 
-<a name="@Parameters_28"></a>
+<a name="@Parameters_30"></a>
 
 ### Parameters
 
@@ -2160,7 +2249,7 @@ Return all of a user's market account IDs.
 * <code><a href="user.md#0xc0deb00c_user">user</a></code>: Address of user to check market account IDs for.
 
 
-<a name="@Returns_29"></a>
+<a name="@Returns_31"></a>
 
 ### Returns
 
@@ -2169,7 +2258,7 @@ Return all of a user's market account IDs.
 no market accounts.
 
 
-<a name="@Gas_considerations_30"></a>
+<a name="@Gas_considerations_32"></a>
 
 ### Gas considerations
 
@@ -2181,7 +2270,7 @@ read, incurring linearly-scaled vector operation costs. Returns
 a vector via pass-by-value.
 
 
-<a name="@Testing_31"></a>
+<a name="@Testing_33"></a>
 
 ### Testing
 
@@ -2244,7 +2333,7 @@ a vector via pass-by-value.
 Return custodian ID encoded in market account ID.
 
 
-<a name="@Testing_32"></a>
+<a name="@Testing_34"></a>
 
 ### Testing
 
@@ -2278,7 +2367,7 @@ Return human-readable <code><a href="user.md#0xc0deb00c_user_MarketAccountView">
 Mutates state, so kept as a private view function.
 
 
-<a name="@Aborts_33"></a>
+<a name="@Aborts_35"></a>
 
 ### Aborts
 
@@ -2286,7 +2375,7 @@ Mutates state, so kept as a private view function.
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No such specified market account.
 
 
-<a name="@Testing_34"></a>
+<a name="@Testing_36"></a>
 
 ### Testing
 
@@ -2346,7 +2435,7 @@ Mutates state, so kept as a private view function.
 Return market account ID with encoded market and custodian IDs.
 
 
-<a name="@Testing_35"></a>
+<a name="@Testing_37"></a>
 
 ### Testing
 
@@ -2381,7 +2470,7 @@ Get user-friendly views of all of a <code><a href="user.md#0xc0deb00c_user">user
 Mutates state, so kept as a private view function.
 
 
-<a name="@Testing_36"></a>
+<a name="@Testing_38"></a>
 
 ### Testing
 
@@ -2435,7 +2524,7 @@ Restricted to private view function to prevent runtime handle
 contention.
 
 
-<a name="@Testing_37"></a>
+<a name="@Testing_39"></a>
 
 ### Testing
 
@@ -2498,7 +2587,7 @@ contention.
 Return market ID encoded in market account ID.
 
 
-<a name="@Testing_38"></a>
+<a name="@Testing_40"></a>
 
 ### Testing
 
@@ -2531,7 +2620,7 @@ Return <code><b>true</b></code> if <code><a href="user.md#0xc0deb00c_user">user<
 given <code>market_id</code> and <code>custodian_id</code>.
 
 
-<a name="@Testing_39"></a>
+<a name="@Testing_41"></a>
 
 ### Testing
 
@@ -2568,7 +2657,7 @@ Return <code><b>true</b></code> if <code><a href="user.md#0xc0deb00c_user">user<
 given <code>market_account_id</code>.
 
 
-<a name="@Testing_40"></a>
+<a name="@Testing_42"></a>
 
 ### Testing
 
@@ -2608,7 +2697,7 @@ Return <code><b>true</b></code> if <code><a href="user.md#0xc0deb00c_user">user<
 registered with given <code>market_id</code>.
 
 
-<a name="@Testing_41"></a>
+<a name="@Testing_43"></a>
 
 ### Testing
 
@@ -2647,7 +2736,7 @@ registered with given <code>market_id</code>.
 Wrapped call to <code><a href="user.md#0xc0deb00c_user_deposit_asset">deposit_asset</a>()</code> for depositing coins.
 
 
-<a name="@Aborts_42"></a>
+<a name="@Aborts_44"></a>
 
 ### Aborts
 
@@ -2657,7 +2746,7 @@ corresponding to the Econia account having initialized a coin
 of type <code>GenericAsset</code>.
 
 
-<a name="@Testing_43"></a>
+<a name="@Testing_45"></a>
 
 ### Testing
 
@@ -2709,7 +2798,7 @@ of type <code>GenericAsset</code>.
 Wrapped call to <code><a href="user.md#0xc0deb00c_user_deposit_asset">deposit_asset</a>()</code> for depositing generic asset.
 
 
-<a name="@Testing_44"></a>
+<a name="@Testing_46"></a>
 
 ### Testing
 
@@ -2757,7 +2846,7 @@ Restricted to custodian for given market account to prevent
 excessive public queries and thus transaction collisions.
 
 
-<a name="@Testing_45"></a>
+<a name="@Testing_47"></a>
 
 ### Testing
 
@@ -2803,7 +2892,7 @@ Restricted to signing user for given market account to prevent
 excessive public queries and thus transaction collisions.
 
 
-<a name="@Testing_46"></a>
+<a name="@Testing_48"></a>
 
 ### Testing
 
@@ -2847,7 +2936,7 @@ Restricted to custodian for given market account to prevent
 excessive public queries and thus transaction collisions.
 
 
-<a name="@Testing_47"></a>
+<a name="@Testing_49"></a>
 
 ### Testing
 
@@ -2895,7 +2984,7 @@ Restricted to signing user for given market account to prevent
 excessive public queries and thus transaction collisions.
 
 
-<a name="@Testing_48"></a>
+<a name="@Testing_50"></a>
 
 ### Testing
 
@@ -2938,7 +3027,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_coins">withdraw_
 authority of delegated custodian.
 
 
-<a name="@Testing_49"></a>
+<a name="@Testing_51"></a>
 
 ### Testing
 
@@ -2984,7 +3073,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_coins">withdraw_
 authority of signing user.
 
 
-<a name="@Testing_50"></a>
+<a name="@Testing_52"></a>
 
 ### Testing
 
@@ -3029,7 +3118,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_generic_asset">w
 authority of delegated custodian.
 
 
-<a name="@Testing_51"></a>
+<a name="@Testing_53"></a>
 
 ### Testing
 
@@ -3074,7 +3163,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_generic_asset">w
 authority of signing user.
 
 
-<a name="@Testing_52"></a>
+<a name="@Testing_54"></a>
 
 ### Testing
 
@@ -3118,7 +3207,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_deposit_coins">deposit_co
 <code>aptos_framework::coin::CoinStore</code>.
 
 
-<a name="@Testing_53"></a>
+<a name="@Testing_55"></a>
 
 ### Testing
 
@@ -3167,7 +3256,7 @@ market account without associated market event handles, if they
 registered a market account before an on-chain upgrade.
 
 
-<a name="@Parameters_54"></a>
+<a name="@Parameters_56"></a>
 
 ### Parameters
 
@@ -3177,7 +3266,7 @@ registered a market account before an on-chain upgrade.
 * <code>custodian_id</code>: Custodian ID for market account.
 
 
-<a name="@Aborts_55"></a>
+<a name="@Aborts_57"></a>
 
 ### Aborts
 
@@ -3185,7 +3274,7 @@ registered a market account before an on-chain upgrade.
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No such specified market account.
 
 
-<a name="@Testing_56"></a>
+<a name="@Testing_58"></a>
 
 ### Testing
 
@@ -3250,7 +3339,7 @@ Verifies market ID and asset types via internal call to
 <code><a href="user.md#0xc0deb00c_user_register_market_account_account_entries">register_market_account_account_entries</a>()</code>.
 
 
-<a name="@Type_parameters_57"></a>
+<a name="@Type_parameters_59"></a>
 
 ### Type parameters
 
@@ -3261,7 +3350,7 @@ a generic asset, must be passed as <code><a href="registry.md#0xc0deb00c_registr
 * <code>QuoteType</code>: Quote type for indicated market.
 
 
-<a name="@Parameters_58"></a>
+<a name="@Parameters_60"></a>
 
 ### Parameters
 
@@ -3272,7 +3361,7 @@ a generic asset, must be passed as <code><a href="registry.md#0xc0deb00c_registr
 <code><a href="user.md#0xc0deb00c_user_NO_CUSTODIAN">NO_CUSTODIAN</a></code>.
 
 
-<a name="@Aborts_59"></a>
+<a name="@Aborts_61"></a>
 
 ### Aborts
 
@@ -3281,7 +3370,7 @@ a generic asset, must be passed as <code><a href="registry.md#0xc0deb00c_registr
 registered.
 
 
-<a name="@Testing_60"></a>
+<a name="@Testing_62"></a>
 
 ### Testing
 
@@ -3342,7 +3431,7 @@ registered.
 Wrapped <code><a href="user.md#0xc0deb00c_user_register_market_account">register_market_account</a>()</code> call for generic base asset.
 
 
-<a name="@Testing_61"></a>
+<a name="@Testing_63"></a>
 
 ### Testing
 
@@ -3384,7 +3473,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_coins_user">with
 market account to user's <code>aptos_framework::coin::CoinStore</code>.
 
 
-<a name="@Testing_62"></a>
+<a name="@Testing_64"></a>
 
 ### Testing
 
@@ -3444,7 +3533,7 @@ malicious market order ID (portions of which essentially
 function as pointers into AVL queue state).
 
 
-<a name="@Parameters_63"></a>
+<a name="@Parameters_65"></a>
 
 ### Parameters
 
@@ -3467,7 +3556,7 @@ immediate re-placement, corresponding to the cancel reason
 no cancel event is emitted.
 
 
-<a name="@Returns_64"></a>
+<a name="@Returns_66"></a>
 
 ### Returns
 
@@ -3475,7 +3564,7 @@ no cancel event is emitted.
 * <code>u128</code>: Market order ID for corresponding order.
 
 
-<a name="@Terminology_65"></a>
+<a name="@Terminology_67"></a>
 
 ### Terminology
 
@@ -3486,7 +3575,7 @@ from a trade if the cancelled order had been filled.
 away if the cancelled order had been filled.
 
 
-<a name="@Aborts_66"></a>
+<a name="@Aborts_68"></a>
 
 ### Aborts
 
@@ -3497,7 +3586,7 @@ operation and actual size before operation.
 user's open order, when market order ID not passed as <code><a href="user.md#0xc0deb00c_user_NIL">NIL</a></code>.
 
 
-<a name="@Emits_67"></a>
+<a name="@Emits_69"></a>
 
 ### Emits
 
@@ -3505,7 +3594,7 @@ user's open order, when market order ID not passed as <code><a href="user.md#0xc
 * <code><a href="user.md#0xc0deb00c_user_CancelOrderEvent">CancelOrderEvent</a></code>: Information about a cancelled order.
 
 
-<a name="@Assumptions_68"></a>
+<a name="@Assumptions_70"></a>
 
 ### Assumptions
 
@@ -3526,7 +3615,7 @@ or a self match cancel.
 order if market order ID is not <code><a href="user.md#0xc0deb00c_user_NIL">NIL</a></code>.
 
 
-<a name="@Expected_value_testing_69"></a>
+<a name="@Expected_value_testing_71"></a>
 
 ### Expected value testing
 
@@ -3536,7 +3625,7 @@ order if market order ID is not <code><a href="user.md#0xc0deb00c_user_NIL">NIL<
 * <code>test_place_cancel_order_stack()</code>
 
 
-<a name="@Failure_testing_70"></a>
+<a name="@Failure_testing_72"></a>
 
 ### Failure testing
 
@@ -3652,7 +3741,7 @@ order if market order ID is not <code><a href="user.md#0xc0deb00c_user_NIL">NIL<
 Change the size of a user's open order on given side.
 
 
-<a name="@Parameters_71"></a>
+<a name="@Parameters_73"></a>
 
 ### Parameters
 
@@ -3669,7 +3758,7 @@ to <code><a href="user.md#0xc0deb00c_user_place_order_internal">place_order_inte
 * <code>market_order_id</code>: Market order ID for order book lookup.
 
 
-<a name="@Aborts_72"></a>
+<a name="@Aborts_74"></a>
 
 ### Aborts
 
@@ -3677,7 +3766,7 @@ to <code><a href="user.md#0xc0deb00c_user_place_order_internal">place_order_inte
 * <code><a href="user.md#0xc0deb00c_user_E_CHANGE_ORDER_NO_CHANGE">E_CHANGE_ORDER_NO_CHANGE</a></code>: No change in order size.
 
 
-<a name="@Emits_73"></a>
+<a name="@Emits_75"></a>
 
 ### Emits
 
@@ -3686,7 +3775,7 @@ to <code><a href="user.md#0xc0deb00c_user_place_order_internal">place_order_inte
 manual size change.
 
 
-<a name="@Assumptions_74"></a>
+<a name="@Assumptions_76"></a>
 
 ### Assumptions
 
@@ -3699,7 +3788,7 @@ order ID, which is checked in <code><a href="user.md#0xc0deb00c_user_cancel_orde
 order.
 
 
-<a name="@Testing_75"></a>
+<a name="@Testing_77"></a>
 
 ### Testing
 
@@ -3866,7 +3955,7 @@ Should only be called by the matching engine when matching from
 a user's market account.
 
 
-<a name="@Type_parameters_76"></a>
+<a name="@Type_parameters_78"></a>
 
 ### Type parameters
 
@@ -3875,7 +3964,7 @@ a user's market account.
 * <code>QuoteType</code>: Quote type for market.
 
 
-<a name="@Parameters_77"></a>
+<a name="@Parameters_79"></a>
 
 ### Parameters
 
@@ -3889,7 +3978,7 @@ a user's market account.
 * <code>underwriter_id</code>: Underwriter ID for market.
 
 
-<a name="@Testing_78"></a>
+<a name="@Testing_80"></a>
 
 ### Testing
 
@@ -3937,7 +4026,7 @@ a user's market account.
 Emit limit order events to a user's market event handles.
 
 
-<a name="@Parameters_79"></a>
+<a name="@Parameters_81"></a>
 
 ### Parameters
 
@@ -3961,7 +4050,7 @@ across the spread, may be empty.
 cancel reason associated with a <code><a href="user.md#0xc0deb00c_user_CancelOrderEvent">CancelOrderEvent</a></code>.
 
 
-<a name="@Emits_80"></a>
+<a name="@Emits_82"></a>
 
 ### Emits
 
@@ -4055,7 +4144,7 @@ transaction in which it was placed.
 Emit market order events to a user's market event handles.
 
 
-<a name="@Parameters_81"></a>
+<a name="@Parameters_83"></a>
 
 ### Parameters
 
@@ -4075,7 +4164,7 @@ Emit market order events to a user's market event handles.
 cancel reason associated with a <code><a href="user.md#0xc0deb00c_user_CancelOrderEvent">CancelOrderEvent</a></code>.
 
 
-<a name="@Emits_82"></a>
+<a name="@Emits_84"></a>
 
 ### Emits
 
@@ -4196,7 +4285,7 @@ order as indicated with sufficient assets to fill it. Hence no
 error checking.
 
 
-<a name="@Type_parameters_83"></a>
+<a name="@Type_parameters_85"></a>
 
 ### Type parameters
 
@@ -4205,7 +4294,7 @@ error checking.
 * <code>QuoteType</code>: Quote type for indicated market.
 
 
-<a name="@Parameters_84"></a>
+<a name="@Parameters_86"></a>
 
 ### Parameters
 
@@ -4226,7 +4315,7 @@ matching engine.
 * <code>quote_to_route</code>: Amount of quote asset filled.
 
 
-<a name="@Returns_85"></a>
+<a name="@Returns_87"></a>
 
 ### Returns
 
@@ -4238,7 +4327,7 @@ matching engine.
 * <code>u128</code>: Market order ID just filled against.
 
 
-<a name="@Aborts_86"></a>
+<a name="@Aborts_88"></a>
 
 ### Aborts
 
@@ -4247,7 +4336,7 @@ matching engine.
 operation and actual size before operation.
 
 
-<a name="@Assumptions_87"></a>
+<a name="@Assumptions_89"></a>
 
 ### Assumptions
 
@@ -4255,7 +4344,7 @@ operation and actual size before operation.
 * Only called by the matching engine as described above.
 
 
-<a name="@Testing_88"></a>
+<a name="@Testing_90"></a>
 
 ### Testing
 
@@ -4403,7 +4492,7 @@ operation and actual size before operation.
 Return asset counts for specified market account.
 
 
-<a name="@Parameters_89"></a>
+<a name="@Parameters_91"></a>
 
 ### Parameters
 
@@ -4413,7 +4502,7 @@ Return asset counts for specified market account.
 * <code>custodian_id</code>: Custodian ID for market account.
 
 
-<a name="@Returns_90"></a>
+<a name="@Returns_92"></a>
 
 ### Returns
 
@@ -4426,7 +4515,7 @@ Return asset counts for specified market account.
 * <code><a href="user.md#0xc0deb00c_user_MarketAccount">MarketAccount</a>.quote_ceiling</code>
 
 
-<a name="@Aborts_91"></a>
+<a name="@Aborts_93"></a>
 
 ### Aborts
 
@@ -4435,7 +4524,7 @@ Return asset counts for specified market account.
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No market account resource found.
 
 
-<a name="@Testing_92"></a>
+<a name="@Testing_94"></a>
 
 ### Testing
 
@@ -4495,7 +4584,7 @@ Return asset counts for specified market account.
 Return all active market order IDs for given market account.
 
 
-<a name="@Parameters_93"></a>
+<a name="@Parameters_95"></a>
 
 ### Parameters
 
@@ -4506,7 +4595,7 @@ Return all active market order IDs for given market account.
 * <code>side</code>: <code><a href="user.md#0xc0deb00c_user_ASK">ASK</a></code> or <code><a href="user.md#0xc0deb00c_user_BID">BID</a></code>, the side on which to check.
 
 
-<a name="@Returns_94"></a>
+<a name="@Returns_96"></a>
 
 ### Returns
 
@@ -4515,7 +4604,7 @@ Return all active market order IDs for given market account.
 given market account and side, empty if none.
 
 
-<a name="@Aborts_95"></a>
+<a name="@Aborts_97"></a>
 
 ### Aborts
 
@@ -4524,7 +4613,7 @@ given market account and side, empty if none.
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No market account resource found.
 
 
-<a name="@Testing_96"></a>
+<a name="@Testing_98"></a>
 
 ### Testing
 
@@ -4593,7 +4682,7 @@ order access key to be allocated. Otherwise is order access key
 at top of inactive order stack.
 
 
-<a name="@Parameters_97"></a>
+<a name="@Parameters_99"></a>
 
 ### Parameters
 
@@ -4605,7 +4694,7 @@ at top of inactive order stack.
 placed.
 
 
-<a name="@Returns_98"></a>
+<a name="@Returns_100"></a>
 
 ### Returns
 
@@ -4613,7 +4702,7 @@ placed.
 * <code>u64</code>: Order access key of next order to be placed.
 
 
-<a name="@Aborts_99"></a>
+<a name="@Aborts_101"></a>
 
 ### Aborts
 
@@ -4622,7 +4711,7 @@ placed.
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No market account resource found.
 
 
-<a name="@Testing_100"></a>
+<a name="@Testing_102"></a>
 
 ### Testing
 
@@ -4686,7 +4775,7 @@ Restricted to public friend to prevent runtime user state
 contention.
 
 
-<a name="@Testing_101"></a>
+<a name="@Testing_103"></a>
 
 ### Testing
 
@@ -4756,7 +4845,7 @@ required. Once an order book entry has been created, a market
 order ID will then be made available.
 
 
-<a name="@Parameters_102"></a>
+<a name="@Parameters_104"></a>
 
 ### Parameters
 
@@ -4772,7 +4861,7 @@ order ID will then be made available.
 assigned to order.
 
 
-<a name="@Terminology_103"></a>
+<a name="@Terminology_105"></a>
 
 ### Terminology
 
@@ -4781,7 +4870,7 @@ assigned to order.
 * The "outbound" asset is the asset traded away.
 
 
-<a name="@Assumptions_104"></a>
+<a name="@Assumptions_106"></a>
 
 ### Assumptions
 
@@ -4792,7 +4881,7 @@ assigned to order.
 verified by <code><a href="user.md#0xc0deb00c_user_get_next_order_access_key_internal">get_next_order_access_key_internal</a>()</code>.
 
 
-<a name="@Aborts_105"></a>
+<a name="@Aborts_107"></a>
 
 ### Aborts
 
@@ -4807,7 +4896,7 @@ received from trade.
 match assigned order access key.
 
 
-<a name="@Expected_value_testing_106"></a>
+<a name="@Expected_value_testing_108"></a>
 
 ### Expected value testing
 
@@ -4817,7 +4906,7 @@ match assigned order access key.
 * <code>test_place_cancel_order_stack()</code>
 
 
-<a name="@Failure_testing_107"></a>
+<a name="@Failure_testing_109"></a>
 
 ### Failure testing
 
@@ -4931,7 +5020,7 @@ Should only be called by the matching engine when matching from
 a user's market account.
 
 
-<a name="@Type_parameters_108"></a>
+<a name="@Type_parameters_110"></a>
 
 ### Type parameters
 
@@ -4940,7 +5029,7 @@ a user's market account.
 * <code>QuoteType</code>: Quote type for market.
 
 
-<a name="@Parameters_109"></a>
+<a name="@Parameters_111"></a>
 
 ### Parameters
 
@@ -4953,7 +5042,7 @@ a user's market account.
 * <code>underwriter_id</code>: Underwriter ID for market.
 
 
-<a name="@Returns_110"></a>
+<a name="@Returns_112"></a>
 
 ### Returns
 
@@ -4963,7 +5052,7 @@ market account.
 * <code>&lt;Coin&lt;QuoteType&gt;</code>: Quote coins from user's market account.
 
 
-<a name="@Testing_111"></a>
+<a name="@Testing_113"></a>
 
 ### Testing
 
@@ -5016,7 +5105,7 @@ Deposit an asset to a user's market account.
 Update asset counts, deposit optional coins as collateral.
 
 
-<a name="@Type_parameters_112"></a>
+<a name="@Type_parameters_114"></a>
 
 ### Type parameters
 
@@ -5025,7 +5114,7 @@ Update asset counts, deposit optional coins as collateral.
 if a generic asset.
 
 
-<a name="@Parameters_113"></a>
+<a name="@Parameters_115"></a>
 
 ### Parameters
 
@@ -5039,7 +5128,7 @@ if a generic asset.
 depositing coins.
 
 
-<a name="@Aborts_114"></a>
+<a name="@Aborts_116"></a>
 
 ### Aborts
 
@@ -5054,7 +5143,7 @@ asset ceiling.
 indicated market, in the case of a generic asset deposit.
 
 
-<a name="@Assumptions_115"></a>
+<a name="@Assumptions_117"></a>
 
 ### Assumptions
 
@@ -5063,7 +5152,7 @@ indicated market, in the case of a generic asset deposit.
 does a corresponding collateral map entry.
 
 
-<a name="@Testing_116"></a>
+<a name="@Testing_118"></a>
 
 ### Testing
 
@@ -5205,7 +5294,7 @@ indicated market account.
 Return <code><a href="registry.md#0xc0deb00c_registry_MarketInfo">registry::MarketInfo</a></code> fields stored in market account.
 
 
-<a name="@Parameters_117"></a>
+<a name="@Parameters_119"></a>
 
 ### Parameters
 
@@ -5215,7 +5304,7 @@ Return <code><a href="registry.md#0xc0deb00c_registry_MarketInfo">registry::Mark
 * <code>custodian_id</code>: Custodian ID for market account.
 
 
-<a name="@Returns_118"></a>
+<a name="@Returns_120"></a>
 
 ### Returns
 
@@ -5229,7 +5318,7 @@ Return <code><a href="registry.md#0xc0deb00c_registry_MarketInfo">registry::Mark
 * <code><a href="user.md#0xc0deb00c_user_MarketAccount">MarketAccount</a>.underwriter_id</code>
 
 
-<a name="@Aborts_119"></a>
+<a name="@Aborts_121"></a>
 
 ### Aborts
 
@@ -5238,7 +5327,7 @@ Return <code><a href="registry.md#0xc0deb00c_registry_MarketInfo">registry::Mark
 * <code><a href="user.md#0xc0deb00c_user_E_NO_MARKET_ACCOUNT">E_NO_MARKET_ACCOUNT</a></code>: No market account resource found.
 
 
-<a name="@Testing_120"></a>
+<a name="@Testing_122"></a>
 
 ### Testing
 
@@ -5307,7 +5396,7 @@ registered market, via call to
 <code><a href="registry.md#0xc0deb00c_registry_get_market_info_for_market_account">registry::get_market_info_for_market_account</a>()</code>.
 
 
-<a name="@Type_parameters_121"></a>
+<a name="@Type_parameters_123"></a>
 
 ### Type parameters
 
@@ -5316,7 +5405,7 @@ registered market, via call to
 * <code>QuoteType</code>: Quote type for indicated market.
 
 
-<a name="@Parameters_122"></a>
+<a name="@Parameters_124"></a>
 
 ### Parameters
 
@@ -5328,7 +5417,7 @@ registered market, via call to
 <code><a href="user.md#0xc0deb00c_user_NO_CUSTODIAN">NO_CUSTODIAN</a></code>.
 
 
-<a name="@Aborts_123"></a>
+<a name="@Aborts_125"></a>
 
 ### Aborts
 
@@ -5336,7 +5425,7 @@ registered market, via call to
 * <code><a href="user.md#0xc0deb00c_user_E_EXISTS_MARKET_ACCOUNT">E_EXISTS_MARKET_ACCOUNT</a></code>: Market account already exists.
 
 
-<a name="@Testing_124"></a>
+<a name="@Testing_126"></a>
 
 ### Testing
 
@@ -5420,7 +5509,7 @@ performed by <code>register_market_account_accounts_entries()</code> in
 <code><a href="user.md#0xc0deb00c_user_register_market_account">register_market_account</a>()</code>.
 
 
-<a name="@Type_parameters_125"></a>
+<a name="@Type_parameters_127"></a>
 
 ### Type parameters
 
@@ -5428,7 +5517,7 @@ performed by <code>register_market_account_accounts_entries()</code> in
 * <code>CoinType</code>: Phantom coin type for indicated market.
 
 
-<a name="@Parameters_126"></a>
+<a name="@Parameters_128"></a>
 
 ### Parameters
 
@@ -5437,7 +5526,7 @@ performed by <code>register_market_account_accounts_entries()</code> in
 * <code>market_account_id</code>: Market account ID for given market.
 
 
-<a name="@Testing_127"></a>
+<a name="@Testing_129"></a>
 
 ### Testing
 
@@ -5482,7 +5571,7 @@ performed by <code>register_market_account_accounts_entries()</code> in
 Convert a tablist of <code><a href="user.md#0xc0deb00c_user_Order">Order</a></code> into a vector of only open orders.
 
 
-<a name="@Testing_128"></a>
+<a name="@Testing_130"></a>
 
 ### Testing
 
@@ -5535,7 +5624,7 @@ Withdraw an asset from a user's market account.
 Update asset counts, withdraw optional collateral coins.
 
 
-<a name="@Type_parameters_129"></a>
+<a name="@Type_parameters_131"></a>
 
 ### Type parameters
 
@@ -5544,7 +5633,7 @@ Update asset counts, withdraw optional collateral coins.
 if a generic asset.
 
 
-<a name="@Parameters_130"></a>
+<a name="@Parameters_132"></a>
 
 ### Parameters
 
@@ -5557,7 +5646,7 @@ if a generic asset.
 withdrawing coins.
 
 
-<a name="@Returns_131"></a>
+<a name="@Returns_133"></a>
 
 ### Returns
 
@@ -5565,7 +5654,7 @@ withdrawing coins.
 * <code>Option&lt;Coin&lt;AssetType&gt;&gt;</code>: Optional collateral coins.
 
 
-<a name="@Aborts_132"></a>
+<a name="@Aborts_134"></a>
 
 ### Aborts
 
@@ -5580,7 +5669,7 @@ withdrawal.
 indicated market, in the case of a generic asset withdrawal.
 
 
-<a name="@Testing_133"></a>
+<a name="@Testing_135"></a>
 
 ### Testing
 
@@ -5675,7 +5764,7 @@ indicated market, in the case of a generic asset withdrawal.
 Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_asset">withdraw_asset</a>()</code> for withdrawing coins.
 
 
-<a name="@Testing_134"></a>
+<a name="@Testing_136"></a>
 
 ### Testing
 
@@ -5722,7 +5811,7 @@ Wrapped call to <code><a href="user.md#0xc0deb00c_user_withdraw_asset">withdraw_
 asset.
 
 
-<a name="@Testing_135"></a>
+<a name="@Testing_137"></a>
 
 ### Testing
 

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -7376,10 +7376,36 @@ module econia::market {
             market_id, side_maker, market_order_id_lo), 0);
         assert!(is_list_node_order_active(
             market_id, side_maker, market_order_id_hi), 0);
+        // Assert event streams.
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Place taker order with self match.
         place_market_order_user<BC, QC>(
             &user, market_id, integrator, direction_taker, size_taker,
             self_match_behavior_taker);
+        // Assert event streams.
+        let market_order_id_taker_only = order_id_no_post(3);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    market_order_id_lo,
+                    user_address,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_SELF_MATCH_MAKER
+                ),
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    market_order_id_taker_only,
+                    user_address,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_SELF_MATCH_TAKER
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Assert list node order inactive for low price, active for
         // high price.
         assert!(!is_list_node_order_active(
@@ -7505,11 +7531,29 @@ module econia::market {
             market_id, side_maker, market_order_id_lo), 0);
         assert!(is_list_node_order_active(
             market_id, side_maker, market_order_id_hi), 0);
+        // Assert event streams.
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Place taker order with self match.
         let (base_trade_r, quote_trade_r, fee_r) =
                 place_market_order_user<BC, QC>(
             &user, market_id, integrator, direction_taker, size_taker,
             self_match_behavior_taker);
+        // Assert event streams.
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    market_order_id_lo,
+                    user_address,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_SELF_MATCH_MAKER
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Assert returns.
         assert!(base_trade_r  == base_trade, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -7631,10 +7675,29 @@ module econia::market {
             market_id, side_maker, market_order_id_lo), 0);
         assert!(is_list_node_order_active(
             market_id, side_maker, market_order_id_hi), 0);
+        // Assert event streams.
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Place taker order with self match.
         place_market_order_user<BC, QC>(
             &user, market_id, integrator, direction_taker, size_taker,
             self_match_behavior_taker);
+        // Assert event streams.
+        let market_order_id_taker_only = order_id_no_post(3);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, NO_CUSTODIAN) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    market_order_id_taker_only,
+                    user_address,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_SELF_MATCH_TAKER
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, user_address, CUSTODIAN_ID_USER_0) == vector[], 0);
         // Assert list node orders active.
         assert!(is_list_node_order_active(
             market_id, side_maker, market_order_id_lo), 0);

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2941,9 +2941,9 @@ module econia::market {
     ///
     /// # Expected value testing
     ///
-    /// * `test_match_complete_fill_no_lots_buy()` TODO
-    /// * `test_match_complete_fill_no_ticks_sell()` TODO
-    /// * `test_match_empty()` TODO
+    /// * `test_match_complete_fill_no_lots_buy()`
+    /// * `test_match_complete_fill_no_ticks_sell()`
+    /// * `test_match_empty()`
     /// * `test_match_fill_size_0()` TODO
     /// * `test_match_loop_twice()` TODO
     /// * `test_match_partial_fill_lot_limited_sell()` TODO
@@ -6129,6 +6129,14 @@ module econia::market {
                                 assets::mint_test(deposit_base));
         user::deposit_coins<QC>(maker_address, market_id, custodian_id,
                                 assets::mint_test(deposit_quote));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order, storing market order ID for lookup.
         let (market_order_id, _, _, _) = place_limit_order_user<BC, QC>(
             &maker, market_id, @integrator, side_maker, size_maker, price,
@@ -6141,6 +6149,59 @@ module econia::market {
             swap_coins(market_id, integrator, direction_taker, min_base,
                        max_base, min_quote, max_quote, price, base_coins,
                        quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[
+                user::create_place_limit_order_event_test(
+                    market_id,
+                    maker_address,
+                    custodian_id,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[
+                user::create_fill_event_internal(
+                    market_id,
+                    size_taker,
+                    price,
+                    side_maker,
+                    maker_address,
+                    custodian_id,
+                    market_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction: direction_taker,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(market_id) == vector[], 0);
         // Assert returns.
         assert!(coin::value(&base_coins)  == base_coin_end, 0);
         assert!(coin::value(&quote_coins) == quote_coin_end, 0);
@@ -6257,6 +6318,14 @@ module econia::market {
                                 assets::mint_test(deposit_base));
         user::deposit_coins<QC>(maker_address, market_id, custodian_id,
                                 assets::mint_test(deposit_quote));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order, storing market order ID for lookup.
         let (market_order_id, _, _, _) = place_limit_order_user<BC, QC>(
             &maker, market_id, @integrator, side_maker, size_maker, price,
@@ -6269,6 +6338,68 @@ module econia::market {
             swap_coins(market_id, integrator, direction_taker, min_base,
                        max_base, min_quote, max_quote, price, base_coins,
                        quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[
+                user::create_place_limit_order_event_test(
+                    market_id,
+                    maker_address,
+                    custodian_id,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[
+                user::create_fill_event_internal(
+                    market_id,
+                    size_taker,
+                    price,
+                    side_maker,
+                    maker_address,
+                    custodian_id,
+                    market_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            market_id) == vector[
+                PlaceSwapOrderEvent{
+                    market_id,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction: direction_taker,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            market_id) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_NOT_ENOUGH_LIQUIDITY
+                ),
+            ], 0);
         // Assert returns.
         assert!(coin::value(&base_coins)  == base_coin_end, 0);
         assert!(coin::value(&quote_coins) == quote_coin_end, 0);
@@ -6334,11 +6465,40 @@ module econia::market {
         let limit_price = 1;
         let base_coins  = coin::zero<BC>();
         let quote_coins = assets::mint_test<QC>(max_quote);
+        // Assert events.
+        assert!(!exists_market_event_handles(), 0);
         // Invoke matching engine via coin swap.
         let (base_coins, quote_coins, base_trade, quote_trade, fee) =
             swap_coins(market_id, integrator, direction, min_base, max_base,
                        min_quote, max_quote, limit_price, base_coins,
                        quote_coins);
+        let taker_order_id = order_id_no_post(1);
+        // Assert events.
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            market_id) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_NOT_ENOUGH_LIQUIDITY
+                ),
+            ], 0);
         // Assert returns.
         assert!(coin::value(&base_coins)  == 0, 0);
         assert!(coin::value(&quote_coins) == max_quote, 0);
@@ -6376,11 +6536,11 @@ module econia::market {
         // Declare price set to product of fee divisors, to eliminate
         // truncation when predicting fee amounts.
         let price = integrator_divisor * taker_divisor;
-        // Declare order size posted by maker, filled by taker.
+        // Declare order size posted by maker.
         let size_maker = MIN_SIZE_COIN + 10;
         // Declare base and quote required to fill maker.
         let base_maker = size_maker * LOT_SIZE_COIN;
-        let quote_maker = size_maker * price* TICK_SIZE_COIN;
+        let quote_maker = size_maker * price * TICK_SIZE_COIN;
         // Declare maker deposit amounts.
         let deposit_base  = HI_64 - base_maker;
         let deposit_quote = quote_maker;
@@ -6412,6 +6572,14 @@ module econia::market {
                                 assets::mint_test(deposit_base));
         user::deposit_coins<QC>(maker_address, market_id, custodian_id,
                                 assets::mint_test(deposit_quote));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order, storing market order ID for lookup.
         let (market_order_id, _, _, _) = place_limit_order_user<BC, QC>(
             &maker, market_id, @integrator, side_maker, size_maker, price,
@@ -6421,6 +6589,54 @@ module econia::market {
             swap_coins(market_id, integrator, direction_taker, min_base,
                        max_base, min_quote, max_quote, price, base_coins,
                        quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            market_id, maker_address, custodian_id) == vector[
+                user::create_place_limit_order_event_test(
+                    market_id,
+                    maker_address,
+                    custodian_id,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            market_id, maker_address, custodian_id) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            market_id, maker_address, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            market_id) == vector[
+                PlaceSwapOrderEvent{
+                    market_id,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction: direction_taker,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            market_id) == vector[
+                user::create_cancel_order_event_internal(
+                    market_id,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    // Should be: `CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                ),
+            ], 0);
         // Assert returns.
         assert!(coin::value(&base_coins)  == base_coin_end, 0);
         assert!(coin::value(&quote_coins) == quote_coin_end, 0);

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -11533,48 +11533,6 @@ module econia::market {
     }
 
     #[test]
-    #[expected_failure(abort_code = E_SIZE_BASE_OVERFLOW)]
-    /// Verify failure for invalid size argument.
-    fun test_place_market_order_size_base_overflow()
-    acquires OrderBooks {
-        // Initialize markets, users, and an integrator.
-        init_markets_users_integrator_test();
-        // Declare order arguments.
-        let user_address = @user_0;
-        let market_id = MARKET_ID_COIN;
-        let custodian_id = NO_CUSTODIAN;
-        let integrator = @integrator;
-        let direction = BUY;
-        let size = HI_64 / LOT_SIZE_COIN + 1;
-        let self_match_behavior = ABORT;
-        // Attempt invalid invocation.
-        place_market_order<BC, QC>(
-            user_address, market_id, custodian_id, integrator, direction,
-            size, self_match_behavior);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = E_SIZE_TOO_SMALL)]
-    /// Verify failure for invalid size argument.
-    fun test_place_market_order_size_too_small()
-    acquires OrderBooks {
-        // Initialize markets, users, and an integrator.
-        init_markets_users_integrator_test();
-        // Declare order arguments.
-        let user_address = @user_0;
-        let market_id = MARKET_ID_COIN;
-        let custodian_id = NO_CUSTODIAN;
-        let integrator = @integrator;
-        let direction = BUY;
-        let size = MIN_SIZE_COIN - 1;
-        let self_match_behavior = ABORT;
-        // Attempt invalid invocation.
-        place_market_order<BC, QC>(
-            user_address, market_id, custodian_id, integrator, direction,
-            size, self_match_behavior);
-    }
-
-    #[test]
     /// Verify state updates, returns for market buy when user specifies
     /// base trade amount that is less than max possible, under
     /// authority of signing user.
@@ -12485,6 +12443,48 @@ module econia::market {
         place_market_order_user<BC, QC>(
             &user_1, MARKET_ID_COIN, @integrator, BUY, size_match,
             self_match_behavior);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_SIZE_BASE_OVERFLOW)]
+    /// Verify failure for invalid size argument.
+    fun test_place_market_order_size_base_overflow()
+    acquires OrderBooks {
+        // Initialize markets, users, and an integrator.
+        init_markets_users_integrator_test();
+        // Declare order arguments.
+        let user_address = @user_0;
+        let market_id = MARKET_ID_COIN;
+        let custodian_id = NO_CUSTODIAN;
+        let integrator = @integrator;
+        let direction = BUY;
+        let size = HI_64 / LOT_SIZE_COIN + 1;
+        let self_match_behavior = ABORT;
+        // Attempt invalid invocation.
+        place_market_order<BC, QC>(
+            user_address, market_id, custodian_id, integrator, direction,
+            size, self_match_behavior);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_SIZE_TOO_SMALL)]
+    /// Verify failure for invalid size argument.
+    fun test_place_market_order_size_too_small()
+    acquires OrderBooks {
+        // Initialize markets, users, and an integrator.
+        init_markets_users_integrator_test();
+        // Declare order arguments.
+        let user_address = @user_0;
+        let market_id = MARKET_ID_COIN;
+        let custodian_id = NO_CUSTODIAN;
+        let integrator = @integrator;
+        let direction = BUY;
+        let size = MIN_SIZE_COIN - 1;
+        let self_match_behavior = ABORT;
+        // Attempt invalid invocation.
+        place_market_order<BC, QC>(
+            user_address, market_id, custodian_id, integrator, direction,
+            size, self_match_behavior);
     }
 
     #[test]

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2723,7 +2723,7 @@ module econia::market {
     ///
     /// * `Option<u8>`: An optional cancel reason, if the order needs
     ///   to be cancelled.
-    inline fun get_cancel_reason_option_for_market_order_or_swap(
+    /*inline*/ fun get_cancel_reason_option_for_market_order_or_swap(
         self_match_taker_cancel: bool,
         base_traded: u64,
         max_base: u64,

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -4274,6 +4274,30 @@ module econia::market {
     // Test-only functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
     #[test_only]
+    /// Immutably borrow market event handles for a market.
+    inline fun borrow_market_event_handles_for_market(
+        market_id: u64
+    ): &MarketEventHandlesForMarket
+    acquires MarketEventHandles {
+        let market_event_handles_map_ref =
+            &borrow_global<MarketEventHandles>(
+                resource_account::get_address()).map;
+        table::borrow(market_event_handles_map_ref, market_id)
+    }
+
+    #[test_only]
+    /// Immutably borrow swapper event handles for a market.
+    inline fun borrow_swapper_event_handles_for_market(
+        market_id: u64,
+        swapper: address
+    ): &SwapperEventHandlesForMarket
+    acquires SwapperEventHandles {
+        let swapper_event_handles_map_ref =
+            &borrow_global<SwapperEventHandles>(swapper).map;
+        table::borrow(swapper_event_handles_map_ref, market_id)
+    }
+
+    #[test_only]
     /// Assuming order placed by `@user_0` on `MARKET_ID_COIN`, verify
     /// order fields.
     public fun check_order_fields_test(
@@ -4326,6 +4350,64 @@ module econia::market {
                 &user, MARKET_ID_COIN, @integrator, ASK, MIN_SIZE_COIN,
                 min_ask_price, NO_RESTRICTION, ABORT);};
         user // Return user signature.
+    }
+
+    #[test_only]
+    /// Get `CancelOrderEvent`s at market level.
+    public fun get_cancel_order_events_market(
+        market_id: u64
+    ): vector<CancelOrderEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market(market_id).
+                cancel_order_events))
+    }
+
+    #[test_only]
+    /// Get `CancelOrderEvent`s at swapper level.
+    public fun get_cancel_order_events_swapper(
+        market_id: u64,
+        swapper: address
+    ): vector<CancelOrderEvent>
+    acquires SwapperEventHandles {
+        event::emitted_events(
+            &(borrow_swapper_event_handles_for_market(market_id, swapper).
+                cancel_order_events))
+    }
+
+    #[test_only]
+    /// Get `FillEvent`s at swapper level.
+    public fun get_fill_events_swapper(
+        market_id: u64,
+        swapper: address
+    ): vector<FillEvent>
+    acquires SwapperEventHandles {
+        event::emitted_events(
+            &(borrow_swapper_event_handles_for_market(market_id, swapper).
+                fill_events))
+    }
+
+    #[test_only]
+    /// Get `PlaceSwapOrderEvent`s at market level.
+    public fun get_place_swap_order_events_market(
+        market_id: u64
+    ): vector<PlaceSwapOrderEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market(market_id).
+                place_swap_order_events))
+    }
+
+    #[test_only]
+    /// Get `PlaceSwapOrderEvent`s at swapper level.
+    public fun get_place_swap_order_events_swapper(
+        market_id: u64,
+        swapper: address
+    ): vector<PlaceSwapOrderEvent>
+    acquires SwapperEventHandles {
+        event::emitted_events(
+            &(borrow_swapper_event_handles_for_market(market_id, swapper).
+                place_swap_order_events))
     }
 
     #[test_only]

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2199,11 +2199,11 @@ module econia::market {
     ///
     /// # Testing
     ///
-    /// * `test_swap_generic_buy_base_limiting()` TODO
-    /// * `test_swap_generic_buy_quote_limiting()` TODO
-    /// * `test_swap_generic_sell_max_quote_limiting()` TODO
-    /// * `test_swap_generic_sell_no_max_base_limiting()` TODO
-    /// * `test_swap_generic_sell_no_max_quote_limiting()` TODO
+    /// * `test_swap_generic_buy_base_limiting()`
+    /// * `test_swap_generic_buy_quote_limiting()`
+    /// * `test_swap_generic_sell_max_quote_limiting()`
+    /// * `test_swap_generic_sell_no_max_base_limiting()`
+    /// * `test_swap_generic_sell_no_max_quote_limiting()`
     public fun swap_generic<
         QuoteType
     >(
@@ -13597,6 +13597,14 @@ module econia::market {
                                 assets::mint_test(quote_deposit_maker));
         // Create taker coins.
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<
             GenericAsset, QC>(&user_0, MARKET_ID_GENERIC, @integrator,
@@ -13607,6 +13615,60 @@ module econia::market {
                 MARKET_ID_GENERIC, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, quote_coins,
                 &underwriter_capability);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_GENERIC,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_GENERIC,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_GENERIC,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote: quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[], 0);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert returns.
@@ -13704,6 +13766,14 @@ module econia::market {
                                 assets::mint_test(quote_deposit_maker));
         // Create taker coins.
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<
             GenericAsset, QC>(&user_0, MARKET_ID_GENERIC, @integrator,
@@ -13714,6 +13784,68 @@ module econia::market {
                 MARKET_ID_GENERIC, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, quote_coins,
                 &underwriter_capability);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_GENERIC,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_GENERIC,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_GENERIC,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote: quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_GENERIC,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert returns.
@@ -13811,6 +13943,14 @@ module econia::market {
                                 assets::mint_test(quote_deposit_maker));
         // Create taker coins.
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<
             GenericAsset, QC>(&user_0, MARKET_ID_GENERIC, @integrator,
@@ -13821,6 +13961,68 @@ module econia::market {
                 MARKET_ID_GENERIC, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, quote_coins,
                 &underwriter_capability);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_GENERIC,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_GENERIC,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_GENERIC,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote: HI_64 - quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_GENERIC,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert returns.
@@ -13918,6 +14120,14 @@ module econia::market {
                                 assets::mint_test(quote_deposit_maker));
         // Create taker coins.
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<
             GenericAsset, QC>(&user_0, MARKET_ID_GENERIC, @integrator,
@@ -13928,6 +14138,60 @@ module econia::market {
                 MARKET_ID_GENERIC, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, quote_coins,
                 &underwriter_capability);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_GENERIC,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_GENERIC,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_GENERIC,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[], 0);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert returns.
@@ -14025,6 +14289,14 @@ module econia::market {
                                 assets::mint_test(quote_deposit_maker));
         // Create taker coins.
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<
             GenericAsset, QC>(&user_0, MARKET_ID_GENERIC, @integrator,
@@ -14035,6 +14307,68 @@ module econia::market {
                 MARKET_ID_GENERIC, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, quote_coins,
                 &underwriter_capability);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_GENERIC,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_GENERIC,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_GENERIC, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_GENERIC,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_GENERIC) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_GENERIC,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Drop underwriter capability.
         registry::drop_underwriter_capability_test(underwriter_capability);
         // Assert returns.

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2674,7 +2674,8 @@ module econia::market {
         // and new size.
         user::change_order_size_internal(
             user, market_id, custodian_id, side, order_ref_mut.size, new_size,
-            order_ref_mut.price, order_ref_mut.order_access_key, market_order_id);
+            order_ref_mut.price, order_ref_mut.order_access_key,
+            market_order_id);
         // Get order price.
         let price = avl_queue::get_access_key_insertion_key(avlq_access_key);
         // If size change is for a size decrease or if order is at tail
@@ -12133,7 +12134,8 @@ module econia::market {
         assert!(custodian_id_r == NO_CUSTODIAN, 0);
         // Assert user-side order fields.
         let (market_order_id_r, size_r) = user::get_order_fields_simple_test(
-            @user_0, MARKET_ID_COIN, NO_CUSTODIAN, side_maker, order_access_key);
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN, side_maker,
+            order_access_key);
         assert!(market_order_id_r == market_order_id_0, 0);
         assert!(size_r            == size_maker - size_taker, 0);
         // Assert maker's asset counts.

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -1896,15 +1896,15 @@ module econia::market {
     ///
     /// # Testing
     ///
-    /// * `test_swap_between_coinstores_max_possible_base_buy()`
-    /// * `test_swap_between_coinstores_max_possible_base_sell()`
-    /// * `test_swap_between_coinstores_max_possible_quote_buy()`
-    /// * `test_swap_between_coinstores_max_possible_quote_sell()`
-    /// * `test_swap_between_coinstores_max_quote_traded()`
-    /// * `test_swap_between_coinstores_not_enough_liquidity()`
-    /// * `test_swap_between_coinstores_register_base_store()`
-    /// * `test_swap_between_coinstores_register_quote_store()`
-    /// * `test_swap_between_coinstores_self_match_taker_cancel()`
+    /// * `test_swap_between_coinstores_max_possible_base_buy()` TODO
+    /// * `test_swap_between_coinstores_max_possible_base_sell()` TODO
+    /// * `test_swap_between_coinstores_max_possible_quote_buy()` TODO
+    /// * `test_swap_between_coinstores_max_possible_quote_sell()` TODO
+    /// * `test_swap_between_coinstores_max_quote_traded()` TODO
+    /// * `test_swap_between_coinstores_not_enough_liquidity()` TODO
+    /// * `test_swap_between_coinstores_register_base_store()` TODO
+    /// * `test_swap_between_coinstores_register_quote_store()` TODO
+    /// * `test_swap_between_coinstores_self_match_taker_cancel()` TODO
     public fun swap_between_coinstores<
         BaseType,
         QuoteType
@@ -2073,12 +2073,12 @@ module econia::market {
     ///
     /// # Testing
     ///
-    /// * `test_swap_coins_buy_max_base_limiting()`
-    /// * `test_swap_coins_buy_no_max_quote_limiting()`
-    /// * `test_swap_coins_buy_no_max_base_limiting()`
-    /// * `test_swap_coins_sell_max_quote_limiting()`
-    /// * `test_swap_coins_sell_no_max_base_limiting()`
-    /// * `test_swap_coins_sell_no_max_quote_limiting()`
+    /// * `test_swap_coins_buy_max_base_limiting()` TODO
+    /// * `test_swap_coins_buy_no_max_quote_limiting()` TODO
+    /// * `test_swap_coins_buy_no_max_base_limiting()` TODO
+    /// * `test_swap_coins_sell_max_quote_limiting()` TODO
+    /// * `test_swap_coins_sell_no_max_base_limiting()` TODO
+    /// * `test_swap_coins_sell_no_max_quote_limiting()` TODO
     public fun swap_coins<
         BaseType,
         QuoteType
@@ -2199,11 +2199,11 @@ module econia::market {
     ///
     /// # Testing
     ///
-    /// * `test_swap_generic_buy_base_limiting()`
-    /// * `test_swap_generic_buy_quote_limiting()`
-    /// * `test_swap_generic_sell_max_quote_limiting()`
-    /// * `test_swap_generic_sell_no_max_base_limiting()`
-    /// * `test_swap_generic_sell_no_max_quote_limiting()`
+    /// * `test_swap_generic_buy_base_limiting()` TODO
+    /// * `test_swap_generic_buy_quote_limiting()` TODO
+    /// * `test_swap_generic_sell_max_quote_limiting()` TODO
+    /// * `test_swap_generic_sell_no_max_base_limiting()` TODO
+    /// * `test_swap_generic_sell_no_max_quote_limiting()` TODO
     public fun swap_generic<
         QuoteType
     >(
@@ -2940,18 +2940,18 @@ module econia::market {
     ///
     /// # Expected value testing
     ///
-    /// * `test_match_complete_fill_no_lots_buy()`
-    /// * `test_match_complete_fill_no_ticks_sell()`
-    /// * `test_match_empty()`
-    /// * `test_match_fill_size_0()`
-    /// * `test_match_loop_twice()`
-    /// * `test_match_partial_fill_lot_limited_sell()`
-    /// * `test_match_partial_fill_tick_limited_buy()`
-    /// * `test_match_price_break_buy()`
-    /// * `test_match_price_break_sell()`
-    /// * `test_match_self_match_cancel_both()`
-    /// * `test_match_self_match_cancel_maker()`
-    /// * `test_match_self_match_cancel_taker()`
+    /// * `test_match_complete_fill_no_lots_buy()` TODO
+    /// * `test_match_complete_fill_no_ticks_sell()` TODO
+    /// * `test_match_empty()` TODO
+    /// * `test_match_fill_size_0()` TODO
+    /// * `test_match_loop_twice()` TODO
+    /// * `test_match_partial_fill_lot_limited_sell()` TODO
+    /// * `test_match_partial_fill_tick_limited_buy()` TODO
+    /// * `test_match_price_break_buy()` TODO
+    /// * `test_match_price_break_sell()` TODO
+    /// * `test_match_self_match_cancel_both()` TODO
+    /// * `test_match_self_match_cancel_maker()` TODO
+    /// * `test_match_self_match_cancel_taker()` TODO
     ///
     /// # Failure testing
     ///
@@ -3233,19 +3233,19 @@ module econia::market {
     ///
     /// # Expected value testing
     ///
-    /// * `test_place_limit_order_crosses_ask_exact()`
-    /// * `test_place_limit_order_crosses_ask_partial()`
-    /// * `test_place_limit_order_crosses_ask_partial_cancel()`
-    /// * `test_place_limit_order_crosses_ask_self_match_cancel()`
-    /// * `test_place_limit_order_crosses_bid_exact()`
-    /// * `test_place_limit_order_crosses_bid_partial()`
-    /// * `test_place_limit_order_crosses_bid_partial_post_under_min()`
+    /// * `test_place_limit_order_crosses_ask_exact()` TODO
+    /// * `test_place_limit_order_crosses_ask_partial()` TODO
+    /// * `test_place_limit_order_crosses_ask_partial_cancel()` TODO
+    /// * `test_place_limit_order_crosses_ask_self_match_cancel()` TODO
+    /// * `test_place_limit_order_crosses_bid_exact()` TODO
+    /// * `test_place_limit_order_crosses_bid_partial()` TODO
+    /// * `test_place_limit_order_crosses_bid_partial_post_under_min()` TODO
     /// * `test_place_limit_order_evict()`
-    /// * `test_place_limit_order_no_cross_ask_user()`
-    /// * `test_place_limit_order_no_cross_ask_user_ioc()`
-    /// * `test_place_limit_order_no_cross_bid_custodian()`
-    /// * `test_place_limit_order_still_crosses_ask()`
-    /// * `test_place_limit_order_still_crosses_bid()`
+    /// * `test_place_limit_order_no_cross_ask_user()` TODO
+    /// * `test_place_limit_order_no_cross_ask_user_ioc()` TODO
+    /// * `test_place_limit_order_no_cross_bid_custodian()` TODO
+    /// * `test_place_limit_order_still_crosses_ask()` TODO
+    /// * `test_place_limit_order_still_crosses_bid()` TODO
     ///
     /// # Failure testing
     ///
@@ -3726,11 +3726,11 @@ module econia::market {
     ///
     /// # Expected value testing
     ///
-    /// * `test_place_market_order_max_base_adjust_buy_user()`
-    /// * `test_place_market_order_max_base_buy_user()`
-    /// * `test_place_market_order_max_base_sell_custodian()`
-    /// * `test_place_market_order_max_quote_buy_custodian()`
-    /// * `test_place_market_order_max_quote_sell_user()`
+    /// * `test_place_market_order_max_base_adjust_buy_user()` TODO
+    /// * `test_place_market_order_max_base_buy_user()` TODO
+    /// * `test_place_market_order_max_base_sell_custodian()` TODO
+    /// * `test_place_market_order_max_quote_buy_custodian()` TODO
+    /// * `test_place_market_order_max_quote_sell_user()` TODO
     ///
     /// # Failure testing
     ///
@@ -8522,6 +8522,15 @@ module econia::market {
                                 assets::mint_test(base_deposit));
         user::deposit_coins<QC>(@user_1, MARKET_ID_COIN, NO_CUSTODIAN,
                                 assets::mint_test(quote_deposit));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
         // Place a single order by user 0.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side, size_0, price_0,
@@ -8562,6 +8571,64 @@ module econia::market {
         let (market_order_id_2, _, _, _) = place_limit_order<BC, QC>(
             @user_1, MARKET_ID_COIN, NO_CUSTODIAN, @integrator, side, size_2,
             price_2, restriction, self_match_behavior, critical_height);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side,
+                    size_0,
+                    price_0,
+                    restriction,
+                    self_match_behavior,
+                    size_0,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_1,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side,
+                    size_1,
+                    price_1,
+                    restriction,
+                    self_match_behavior,
+                    size_1,
+                    market_order_id_1
+                ),
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_1,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side,
+                    size_2,
+                    price_2,
+                    restriction,
+                    self_match_behavior,
+                    size_2,
+                    market_order_id_2
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_COIN,
+                    market_order_id_0,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_EVICTION
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
         // Assert order fields for third placed order.
         let (size_r, price_r, user_r, custodian_id_r, order_access_key_2) =
             get_order_fields_test(MARKET_ID_COIN, side, market_order_id_2);

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2733,7 +2733,7 @@ module econia::market {
     ///
     /// * `Option<u8>`: An optional cancel reason, if the order needs
     ///   to be cancelled.
-    /*inline*/ fun get_cancel_reason_option_for_market_order_or_swap(
+    inline fun get_cancel_reason_option_for_market_order_or_swap(
         self_match_taker_cancel: bool,
         base_traded: u64,
         max_base: u64,

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2073,12 +2073,12 @@ module econia::market {
     ///
     /// # Testing
     ///
-    /// * `test_swap_coins_buy_max_base_limiting()` TODO
-    /// * `test_swap_coins_buy_no_max_quote_limiting()` TODO
-    /// * `test_swap_coins_buy_no_max_base_limiting()` TODO
-    /// * `test_swap_coins_sell_max_quote_limiting()` TODO
-    /// * `test_swap_coins_sell_no_max_base_limiting()` TODO
-    /// * `test_swap_coins_sell_no_max_quote_limiting()` TODO
+    /// * `test_swap_coins_buy_max_base_limiting()`
+    /// * `test_swap_coins_buy_no_max_base_limiting()`
+    /// * `test_swap_coins_buy_no_max_quote_limiting()`
+    /// * `test_swap_coins_sell_max_quote_limiting()`
+    /// * `test_swap_coins_sell_no_max_base_limiting()`
+    /// * `test_swap_coins_sell_no_max_quote_limiting()`
     public fun swap_coins<
         BaseType,
         QuoteType
@@ -12548,6 +12548,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -12556,6 +12565,60 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base: HI_64 - base_deposit_taker,
+                    min_quote,
+                    max_quote: quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -12656,6 +12719,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -12664,6 +12736,60 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base: base_taker,
+                    min_quote,
+                    max_quote: quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -12764,6 +12890,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -12772,6 +12907,68 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base,
+                    min_quote,
+                    max_quote: quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_COIN,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -12872,6 +13069,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -12880,6 +13086,68 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base: base_deposit_taker,
+                    min_quote,
+                    max_quote: HI_64 - quote_deposit_taker,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_COIN,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -12980,6 +13248,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -12988,6 +13265,60 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base: base_deposit_taker,
+                    min_quote,
+                    max_quote: max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);
@@ -13087,6 +13418,15 @@ module econia::market {
         // Create taker coins.
         let base_coins  = assets::mint_test<BC>(base_deposit_taker);
         let quote_coins = assets::mint_test<QC>(quote_deposit_taker);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(!exists<SwapperEventHandles>(@user_0), 0);
+        assert!(!exists_market_event_handles(), 0);
         // Place maker order.
         let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
             &user_0, MARKET_ID_COIN, @integrator, side_maker, size_maker,
@@ -13095,6 +13435,68 @@ module econia::market {
             swap_coins<BC, QC>( // Place taker order.
                 MARKET_ID_COIN, @integrator, direction, min_base, max_base,
                 min_quote, max_quote, price, base_coins, quote_coins);
+        let taker_order_id = order_id_no_post(2);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side_maker,
+                    size_maker,
+                    price,
+                    NO_RESTRICTION,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_fill_event_internal(
+                    MARKET_ID_COIN,
+                    size_taker,
+                    price,
+                    side_maker,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    market_order_id_0,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    taker_order_id,
+                    fee,
+                    0
+                )
+            ], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(get_place_swap_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                PlaceSwapOrderEvent{
+                    market_id: MARKET_ID_COIN,
+                    signing_account: NO_TAKER_ADDRESS,
+                    integrator: @integrator,
+                    direction,
+                    min_base,
+                    max_base: base_deposit_taker,
+                    min_quote,
+                    max_quote,
+                    limit_price: price,
+                    order_id: taker_order_id
+                }
+            ], 0);
+        assert!(get_cancel_order_events_market_test(
+            MARKET_ID_COIN) == vector[
+                user::create_cancel_order_event_internal(
+                    MARKET_ID_COIN,
+                    taker_order_id,
+                    NO_TAKER_ADDRESS,
+                    NO_CUSTODIAN,
+                    CANCEL_REASON_MAX_QUOTE_TRADED
+                )
+            ], 0);
         // Assert returns.
         assert!(base_trade_r  == base_taker, 0);
         assert!(quote_trade_r == quote_trade, 0);

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -2835,7 +2835,7 @@ module econia::user {
     /// Emit a `FillEvent` for the market account of the maker
     /// associated with a fill, if market event handles exist for the
     /// indicated market account.
-    inline fun emit_maker_fill_event(
+    /*inline*/ fun emit_maker_fill_event(
         event_ref: &FillEvent
     ) acquires MarketEventHandles {
         let maker = event_ref.maker;

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -3305,6 +3305,35 @@ module econia::user {
         }
     }
 
+    #[test_only]
+    /// Return a `PlaceLimitOrderEvent` with the indicated fields.
+    public fun create_place_limit_order_event_test(
+        market_id: u64,
+        user: address,
+        custodian_id: u64,
+        integrator: address,
+        side: bool,
+        size: u64,
+        price: u64,
+        restriction: u8,
+        self_match_behavior: u8,
+        remaining_size: u64,
+        order_id: u128
+    ): PlaceLimitOrderEvent {
+        PlaceLimitOrderEvent{
+            market_id,
+            user,
+            custodian_id,
+            integrator,
+            side,
+            size,
+            price,
+            restriction,
+            self_match_behavior,
+            remaining_size,
+            order_id
+        }
+    }
 
     #[test_only]
     /// Return `HI_PRICE`, for testing synchronization with

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -3365,6 +3365,30 @@ module econia::user {
     }
 
     #[test_only]
+    /// Return a `PlaceMarketOrderEvent` with the indicated fields.
+    public fun create_place_market_order_event_test(
+        market_id: u64,
+        user: address,
+        custodian_id: u64,
+        integrator: address,
+        direction: bool,
+        size: u64,
+        self_match_behavior: u8,
+        order_id: u128
+    ): PlaceMarketOrderEvent {
+        PlaceMarketOrderEvent{
+            market_id,
+            user,
+            custodian_id,
+            integrator,
+            direction,
+            size,
+            self_match_behavior,
+            order_id
+        }
+    }
+
+    #[test_only]
     /// Return `HI_PRICE`, for testing synchronization with
     /// `market.move`.
     public fun get_HI_PRICE_test(): u64 {HI_PRICE}

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -2864,7 +2864,7 @@ module econia::user {
     /// Emit a `FillEvent` for the market account of the maker
     /// associated with a fill, if market event handles exist for the
     /// indicated market account.
-    /*inline*/ fun emit_maker_fill_event(
+    inline fun emit_maker_fill_event(
         event_ref: &FillEvent
     ) acquires MarketEventHandles {
         let maker = event_ref.maker;

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -95,6 +95,7 @@
 /// * `get_CANCEL_REASON_SELF_MATCH_MAKER()`
 /// * `get_CANCEL_REASON_SELF_MATCH_TAKER()`
 /// * `get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT()`
+/// * `get_CANCEL_REASON_VIOLATED_LIMIT_PRICE()`
 /// * `get_NO_CUSTODIAN()`
 ///
 /// Market account lookup:
@@ -688,6 +689,9 @@ module econia::user {
     /// Swap order cancelled because the remaining base asset amount to
     /// match was too small to fill a single lot.
     const CANCEL_REASON_TOO_SMALL_TO_FILL_LOT: u8 = 8;
+    /// Swap order cancelled because the next order on the book to match
+    /// against violated the swap order limit price.
+    const CANCEL_REASON_VIOLATED_LIMIT_PRICE: u8 = 9;
     /// `u64` bitmask with all bits set, generated in Python via
     /// `hex(int('1' * 64, 2))`.
     const HI_64: u64 = 0xffffffffffffffff;
@@ -802,6 +806,16 @@ module econia::user {
     /// * `test_get_cancel_reasons()`
     public fun get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT(): u8 {
         CANCEL_REASON_TOO_SMALL_TO_FILL_LOT
+    }
+
+    #[view]
+    /// Public constant getter for `CANCEL_REASON_VIOLATED_LIMIT_PRICE`.
+    ///
+    /// # Testing
+    ///
+    /// * `test_get_cancel_reasons()`
+    public fun get_CANCEL_REASON_VIOLATED_LIMIT_PRICE(): u8 {
+        CANCEL_REASON_VIOLATED_LIMIT_PRICE
     }
 
     #[view]
@@ -4695,6 +4709,8 @@ module econia::user {
                     CANCEL_REASON_SELF_MATCH_TAKER, 0);
         assert!(get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT() ==
                     CANCEL_REASON_TOO_SMALL_TO_FILL_LOT, 0);
+        assert!(get_CANCEL_REASON_VIOLATED_LIMIT_PRICE() ==
+                    CANCEL_REASON_VIOLATED_LIMIT_PRICE, 0);
     }
 
     #[test]

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -3273,7 +3273,7 @@ module econia::user {
 
     #[test_only]
     /// Immutably borrow market event handles for a market account.
-    inline fun borrow_market_event_handles_for_market_account(
+    inline fun borrow_market_event_handles_for_market_account_test(
         market_id: u64,
         user: address,
         custodian_id: u64
@@ -3284,6 +3284,27 @@ module econia::user {
         let market_account_id = get_market_account_id(market_id, custodian_id);
         table::borrow(market_event_handles_map_ref, market_account_id)
     }
+
+    #[test_only]
+    /// Return a `ChangeOrderSizeEvent` with the indicated fields.
+    public fun create_change_order_size_event_test(
+        market_id: u64,
+        order_id: u128,
+        user: address,
+        custodian_id: u64,
+        side: bool,
+        new_size: u64
+    ): ChangeOrderSizeEvent {
+        ChangeOrderSizeEvent{
+            market_id,
+            order_id,
+            user,
+            custodian_id,
+            side,
+            new_size
+        }
+    }
+
 
     #[test_only]
     /// Return `HI_PRICE`, for testing synchronization with
@@ -3297,28 +3318,28 @@ module econia::user {
 
     #[test_only]
     /// Get `CancelOrderEvent`s at a market account handle.
-    public fun get_cancel_order_events(
+    public fun get_cancel_order_events_test(
         market_id: u64,
         user: address,
         custodian_id: u64
     ): vector<CancelOrderEvent>
     acquires MarketEventHandles {
         event::emitted_events(
-            &(borrow_market_event_handles_for_market_account(
+            &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 cancel_order_events))
     }
 
     #[test_only]
     /// Get `ChangeOrderSizeEvent`s at a market account handle.
-    public fun get_change_order_size_events(
+    public fun get_change_order_size_events_test(
         market_id: u64,
         user: address,
         custodian_id: u64
     ): vector<ChangeOrderSizeEvent>
     acquires MarketEventHandles {
         event::emitted_events(
-            &(borrow_market_event_handles_for_market_account(
+            &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 change_order_size_events))
     }
@@ -3357,14 +3378,14 @@ module econia::user {
 
     #[test_only]
     /// Get `FillEvent`s at a market account handle.
-    public fun get_fill_events(
+    public fun get_fill_events_test(
         market_id: u64,
         user: address,
         custodian_id: u64
     ): vector<FillEvent>
     acquires MarketEventHandles {
         event::emitted_events(
-            &(borrow_market_event_handles_for_market_account(
+            &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 fill_events))
     }
@@ -3449,28 +3470,28 @@ module econia::user {
 
     #[test_only]
     /// Get `PlaceLimitOrderEvent`s at a market account handle.
-    public fun get_place_limit_order_events(
+    public fun get_place_limit_order_events_test(
         market_id: u64,
         user: address,
         custodian_id: u64
     ): vector<PlaceLimitOrderEvent>
     acquires MarketEventHandles {
         event::emitted_events(
-            &(borrow_market_event_handles_for_market_account(
+            &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 place_limit_order_events))
     }
 
     #[test_only]
     /// Get `PlaceMarketOrderEvent`s at a market account handle.
-    public fun get_place_market_order_events(
+    public fun get_place_market_order_events_test(
         market_id: u64,
         user: address,
         custodian_id: u64
     ): vector<PlaceMarketOrderEvent>
     acquires MarketEventHandles {
         event::emitted_events(
-            &(borrow_market_event_handles_for_market_account(
+            &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 place_market_order_events))
     }

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -4537,8 +4537,8 @@ module econia::user {
         // Fill order, storing base and quote coins for matching engine.
         (optional_base_coins, quote_coins, _) = fill_order_internal<BC, QC>(
                 @user, MARKET_ID_PURE_COIN, CUSTODIAN_ID, side, access_key,
-                size + 1, size, complete_fill, optional_base_coins, quote_coins,
-                base_fill, quote_fill);
+                size + 1, size, complete_fill, optional_base_coins,
+                quote_coins, base_fill, quote_fill);
         // Destroy external coins.
         assets::burn(option::destroy_some(optional_base_coins));
         assets::burn(quote_coins);

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -94,6 +94,7 @@
 /// * `get_CANCEL_REASON_NOT_ENOUGH_LIQUIDITY()`
 /// * `get_CANCEL_REASON_SELF_MATCH_MAKER()`
 /// * `get_CANCEL_REASON_SELF_MATCH_TAKER()`
+/// * `get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT()`
 /// * `get_NO_CUSTODIAN()`
 ///
 /// Market account lookup:
@@ -684,6 +685,9 @@ module econia::user {
     /// market account memory because it will be subsequently re-placed
     /// as part of a size change.
     const CANCEL_REASON_SIZE_CHANGE_INTERNAL: u8 = 0;
+    /// Swap order cancelled because the remaining base asset amount to
+    /// match was too small to fill a single lot.
+    const CANCEL_REASON_TOO_SMALL_TO_FILL_LOT: u8 = 8;
     /// `u64` bitmask with all bits set, generated in Python via
     /// `hex(int('1' * 64, 2))`.
     const HI_64: u64 = 0xffffffffffffffff;
@@ -787,6 +791,17 @@ module econia::user {
     /// * `test_get_cancel_reasons()`
     public fun get_CANCEL_REASON_SELF_MATCH_TAKER(): u8 {
         CANCEL_REASON_SELF_MATCH_TAKER
+    }
+
+    #[view]
+    /// Public constant getter for
+    /// `CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`.
+    ///
+    /// # Testing
+    ///
+    /// * `test_get_cancel_reasons()`
+    public fun get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT(): u8 {
+        CANCEL_REASON_TOO_SMALL_TO_FILL_LOT
     }
 
     #[view]
@@ -4678,6 +4693,8 @@ module econia::user {
                     CANCEL_REASON_SELF_MATCH_MAKER, 0);
         assert!(get_CANCEL_REASON_SELF_MATCH_TAKER() ==
                     CANCEL_REASON_SELF_MATCH_TAKER, 0);
+        assert!(get_CANCEL_REASON_TOO_SMALL_TO_FILL_LOT() ==
+                    CANCEL_REASON_TOO_SMALL_TO_FILL_LOT, 0);
     }
 
     #[test]

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -3272,9 +3272,56 @@ module econia::user {
     // Test-only functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
     #[test_only]
+    /// Immutably borrow market event handles for a market account.
+    inline fun borrow_market_event_handles_for_market_account(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): &MarketEventHandlesForMarketAccount
+    acquires MarketEventHandles {
+        let market_event_handles_map_ref =
+            &borrow_global<MarketEventHandles>(user).map;
+        let market_account_id = get_market_account_id(market_id, custodian_id);
+        table::borrow(market_event_handles_map_ref, market_account_id)
+    }
+
+    #[test_only]
     /// Return `HI_PRICE`, for testing synchronization with
     /// `market.move`.
     public fun get_HI_PRICE_test(): u64 {HI_PRICE}
+
+    #[test_only]
+    /// Return `NO_UNDERWRITER`, for testing synchronization with
+    /// `market.move`.
+    public fun get_NO_UNDERWRITER_test(): u64 {NO_UNDERWRITER}
+
+    #[test_only]
+    /// Get `CancelOrderEvent`s at a market account handle.
+    public fun get_cancel_order_events(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): vector<CancelOrderEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market_account(
+                market_id, user, custodian_id).
+                cancel_order_events))
+    }
+
+    #[test_only]
+    /// Get `ChangeOrderSizeEvent`s at a market account handle.
+    public fun get_change_order_size_events(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): vector<ChangeOrderSizeEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market_account(
+                market_id, user, custodian_id).
+                change_order_size_events))
+    }
 
     #[test_only]
     /// Like `get_collateral_value_test()`, but accepts market id and
@@ -3306,6 +3353,20 @@ module econia::user {
         let coin_ref = // Immutably borrow coin collateral.
             tablist::borrow(collateral_map_ref, market_account_id);
         coin::value(coin_ref) // Return coin value.
+    }
+
+    #[test_only]
+    /// Get `FillEvent`s at a market account handle.
+    public fun get_fill_events(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): vector<FillEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market_account(
+                market_id, user, custodian_id).
+                fill_events))
     }
 
     #[test_only]
@@ -3342,11 +3403,6 @@ module econia::user {
             user_address, market_account_id, side, order_access_key);
         next // Return next inactive order access key.
     }
-
-    #[test_only]
-    /// Return `NO_UNDERWRITER`, for testing synchronization with
-    /// `market.move`.
-    public fun get_NO_UNDERWRITER_test(): u64 {NO_UNDERWRITER}
 
     #[test_only]
     /// Wrapper for `get_order_fields_test()`, accepting market ID and
@@ -3389,6 +3445,34 @@ module econia::user {
         let order_ref = tablist::borrow(orders_ref, order_access_key);
         // Return order fields.
         (order_ref.market_order_id, order_ref.size)
+    }
+
+    #[test_only]
+    /// Get `PlaceLimitOrderEvent`s at a market account handle.
+    public fun get_place_limit_order_events(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): vector<PlaceLimitOrderEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market_account(
+                market_id, user, custodian_id).
+                place_limit_order_events))
+    }
+
+    #[test_only]
+    /// Get `PlaceMarketOrderEvent`s at a market account handle.
+    public fun get_place_market_order_events(
+        market_id: u64,
+        user: address,
+        custodian_id: u64
+    ): vector<PlaceMarketOrderEvent>
+    acquires MarketEventHandles {
+        event::emitted_events(
+            &(borrow_market_event_handles_for_market_account(
+                market_id, user, custodian_id).
+                place_market_order_events))
     }
 
     #[test_only]


### PR DESCRIPTION
# Background

#321 and several associated follow up PRs added comprehensive event emissions for market events like `PlaceLimitOrderEvent`. At the time, however, event emissions could not verified using the Move unit testing framework, and several minor issues were uncovered through discussions/manual testing:

* #347
* #360

Aptos Labs recently enabled unit testing of events in Move via https://github.com/aptos-labs/aptos-core/pull/9181, and as such this PR updates the Move unit testing suite to test event emissions.

# Methodology

Before this PR, Move code was already tested to 100% coverage, and as such this PR simply adds event assert statements to the existing coverage suite where applicable. Notably, this includes all non-expected-failure tests listed under the doc comments for:

* `market::match()`
* `market::place_limit_order()`
* `market::place_market_order()`,
* `market::swap_between_coinstores()`
* `market::swap_coins()`
* `market::swap_generic()`

Auxiliary event scenarios are also validated for manual order size changes and manual order cancellations, as well as registry events.

# Gaps addressed

The two issues listed under [background](#background) are now tested for and would have been quickly caught if event testing had been available at the time of submission of #321. Two additional edge cases were discovered during testing for this PR, both of which are cancel reasons that only apply to swaps. All applicable cancel reasons for all scenarios (limit order, market order, swap, manual cancel, eviction, self match maker and taker cancel) are now tested. The cancel reason logic and associated documentation is included in this PR per:

* `CANCEL_REASON_TOO_SMALL_TO_FILL_LOT`: https://github.com/econia-labs/econia/pull/366/commits/dd968e97400c4bb41ad556aca35d59f90dfa3973
* `CANCEL_REASON_VIOLATED_LIMIT_PRICE`: https://github.com/econia-labs/econia/pull/366/commits/a894fdb35be649a8a4e2b5dbc2cb3b6faf85c95f

