### PR TITLE
[ECO-270] Change README for docs-site

### DIFF
--- a/doc/doc-site/README.md
+++ b/doc/doc-site/README.md
@@ -6,40 +6,32 @@ Econia's docs are built using [Docusaurus].
 
 1. Install [Homebrew] or a similar package manager.
 
-1. Install [Yarn]:
+2. Install [pnpm]:
 
    ```zsh
 
-   brew install yarn
+   wget -qO- https://get.pnpm.io/install.sh | sh -
 
    ```
 
-1. Install the docs site package dependencies:
+3. Install the docs site package dependencies:
 
    ```zsh
 
-   yarn
+   pnpm install
 
    ```
 
-1. To build locally:
+4. To serve a local site preview:
 
    ```zsh
 
-   yarn build
+   pnpm start
 
    ```
 
-1. To serve a local site preview:
-
-   ```zsh
-
-   yarn start
-
-   ```
-
-1. Open http://localhost:3000
+5. Open http://localhost:3000
 
 [docusaurus]: https://docusaurus.io/
 [homebrew]: https://brew.sh
-[yarn]: https://yarnpkg.com/
+[pnpm]: https://pnpm.io/

--- a/doc/doc-site/README.md
+++ b/doc/doc-site/README.md
@@ -10,7 +10,7 @@ Econia's docs are built using [Docusaurus].
 
    ```zsh
 
-   wget -qO- https://get.pnpm.io/install.sh | sh -
+   brew install pnpm
 
    ```
 


### PR DESCRIPTION
They are currently using yarn and should be using pnpm. In addition, the corrected steps for running should be:

pnpm install

pnpm start