### PR TITLE
[ECO-272] Add the new constant to the enum

### DIFF
--- a/src/python/sdk/econia_sdk/types.py
+++ b/src/python/sdk/econia_sdk/types.py
@@ -33,4 +33,5 @@ class CancelReason(IntEnum):
     NotEnoughLiquidity = 5
     SelfMatchMaker = 6
     SelfMatchTaker = 7
+    TooSmallToFitLot = 8
     ViolatedLimitPrice = 9

--- a/src/python/sdk/econia_sdk/types.py
+++ b/src/python/sdk/econia_sdk/types.py
@@ -33,5 +33,5 @@ class CancelReason(IntEnum):
     NotEnoughLiquidity = 5
     SelfMatchMaker = 6
     SelfMatchTaker = 7
-    TooSmallToFitLot = 8
+    TooSmallToFillLot = 8
     ViolatedLimitPrice = 9

--- a/src/python/sdk/econia_sdk/types.py
+++ b/src/python/sdk/econia_sdk/types.py
@@ -33,3 +33,4 @@ class CancelReason(IntEnum):
     NotEnoughLiquidity = 5
     SelfMatchMaker = 6
     SelfMatchTaker = 7
+    ViolatedLimitPrice = 9


### PR DESCRIPTION
This constant is being added soon. Let's add it in parallel. We're missing `8` because I believe it's no longer in use.