### PR TITLE
ECO-133: Add sorting to orders table, overflow when order rows do not fit

### DIFF
--- a/src/typescript/frontend/src/components/trade/OrdersTable.tsx
+++ b/src/typescript/frontend/src/components/trade/OrdersTable.tsx
@@ -1,4 +1,5 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 import { useQuery } from "@tanstack/react-query";
 import {
   createColumnHelper,
@@ -9,13 +10,11 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import { type ApiMarket, type ApiOrder } from "@/types/api";
 
 import { ConnectedButton } from "../ConnectedButton";
-
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 
 type TableOrder = ApiOrder & { total: number };
 
@@ -68,22 +67,15 @@ export const OrdersTable: React.FC<{
   }, [allMarketData]);
 
   const sortLabel = useMemo(() => {
-    const map = new Map<
-      SortDirection | false,
-      string | null | React.JSX.Element // ok for some weird reason `Element` seems to point to a different type
-    >();
+    const map = new Map<SortDirection | false, ReactNode>();
     map.set(false, null);
     map.set(
       "asc",
-      <ChevronUpIcon
-        className={"absolute top-0 inline-block h-4 w-4 translate-y-1/2"}
-      />,
+      <ChevronUpIcon className="absolute top-0 ml-0.5 inline-block h-4 w-4 translate-y-1/2" />,
     );
     map.set(
       "desc",
-      <ChevronDownIcon
-        className={"absolute top-0 inline-block h-4 w-4 translate-y-1/2"}
-      />,
+      <ChevronDownIcon className="absolute top-0 ml-0.5 inline-block h-4 w-4 translate-y-1/2" />,
     );
     return map;
   }, []);

--- a/src/typescript/frontend/src/components/trade/OrdersTable.tsx
+++ b/src/typescript/frontend/src/components/trade/OrdersTable.tsx
@@ -15,6 +15,8 @@ import { type ApiMarket, type ApiOrder } from "@/types/api";
 
 import { ConnectedButton } from "../ConnectedButton";
 
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
+
 type TableOrder = ApiOrder & { total: number };
 
 const columnHelper = createColumnHelper<TableOrder>();
@@ -66,10 +68,16 @@ export const OrdersTable: React.FC<{
   }, [allMarketData]);
 
   const sortLabel = useMemo(() => {
-    const map = new Map<SortDirection | false, string | null>();
+    const map = new Map<
+      SortDirection | false,
+      string | null | React.JSX.Element // ok for some weird reason `Element` seems to point to a different type
+    >();
     map.set(false, null);
-    map.set("asc", " ▲");
-    map.set("desc", " ▼");
+    map.set("asc", <ChevronUpIcon className={"ml-1 inline-block h-4 w-4"} />);
+    map.set(
+      "desc",
+      <ChevronDownIcon className={"ml-1 inline-block h-4 w-4"} />,
+    );
     return map;
   }, []);
 

--- a/src/typescript/frontend/src/components/trade/OrdersTable.tsx
+++ b/src/typescript/frontend/src/components/trade/OrdersTable.tsx
@@ -73,10 +73,17 @@ export const OrdersTable: React.FC<{
       string | null | React.JSX.Element // ok for some weird reason `Element` seems to point to a different type
     >();
     map.set(false, null);
-    map.set("asc", <ChevronUpIcon className={"ml-1 inline-block h-4 w-4"} />);
+    map.set(
+      "asc",
+      <ChevronUpIcon
+        className={"absolute top-0 inline-block h-4 w-4 translate-y-1/2"}
+      />,
+    );
     map.set(
       "desc",
-      <ChevronDownIcon className={"ml-1 inline-block h-4 w-4"} />,
+      <ChevronDownIcon
+        className={"absolute top-0 inline-block h-4 w-4 translate-y-1/2"}
+      />,
     );
     return map;
   }, []);

--- a/src/typescript/frontend/src/components/trade/OrdersTable.tsx
+++ b/src/typescript/frontend/src/components/trade/OrdersTable.tsx
@@ -155,10 +155,8 @@ export const OrdersTable: React.FC<{
       <table
         className={"w-full table-auto" + (className ? ` ${className}` : "")}
       >
-        <thead className="sticky top-0 h-8 bg-black">
-          {/* These classes create a pseudoelement at the bottom of the table
-              header for a border that does not scroll with the table body. */}
-          <tr className="after:absolute after:bottom-[-1px] after:left-0 after:w-full after:border-b after:border-neutral-600 after:content-['']">
+        <thead className="sticky top-0 h-8 bg-black shadow-[inset_0_-1px_0_theme(colors.neutral.600)]">
+          <tr>
             {table.getFlatHeaders().map((header) => (
               <th
                 className="cursor-pointer select-none py-0.5 text-left font-roboto-mono text-sm font-light uppercase text-neutral-500"

--- a/src/typescript/frontend/src/components/trade/OrdersTable.tsx
+++ b/src/typescript/frontend/src/components/trade/OrdersTable.tsx
@@ -4,145 +4,173 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getSortedRowModel,
+  type SortDirection,
+  type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import React from "react";
+import { useMemo, useState } from "react";
 
 import { type ApiMarket, type ApiOrder } from "@/types/api";
 
 import { ConnectedButton } from "../ConnectedButton";
 
-const columnHelper = createColumnHelper<ApiOrder>();
+type TableOrder = ApiOrder & { total: number };
+
+const columnHelper = createColumnHelper<TableOrder>();
 
 export const OrdersTable: React.FC<{
   className?: string;
   allMarketData: ApiMarket[];
 }> = ({ className, allMarketData }) => {
   const { connected, account } = useWallet();
-  const { data, isLoading } = useQuery<ApiOrder[]>(
+
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const { data, isLoading } = useQuery<TableOrder[]>(
     ["useUserOrders", account?.address],
     async () => {
       if (!account) return [];
-      return [
-        {
-          market_order_id: 0,
-          market_id: 1,
-          side: "bid",
-          size: 1000,
-          price: 1000,
-          user_address: "0x1",
-          custodian_id: null,
-          order_state: "open",
-          created_at: "2023-05-01T12:34:56.789012Z",
-        },
-        {
-          market_order_id: 1,
-          market_id: 1,
-          side: "ask",
-          size: 1000,
-          price: 2000,
-          user_address: "0x1",
-          custodian_id: null,
-          order_state: "open",
-          created_at: "2023-05-01T12:34:56.789012Z",
-        },
-      ] as ApiOrder[];
+      const apiOrders: ApiOrder[] = [...Array(20).keys()].map((i) => ({
+        market_order_id: i,
+        market_id: 1,
+        side: i % 2 === 0 ? "bid" : "ask",
+        size: (i + 1) * 10,
+        price: (i + 1) * 100,
+        user_address: "0x1",
+        custodian_id: null,
+        order_state: "open",
+        created_at: new Date(
+          new Date("2023-05-01T12:34:56.789012Z").getTime() +
+            (i + 1) * 86400000,
+        ).toISOString(),
+      }));
+      const orders: TableOrder[] = apiOrders.map((order) => ({
+        ...order,
+        total: order.price * order.size,
+      }));
+      return orders;
       // TODO: Need working API
       // return await fetch(
       //   `${API_URL}/account/${account.address.toString()}/open-orders`
       // ).then((res) => res.json());
     },
   );
-  const marketById = React.useMemo(() => {
+
+  const marketById = useMemo(() => {
     const map = new Map<number, ApiMarket>();
-    for (const market of allMarketData) map.set(market.market_id, market);
+    for (const market of allMarketData) {
+      map.set(market.market_id, market);
+    }
     return map;
   }, [allMarketData]);
-  const table = useReactTable({
-    columns: [
+
+  const sortLabel = useMemo(() => {
+    const map = new Map<SortDirection | false, string | null>();
+    map.set(false, null);
+    map.set("asc", " ▲");
+    map.set("desc", " ▼");
+    return map;
+  }, []);
+
+  const columns = useMemo(
+    () => [
       columnHelper.accessor("created_at", {
-        cell: (info) =>
-          new Date(info.getValue()).toLocaleString("en-US", {
-            month: "numeric",
-            day: "2-digit",
-            year: "2-digit",
-            hour: "numeric",
-            minute: "numeric",
-            second: "numeric",
-            hour12: true,
-          }),
-        header: "TIME PLACED",
+        header: () => <span className="pl-4">Time Placed</span>,
+        cell: (info) => (
+          <span className="pl-4 text-neutral-500">
+            {new Date(info.getValue()).toLocaleString("en-US", {
+              month: "numeric",
+              day: "2-digit",
+              year: "2-digit",
+              hour: "numeric",
+              minute: "numeric",
+              second: "numeric",
+              hour12: true,
+            })}
+          </span>
+        ),
       }),
       columnHelper.display({
+        header: "Type",
         cell: () => "LIMIT",
-        header: "TYPE",
       }),
       columnHelper.accessor("side", {
         cell: (info) => info.getValue().toUpperCase(),
-        header: "SIDE",
       }),
       columnHelper.accessor("price", {
         cell: (info) =>
           `${info.getValue()} ${
-            marketById.get(info.row.original.market_id)?.quote.symbol
+            marketById.get(info.row.original.market_id)?.quote.symbol ?? ""
           }`,
-        header: "PRICE",
       }),
       columnHelper.accessor("size", {
-        cell: (info) => {
-          const marketId = info.row.original.market_id;
-          return `${info.getValue()} ${
-            marketById.get(marketId)?.base?.symbol ?? ""
-          }`;
-        },
-        header: "AMOUNT",
+        cell: (info) =>
+          `${info.getValue()} ${
+            marketById.get(info.row.original.market_id)?.base?.symbol ?? ""
+          }`,
       }),
-      columnHelper.display({
+      columnHelper.accessor("total", {
         cell: (info) => {
-          const { price, size, market_id } = info.row.original;
-          return `${price * size} ${
-            marketById.get(market_id)?.quote?.symbol ?? ""
-          }`;
+          const total = info.getValue();
+          const { market_id } = info.row.original;
+          return `${total} ${marketById.get(market_id)?.quote?.symbol ?? ""}`;
         },
-        header: "TOTAL",
       }),
       columnHelper.accessor("order_state", {
-        cell: (info) => info.getValue().toUpperCase(),
-        header: "STATUS",
+        header: "Status",
+        cell: (info) => {
+          const value = info.getValue();
+          if (value === "open") {
+            return <span className="text-green">{value.toUpperCase()}</span>;
+          }
+          // TODO colors for other order statuses?
+          return value.toUpperCase();
+        },
       }),
     ],
+    [marketById],
+  );
+
+  const table = useReactTable({
     data: data || [],
+    columns,
+    state: {
+      sorting,
+    },
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
   return (
-    <div className="h-[200px]">
-      <table className={"w-full" + (className ? ` ${className}` : "")}>
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr
-              className="text-left font-roboto-mono text-sm text-neutral-500 [&>th]:font-light"
-              key={headerGroup.id}
-            >
-              {headerGroup.headers.map((header, i) => (
-                <th className={i === 0 ? "pl-4 text-left" : ""} key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          <tr>
-            <td colSpan={7} className="py-2">
-              <div className="h-[1px] bg-neutral-600"></div>
-            </td>
+    <div className="scrollbar-none h-[200px] overflow-y-auto">
+      <table
+        className={"w-full table-auto" + (className ? ` ${className}` : "")}
+      >
+        <thead className="sticky top-0 h-8 bg-black">
+          {/* These classes create a pseudoelement at the bottom of the table
+              header for a border that does not scroll with the table body. */}
+          <tr className="after:absolute after:bottom-[-1px] after:left-0 after:w-full after:border-b after:border-neutral-600 after:content-['']">
+            {table.getFlatHeaders().map((header) => (
+              <th
+                className="cursor-pointer select-none py-0.5 text-left font-roboto-mono text-sm font-light uppercase text-neutral-500"
+                key={header.id}
+                onClick={header.column.getToggleSortingHandler()}
+              >
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                {sortLabel.get(header.column.getIsSorted())}
+              </th>
+            ))}
           </tr>
+        </thead>
+
+        <tbody className="h-[160px] w-full overflow-y-auto">
           {isLoading || !data ? (
             <tr>
               <td colSpan={7}>
@@ -169,19 +197,10 @@ export const OrdersTable: React.FC<{
             </tr>
           ) : (
             table.getRowModel().rows.map((row) => (
-              <tr
-                className="text-left font-roboto-mono text-sm text-white [&>th]:font-light"
-                key={row.id}
-              >
-                {row.getVisibleCells().map((cell, i) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
                   <td
-                    className={
-                      i === 0
-                        ? "pl-4 text-left text-neutral-500"
-                        : i === 6
-                        ? `${cell.getValue() === "open" ? "text-green" : ""}`
-                        : ""
-                    }
+                    className="h-7 py-0.5 text-left font-roboto-mono text-sm font-light text-white"
                     key={cell.id}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -316,7 +316,10 @@ export default function Market({ allMarketData, marketData }: Props) {
               </div>
             </div>
             <div className="border border-neutral-600">
-              <p className="my-3 ml-4 font-jost font-bold text-white">Orders</p>
+              <div className="bg-black py-3 pl-4">
+                <p className="font-jost font-bold text-white">Orders</p>
+              </div>
+
               <OrdersTable allMarketData={allMarketData} />
             </div>
           </div>


### PR DESCRIPTION
Adds
- Sorting by column when clicking header of orders table
- Overflow on y-axis when there are too many order rows to fit inside the table height

Notes
- It seems like there are no easy solutions for adding a border on the bottom of the table header that does not scroll with the body? I ended up adding a pseudoelement on the `<tr>` element inside `<thead>`, but open to suggestions for better solutions
- Need some icons for sorting direction indicators. I've put in some unicode characters as placeholders, but this shouldn't be the final version
- Should order statuses other than "open" be color coded? Figma only shows this variant.