### PR TITLE
Use ^3.7 which is the Python version for the aptos-sdk

### DIFF
--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "econia_sdk" }]
 
 [tool.poetry.dependencies]
 aptos-sdk = "^0.5.1"
-python = "^3.11"
+python = "^3.7"
 
 [tool.poetry.scripts]
 trade = "examples.trade:start"


### PR DESCRIPTION
Right now the version of the Python SDK is too high. Let's lower it to the lowest reasonable version.