### PR TITLE
ECO-144: frontend toast when tx fail

### DIFF
--- a/src/typescript/frontend/src/contexts/AptosContext.tsx
+++ b/src/typescript/frontend/src/contexts/AptosContext.tsx
@@ -54,10 +54,16 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
           }),
         };
       }
+
       const res = await aptosSignAndSubmitTransaction(transaction, options);
-      await aptosClient.waitForTransaction(res.hash, { checkSuccess: true });
-      toast.success("Transaction confirmed");
-      return res;
+      // taken from https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-react#signandsubmittransactionpayload
+      try {
+        await aptosClient.waitForTransaction(res?.hash || "");
+        toast.success("Transaction confirmed");
+      } catch (error) {
+        toast.error("Transaction failed");
+        console.error(error);
+      }
     },
     [aptosSignAndSubmitTransaction, aptosClient],
   );


### PR DESCRIPTION
did some snooping their codebase and didn't find any references for the option `checkSuccess` (though it does show up in intellisense as a type).
Regardless, they had an example for error handling that I ported over
https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-react#signandsubmittransactionpayload