### PR TITLE
Remove get_CANCEL_REASON_TOO_SMALL_AFTER_MATCHING

### DIFF
--- a/src/python/sdk/econia_sdk/view/user.py
+++ b/src/python/sdk/econia_sdk/view/user.py
@@ -51,13 +51,6 @@ def get_CANCEL_REASON_SELF_MATCH_TAKER(view: EconiaViewer) -> int:
     return int(returns[0])
 
 
-def get_CANCEL_REASON_TOO_SMALL_AFTER_MATCHING(view: EconiaViewer) -> int:
-    returns = view.get_returns(
-        "user", "get_CANCEL_REASON_TOO_SMALL_AFTER_MATCHING"
-    )
-    return int(returns[0])
-
-
 def get_market_event_handle_creation_numbers(
     view: EconiaViewer,
     user: AccountAddress,


### PR DESCRIPTION
This getter doesn't appear to exist in the `user` module, so let's remove it from the SDK. This is used elsewhere in our codebase so I'm not sure how it got in, must have been an old version of a diff that got revised.

Link to constant getters:
https://github.com/econia-labs/econia/blob/main/src/move/econia/sources/user.move#L86-L97