### PR TITLE
[ECO-280] Create cspell dictionary and add words to dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2",
+    "ignorePaths": [],
+    "dictionaryDefinitions": [],
+    "dictionaries": [],
+    "words": [
+        "aptos",
+        "econia"
+    ],
+    "ignoreWords": [],
+    "import": []
+}


### PR DESCRIPTION
Both Aptos and Econia appear often in our texts, but are detected as error words by cspell CLI. Let's fix that.