### PR TITLE
[ECO-279] Develop decimal guidance

### DIFF
--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -71,11 +71,11 @@ python3
 
 Market configuration (beyond base type and quote type) consists of 3 integer values: lot size, tick size, and min size.
 
-| value | units | description |
-| -- | -- | -- |
-| lot size | subunits of base type | the granularity of base sizes |
+| value     | units                  | description                    |
+| --------- | ---------------------- | ------------------------------ |
+| lot size  | subunits of base type  | the granularity of base sizes  |
 | tick size | subunits of quote type | the granularity of quote sizes |
-| min size | number of lots | the minimum limit order size |
+| min size  | number of lots         | the minimum limit order size   |
 
 In order to proceed, we must decide the granularity of base and quote sizes as well as the minimum limit order size for our market.
 Consider that "price" in the exchange is an integer expressed in terms of "ticks per lot", which means that tick size and lot size affect the prices that can be expressed.
@@ -104,7 +104,7 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
 The granularity of price in human terms is \$10 per `eAPT`.
-That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
+That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is \$20/`eAPT`, and so on.
 Given that (real) `APT` is right now \$7, we can assess that this configuration would not be workable or appropriate!
 
 The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
@@ -142,11 +142,11 @@ Let's say orders can only be submitted if they are for at least 1 whole `eAPT`, 
 
 That means we use use a minimum size of 1000 lots to configure our market, so our market parameters would be:
 
-| parameter | value | units |
-| -- | -- | -- |
-| Lot size | 100000 | Subunits of base |
-| Tick size | 10 | Subunits of quote |
-| Min size | 1000 | Lots of base |
+| parameter | value  | units             |
+| --------- | ------ | ----------------- |
+| Lot size  | 100000 | Subunits of base  |
+| Tick size | 10     | Subunits of quote |
+| Min size  | 1000   | Lots of base      |
 
 This gives us a market with a price granularity of 1 cent and minimum order size of 1 `eAPT`!
 Can you see how one would get a price granularity of 0.1 cents instead?

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -95,7 +95,7 @@ Does this work?
 Let's find out!
 
 ```
->>> get_min_quote_per_base("0.001", 0.01)
+>>> get_min_quote_per_base_nominal("0.001", "0.01")
 10.0
 ```
 
@@ -103,36 +103,40 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
-The granularity of price in human terms is $10 per `eAPT`.
-That is, the minimum price is $10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
-Given that (real) `APT` is right now $7, we can assess that this configuration would not be workable or appropriate!
+The granularity of price in human terms is \$10 per `eAPT`.
+That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
+Given that (real) `APT` is right now \$7, we can assess that this configuration would not be workable or appropriate!
 
 The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
 Checking our price granularity now shows better results:
 
 ```
->>> get_min_quote_per_base("0.001", 0.00001)
+>>> get_min_quote_per_base_nominal("0.001", "0.00001")
 0.01
+>>> get_max_quote_per_base_nominal("0.001", "0.00001")
+42949672.95
 ```
 
-That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is $1.
-Now that we have the minimum base and quote size decimals we'd like to use, we're ready to configure the market.
+That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is \$1.
+For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's \$42,949,672.95 per `eAPT` so this is fine!
+Be careful: using a more granular price results in a lower maximum price, which may be relevant in some cases.
+Now that we have the minimum base and quote sizes we'd like to use, we're ready to configure the market.
 Let's get the lot size and tick size:
 
 ```
->>> lot_size = get_lot_size("0.001", base_decimals)
+>>> lot_size = get_lot_size_integer("0.001", base_decimals)
 >>> lot_size
 100000
->>> tick_size = get_tick_size("0.00001", quote_decimals)
+>>> tick_size = get_tick_size_integer("0.00001", quote_decimals)
 >>> tick_size
 10
 ```
 
-We also need a minimum size.
+We also need a minimum (limit order) size.
 Let's say orders can only be submitted if they are for at least 1 whole `eAPT`, using the lot size of 100000 from above:
 
 ```
->>> get_min_size("1.0", base_decimals, lot_size)
+>>> get_min_size_integer("1.0", base_decimals, lot_size)
 1000
 ```
 

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -90,12 +90,12 @@ We know that `eAPT` (the base type) has 8 decimals and `eUSDC` (the quote type) 
 ```
 
 We'd like to be able to express small prices with high granularity.
-Let's try using 0.001 eAPT for the granularity of base coin sizes, and 0.01 eUSDC (one penny) for the granularity of quote coin sizes.
+Let's try using 0.001 `eAPT` for the granularity of base coin sizes, and 0.01 `eUSDC` (one penny) for the granularity of quote coin sizes.
 Does this work?
 Let's find out!
 
 ```
->>> get_min_quote_per_base(0.001, 0.01)
+>>> get_min_quote_per_base("0.001", 0.01)
 10.0
 ```
 
@@ -104,26 +104,26 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
 The granularity of price in human terms is $10 per `eAPT`.
-That is, the minimum price is $10/eAPT, the second-lowest expressible price is $20/eAPT, and so on.
-Given that (real) APT is right now $7, we can assess that this configuration would not be workable or appropriate!
+That is, the minimum price is $10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
+Given that (real) `APT` is right now $7, we can assess that this configuration would not be workable or appropriate!
 
 The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
 Checking our price granularity now shows better results:
 
 ```
->>> get_min_quote_per_base(0.001, 0.00001)
+>>> get_min_quote_per_base("0.001", 0.00001)
 0.01
 ```
 
-That's a price granularity of 1 cent, since the result here is in quote units and 1 eUSDC is $1.
+That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is $1.
 Now that we have the minimum base and quote size decimals we'd like to use, we're ready to configure the market.
 Let's get the lot size and tick size:
 
 ```
->>> lot_size = get_lot_size(0.001, base_decimals)
+>>> lot_size = get_lot_size("0.001", base_decimals)
 >>> lot_size
 100000
->>> tick_size = get_tick_size(0.00001, quote_decimals)
+>>> tick_size = get_tick_size("0.00001", quote_decimals)
 >>> tick_size
 10
 ```
@@ -132,7 +132,7 @@ We also need a minimum size.
 Let's say orders can only be submitted if they are for at least 1 whole `eAPT`, using the lot size of 100000 from above:
 
 ```
->>> get_min_size(1.0, base_decimals, lot_size)
+>>> get_min_size("1.0", base_decimals, lot_size)
 1000
 ```
 
@@ -144,7 +144,7 @@ That means we use use a minimum size of 1000 lots to configure our market, so ou
 | Tick size | 10 | Subunits of quote |
 | Min size | 1000 | Lots of base |
 
-This gives us a market with a price granularity of 1 cent and minimum order size of 1 eAPT!
+This gives us a market with a price granularity of 1 cent and minimum order size of 1 `eAPT`!
 Can you see how one would get a price granularity of 0.1 cents instead?
 
 # Other Contents

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -57,8 +57,9 @@ However, each value in each enum is associated with a constant that exists in th
 ## `econia_sdk.utils.decimals`
 
 This package contains a few helpers for calculating market parameters (lot size, tick size, and min size).
-The intent is to allow one to express their desired sizes in decimal notation, and have that converted to integer notation. These helpers make an effort to check for reasonable inputs, perfect results in all cases would be impossible due to integer division and decimal truncation.
-Price conversion utilities are left out for this reason: truncation, even a small percent's worth, would make them too dangerous.
+The intent is to allow one to express their desired sizes in decimal notation, and have that converted to integer notation.
+Perfect conversions are not always possible due to potential integer division and truncation, so these helpers functions attempt to check for reasonable inputs.
+Price conversion utilities are left out to avoid introducing truncation effects.
 
 Let's walk through an example of configuring a market using these utilities.
 If you'd like to follow along, install the Econia SDK, run the Python interpreter and import the SDK using...
@@ -71,11 +72,11 @@ python3
 
 Market configuration (beyond base type and quote type) consists of 3 integer values: lot size, tick size, and min size.
 
-| value     | units                  | description                    |
-| --------- | ---------------------- | ------------------------------ |
-| lot size  | subunits of base type  | the granularity of base sizes  |
-| tick size | subunits of quote type | the granularity of quote sizes |
-| min size  | number of lots         | the minimum limit order size   |
+| Value     | Units                  | Description                |
+| --------- | ---------------------- | -------------------------- |
+| Lot size  | Subunits of base type  | Granularity of base sizes  |
+| Tick size | Subunits of quote type | Granularity of quote sizes |
+| Min size  | Number of lots         | Minimum limit order size   |
 
 In order to proceed, we must decide the granularity of base and quote sizes as well as the minimum limit order size for our market.
 Consider that "price" in the exchange is an integer expressed in terms of "ticks per lot", which means that tick size and lot size affect the prices that can be expressed.
@@ -142,7 +143,7 @@ Let's say orders can only be submitted if they are for at least 1 whole `eAPT`, 
 
 That means we use use a minimum size of 1000 lots to configure our market, so our market parameters would be:
 
-| parameter | value  | units             |
+| Parameter | Value  | Units             |
 | --------- | ------ | ----------------- |
 | Lot size  | 100000 | Subunits of base  |
 | Tick size | 10     | Subunits of quote |

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -104,9 +104,9 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
-The granularity of price in human terms is \$10 per `eAPT`.
-That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is \$20/`eAPT`, and so on.
-Given that (real) `APT` is right now \$7, we can assess that this configuration would not be workable or appropriate!
+The granularity of price in human terms is $10 per `eAPT`.
+That is, the minimum price is $10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
+Given that (real) `APT` is right now $7, we can assess that this configuration would not be workable or appropriate!
 
 The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
 Checking our price granularity now shows better results:
@@ -118,8 +118,8 @@ Checking our price granularity now shows better results:
 42949672.95
 ```
 
-That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is \$1.
-For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's \$42,949,672.95 per `eAPT` so this is fine!
+That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is $1.
+For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's $42,949,672.95 per `eAPT` so this is fine!
 Be careful: using a more granular price results in a lower maximum price, which may be relevant in some cases.
 Now that we have the minimum base and quote sizes we'd like to use, we're ready to configure the market.
 Let's get the lot size and tick size:

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -104,8 +104,8 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
 The granularity of price in human terms is $10 per `eAPT`.
-That is, the minimum price is \$10/eAPT, the second-lowest expressible price is \$20/eAPT, and so on.
-Given that (real) APT is right now \$7, we can assess that this configuration would not be workable or appropriate!
+That is, the minimum price is $10/eAPT, the second-lowest expressible price is $20/eAPT, and so on.
+Given that (real) APT is right now $7, we can assess that this configuration would not be workable or appropriate!
 
 The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
 Checking our price granularity now shows better results:

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -7,7 +7,7 @@ def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     whole unit's decimals (e.g. ETH has 18 decimals), return the lot size.
 
     Parameters:
-    * `smallest_decimal_unit`: Decimal (e.g. 0.001 for one thousandth) of
+    * `smallest_decimal_unit`: Decimal (e.g. "0.001" for one thousandth) of
       the smallest possible unit relative to a whole unit.
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
@@ -24,7 +24,7 @@ def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int
     whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
 
     Parameters:
-    * `smallest_decimal_unit`: Decimal (e.g. 0.001 for one thousandth) of
+    * `smallest_decimal_unit`: Decimal (e.g. "0.001" for one thousandth) of
       the smallest possible unit relative to a whole unit.
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
@@ -41,7 +41,7 @@ def get_min_size_integer(
     decimal size according to the base coin's decimals and lot size.
 
     Parameters:
-    * `smallest_decimal_size`: Decimal (e.g. 0.001 for one thousandth) of
+    * `smallest_decimal_size`: Decimal (e.g. "0.001" for one thousandth) of
       the smallest possible size relative to a whole unit. Note that this
       maybe different (larger) than the smallest possible unit (lot size).
       This should be of the base coin, not the quote coin!
@@ -57,8 +57,8 @@ def get_min_size_integer(
 
 
 def get_min_quote_per_base_nominal(
-    smallest_decimal_size_base: float,
-    smallest_decimal_size_quote: float,
+    smallest_decimal_size_base: str,
+    smallest_decimal_size_quote: str,
 ) -> float:
     """
     Returns the minimum units of quote that one can obtain for a unit of
@@ -69,7 +69,11 @@ def get_min_quote_per_base_nominal(
     $20/unit, $30/unit, any so on.
 
     Parameters:
-    * `smallest_decimal_size_base`: The decimal size of one lot of base.
-    * `smallest_decimal_size_quote`: The decimal size of one tick of quote.
+    * `smallest_decimal_size_base`: The decimal size of one lot of base,
+      as a string i.e "0.001" for one-thousandth.
+    * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
+      as a string i.e "0.001" for one-thousandth.
     """
-    return (1/smallest_decimal_size_base) * smallest_decimal_size_quote
+    return float(
+        (1/Decimal(smallest_decimal_size_base)) * Decimal(smallest_decimal_size_quote)
+    )

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -2,6 +2,16 @@ import math
 from decimal import Decimal
 
 
+def _verify_decimal_input(decimal_input: str):
+    if type(decimal_input) is not str:
+        raise ValueError("Decimal input should be a string")
+
+
+def _verify_integer_input(integer_input: int):
+    if type(integer_input) is not int:
+        raise ValueError("Integer input should be an integer")
+
+
 def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
@@ -13,6 +23,8 @@ def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
+    _verify_decimal_input(smallest_decimal_unit)
+    _verify_integer_input(coin_decimals)
     smallest_decimal = Decimal(smallest_decimal_unit)
     smallest_subunits = 10 ** (coin_decimals + math.log10(smallest_decimal))
     if smallest_subunits < 1:
@@ -20,9 +32,7 @@ def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     return math.ceil(smallest_subunits)
 
 
-def get_tick_size_integer(
-    smallest_decimal_unit: str, coin_decimals: int
-) -> int:
+def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
@@ -52,10 +62,11 @@ def get_min_size_integer(
       base has (e.g. USDC has 6 decimals, ETH has 18).
     * `lot_size`: The size in subunits of one lot of base coin.
     """
+    _verify_decimal_input(smallest_decimal_size)
+    _verify_integer_input(base_coin_decimals)
+    _verify_integer_input(lot_size)
     smallest_decimal = Decimal(smallest_decimal_size)
-    smallest_subunits = (
-        smallest_decimal * (10**base_coin_decimals)
-    ) / lot_size
+    smallest_subunits = (smallest_decimal * (10**base_coin_decimals)) / lot_size
     if smallest_subunits < 0:
         raise ValueError("Decimal size too small to represent with 1 lot")
     return math.ceil(smallest_subunits)
@@ -79,9 +90,10 @@ def get_min_quote_per_base_nominal(
     * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
       as a string i.e "0.001" for one-thousandth.
     """
+    _verify_decimal_input(smallest_decimal_size_base)
+    _verify_decimal_input(smallest_decimal_size_quote)
     return float(
-        (1 / Decimal(smallest_decimal_size_base))
-        * Decimal(smallest_decimal_size_quote)
+        (1 / Decimal(smallest_decimal_size_base)) * Decimal(smallest_decimal_size_quote)
     )
 
 
@@ -100,6 +112,8 @@ def get_max_quote_per_base_nominal(
     * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
       as a string i.e "0.001" for one-thousandth.
     """
+    _verify_decimal_input(smallest_decimal_size_base)
+    _verify_decimal_input(smallest_decimal_size_quote)
     lots_per_base_unit = 1 / Decimal(smallest_decimal_size_base)
     max_ticks_per_lot = (2**32) - 1
     max_quote_per_lot = Decimal(smallest_decimal_size_quote) * max_ticks_per_lot

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -53,5 +53,15 @@ def get_min_quote_per_base(
     smallest_decimal_size_quote: float,
 ) -> float:
     """
+    Returns the minimum units of quote that one can obtain for a unit of
+    base, given the granularity of base and granularity of quote. This
+    can be thought of as price granularity--how much the price must move
+    by in order to move at all. If the price granularity is 10 USDC for
+    example, then only prices divisible by 10 are expressible: $10/unit,
+    $20/unit, $30/unit, any so on.
+
+    Parameters:
+    * `smallest_decimal_size_base`: The decimal size of one lot of base.
+    * `smallest_decimal_size_quote`: The decimal size of one tick of quote.
     """
     return (1/smallest_decimal_size_base) * smallest_decimal_size_quote

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -1,6 +1,7 @@
 import math
 from decimal import Decimal
 
+
 def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
@@ -13,12 +14,15 @@ def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
     smallest_decimal = Decimal(smallest_decimal_unit)
-    smallest_subunits = 10**(coin_decimals+math.log10(smallest_decimal))
+    smallest_subunits = 10 ** (coin_decimals + math.log10(smallest_decimal))
     if smallest_subunits < 1:
         raise ValueError("Decimal unit too small to represent with 1 subunit")
     return math.ceil(smallest_subunits)
 
-def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
+
+def get_tick_size_integer(
+    smallest_decimal_unit: str, coin_decimals: int
+) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
@@ -31,10 +35,9 @@ def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int
     """
     return get_lot_size_integer(smallest_decimal_unit, coin_decimals)
 
+
 def get_min_size_integer(
-    smallest_decimal_size: str,
-    base_coin_decimals: int,
-    lot_size: int
+    smallest_decimal_size: str, base_coin_decimals: int, lot_size: int
 ) -> int:
     """
     Returns the minimum size, in number of lots, to represent the smallest
@@ -50,7 +53,9 @@ def get_min_size_integer(
     * `lot_size`: The size in subunits of one lot of base coin.
     """
     smallest_decimal = Decimal(smallest_decimal_size)
-    smallest_subunits = (smallest_decimal * (10 ** base_coin_decimals)) / lot_size
+    smallest_subunits = (
+        smallest_decimal * (10**base_coin_decimals)
+    ) / lot_size
     if smallest_subunits < 0:
         raise ValueError("Decimal size too small to represent with 1 lot")
     return math.ceil(smallest_subunits)
@@ -75,8 +80,10 @@ def get_min_quote_per_base_nominal(
       as a string i.e "0.001" for one-thousandth.
     """
     return float(
-        (1/Decimal(smallest_decimal_size_base)) * Decimal(smallest_decimal_size_quote)
+        (1 / Decimal(smallest_decimal_size_base))
+        * Decimal(smallest_decimal_size_quote)
     )
+
 
 def get_max_quote_per_base_nominal(
     smallest_decimal_size_base: str,
@@ -93,7 +100,7 @@ def get_max_quote_per_base_nominal(
     * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
       as a string i.e "0.001" for one-thousandth.
     """
-    lots_per_base_unit = 1/Decimal(smallest_decimal_size_base)
+    lots_per_base_unit = 1 / Decimal(smallest_decimal_size_base)
     max_ticks_per_lot = (2**32) - 1
     max_quote_per_lot = Decimal(smallest_decimal_size_quote) * max_ticks_per_lot
     return float(max_quote_per_lot * lots_per_base_unit)

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -1,6 +1,7 @@
 import math
+from decimal import Decimal
 
-def get_lot_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
+def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the lot size.
@@ -11,9 +12,13 @@ def get_lot_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
-    return math.ceil(10**(coin_decimals+math.log10(smallest_decimal_unit)))
+    smallest_decimal = Decimal(smallest_decimal_unit)
+    smallest_subunits = 10**(coin_decimals+math.log10(smallest_decimal))
+    if smallest_subunits < 1:
+        raise ValueError("Decimal unit too small to represent with 1 subunit")
+    return math.ceil(smallest_subunits)
 
-def get_tick_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
+def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
@@ -24,10 +29,10 @@ def get_tick_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
-    return get_lot_size(smallest_decimal_unit, coin_decimals)
+    return get_lot_size_integer(smallest_decimal_unit, coin_decimals)
 
-def get_min_size(
-    smallest_decimal_size: float,
+def get_min_size_integer(
+    smallest_decimal_size: str,
     base_coin_decimals: int,
     lot_size: int
 ) -> int:
@@ -44,11 +49,14 @@ def get_min_size(
       base has (e.g. USDC has 6 decimals, ETH has 18).
     * `lot_size`: The size in subunits of one lot of base coin.
     """
-    smallest_subunits = smallest_decimal_size * (10 ** base_coin_decimals)
-    return math.ceil(smallest_subunits / lot_size)
+    smallest_decimal = Decimal(smallest_decimal_size)
+    smallest_subunits = (smallest_decimal * (10 ** base_coin_decimals)) / lot_size
+    if smallest_subunits < 0:
+        raise ValueError("Decimal size too small to represent with 1 lot")
+    return math.ceil(smallest_subunits)
 
 
-def get_min_quote_per_base(
+def get_min_quote_per_base_nominal(
     smallest_decimal_size_base: float,
     smallest_decimal_size_quote: float,
 ) -> float:

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -1,0 +1,57 @@
+import math
+
+def get_lot_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
+    """
+    Given a decimal representation of the smallest possible unit and the
+    whole unit's decimals (e.g. ETH has 18 decimals), return the lot size.
+
+    Parameters:
+    * `smallest_decimal_unit`: Decimal (e.g. 0.001 for one thousandth) of
+      the smallest possible unit relative to a whole unit.
+    * `coin_decimals`: The number of decimals one whole unit of the coin
+      has (e.g. USDC has 6 decimals, ETH has 18).
+    """
+    return math.ceil(10**(coin_decimals+math.log10(smallest_decimal_unit)))
+
+def get_tick_size(smallest_decimal_unit: float, coin_decimals: int) -> int:
+    """
+    Given a decimal representation of the smallest possible unit and the
+    whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
+
+    Parameters:
+    * `smallest_decimal_unit`: Decimal (e.g. 0.001 for one thousandth) of
+      the smallest possible unit relative to a whole unit.
+    * `coin_decimals`: The number of decimals one whole unit of the coin
+      has (e.g. USDC has 6 decimals, ETH has 18).
+    """
+    return get_lot_size(smallest_decimal_unit, coin_decimals)
+
+def get_min_size(
+    smallest_decimal_size: float,
+    base_coin_decimals: int,
+    lot_size: int
+) -> int:
+    """
+    Returns the minimum size, in number of lots, to represent the smallest
+    decimal size according to the base coin's decimals and lot size.
+
+    Parameters:
+    * `smallest_decimal_size`: Decimal (e.g. 0.001 for one thousandth) of
+      the smallest possible size relative to a whole unit. Note that this
+      maybe different (larger) than the smallest possible unit (lot size).
+      This should be of the base coin, not the quote coin!
+    * `base_coin_decimals`: The number of decimals one whole unit of the
+      base has (e.g. USDC has 6 decimals, ETH has 18).
+    * `lot_size`: The size in subunits of one lot of base coin.
+    """
+    smallest_subunits = smallest_decimal_size * (10 ** base_coin_decimals)
+    return math.ceil(smallest_subunits / lot_size)
+
+
+def get_min_quote_per_base(
+    smallest_decimal_size_base: float,
+    smallest_decimal_size_quote: float,
+) -> float:
+    """
+    """
+    return (1/smallest_decimal_size_base) * smallest_decimal_size_quote

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -77,3 +77,23 @@ def get_min_quote_per_base_nominal(
     return float(
         (1/Decimal(smallest_decimal_size_base)) * Decimal(smallest_decimal_size_quote)
     )
+
+def get_max_quote_per_base_nominal(
+    smallest_decimal_size_base: str,
+    smallest_decimal_size_quote: str,
+) -> float:
+    """
+    Returns the maximum units of quote that once can obtain for a unit of
+    base, given the granularity of base and granularity of quote. This
+    can be thought of as maximum price.
+
+    Parameters:
+    * `smallest_decimal_size_base`: The decimal size of one lot of base,
+      as a string i.e "0.001" for one-thousandth.
+    * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
+      as a string i.e "0.001" for one-thousandth.
+    """
+    lots_per_base_unit = 1/Decimal(smallest_decimal_size_base)
+    max_ticks_per_lot = (2**32) - 1
+    max_quote_per_lot = Decimal(smallest_decimal_size_quote) * max_ticks_per_lot
+    return float(max_quote_per_lot * lots_per_base_unit)

--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.8"
 
 [tool.poetry.scripts]
 trade = "examples.trade:start"
+market = "examples.market:start"
 
 [tool.poetry.group.docs.dependencies]
 pdoc = "^14.0.0"


### PR DESCRIPTION
Multiple people have stumbled across lot size, tick size, and min size and rightly become confused. I've developed here helpers for the Python SDK (as well as documentation) that calculate lot/tick size and min size for the user. I wanted something to help with price without the chance of it being misused or truncation ruining someone's day so I provided a helper to determine the minimum quote per lot, that is price granularity.