### PR TITLE
[ECO-330] Deprecate MakerEvent/handle in changelog

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -20,6 +20,8 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 
 ### Deprecated
 
+- [`market::MakerEvent`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L523) ([#321]).
+- [`market::OrderBook.maker_events`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L585) ([#321]).
 - [`market::OrderBook.taker_events`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L587) ([#321]).
 - [`market::Orders`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L3337) ([#301]).
 - [`market::TakerEvent`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L600) ([#321]).

--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -22,9 +22,9 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 
 - [`market::MakerEvent`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L523) ([#321]).
 - [`market::OrderBook.maker_events`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L585) ([#321]).
+- [`market::TakerEvent`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L600) ([#321]).
 - [`market::OrderBook.taker_events`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L587) ([#321]).
 - [`market::Orders`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L3337) ([#301]).
-- [`market::TakerEvent`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L600) ([#321]).
 - [`market::index_orders_sdk()`](https://github.com/econia-labs/econia/blob/v4.0.2-audited/src/move/econia/sources/market.move#L3362) ([#287]).
 - [`move-to-ts`](https://github.com/hippospace/move-to-ts) attributes ([#292]).
 


### PR DESCRIPTION
`MakerEvent` and its associated handle were deprecated per #321. This PR specifies the deprecation in the Move changelog