### PR TITLE
[ECO-347] Add missing cancel reasons to Rust

### DIFF
--- a/src/rust/db/src/models/order.rs
+++ b/src/rust/db/src/models/order.rs
@@ -120,6 +120,8 @@ pub enum CancelReason {
     NotEnoughLiquidity,
     SelfMatchMaker,
     SelfMatchTaker,
+    TooSmallToFillLot,
+    ViolatedLimitPrice,
 }
 
 impl From<CancelReason> for types::events::CancelReason {
@@ -133,6 +135,8 @@ impl From<CancelReason> for types::events::CancelReason {
             CancelReason::NotEnoughLiquidity => types::events::CancelReason::NotEnoughLiquidity,
             CancelReason::SelfMatchMaker => types::events::CancelReason::SelfMatchMaker,
             CancelReason::SelfMatchTaker => types::events::CancelReason::SelfMatchTaker,
+            CancelReason::TooSmallToFillLot => types::events::CancelReason::TooSmallToFillLot,
+            CancelReason::ViolatedLimitPrice => types::events::CancelReason::ViolatedLimitPrice,
         }
     }
 }

--- a/src/rust/types/src/events.rs
+++ b/src/rust/types/src/events.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::order::{Side, Restriction, SelfMatchBehavior};
+use crate::order::{Restriction, SelfMatchBehavior, Side};
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -37,6 +37,8 @@ pub enum CancelReason {
     NotEnoughLiquidity,
     SelfMatchMaker,
     SelfMatchTaker,
+    TooSmallToFillLot,
+    ViolatedLimitPrice,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This PR adds to Rust enums cancel reasons that were uncovered during event emission unit testing per #366