### PR TITLE
[ECO-137 - ECO-141] Order validation logic changes

### DIFF
--- a/src/typescript/frontend/src/components/trade/DepositWithdrawModal/DepositWithdrawContent.tsx
+++ b/src/typescript/frontend/src/components/trade/DepositWithdrawModal/DepositWithdrawContent.tsx
@@ -134,14 +134,14 @@ const DepositWithdrawForm: React.FC<{
               TypeTag.fromApiCoin(selectedCoin).toString(),
               BigInt(selectedMarket.market_id),
               BigInt(NO_CUSTODIAN),
-              BigInt(toRawCoinAmount(amount, selectedCoin.decimals)),
+              BigInt(toRawCoinAmount(amount, selectedCoin.decimals).toString()),
             );
           } else {
             payload = entryFunctions.withdrawToCoinstore(
               ECONIA_ADDR,
               TypeTag.fromApiCoin(selectedCoin).toString(),
               BigInt(selectedMarket.market_id),
-              BigInt(toRawCoinAmount(amount, selectedCoin.decimals)),
+              BigInt(toRawCoinAmount(amount, selectedCoin.decimals).toString()),
             );
           }
           await signAndSubmitTransaction({

--- a/src/typescript/frontend/src/components/trade/OrderEntry/LimitOrderEntry.tsx
+++ b/src/typescript/frontend/src/components/trade/OrderEntry/LimitOrderEntry.tsx
@@ -1,4 +1,5 @@
 import { entryFunctions, type order } from "@econia-labs/sdk";
+import BigNumber from "bignumber.js";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
@@ -10,14 +11,13 @@ import { ECONIA_ADDR } from "@/env";
 import { useMarketAccountBalance } from "@/hooks/useMarketAccountBalance";
 import { type ApiMarket } from "@/types/api";
 import { type Side } from "@/types/global";
+import { toRawCoinAmount } from "@/utils/coin";
 import { fromDecimalPrice, fromDecimalSize } from "@/utils/econia";
+import { canBeBigInt } from "@/utils/formatter";
 import { TypeTag } from "@/utils/TypeTag";
 
 import { OrderEntryInfo } from "./OrderEntryInfo";
 import { OrderEntryInputWrapper } from "./OrderEntryInputWrapper";
-import { toast } from "react-toastify";
-import { toRawCoinAmount } from "@/utils/coin";
-import { canBeBigInt } from "@/utils/formatter";
 
 type LimitFormValues = {
   price: string;
@@ -57,118 +57,92 @@ export const LimitOrderEntry: React.FC<{
     marketData.quote,
   );
 
-  const onSubmit = async (values: LimitFormValues) => {
+  const onSubmit = async ({ price, size }: LimitFormValues) => {
+    if (marketData.base == null) {
+      throw new Error("Markets without base coin not supported");
+    }
+
+    if (baseBalance.data == null || quoteBalance.data == null) {
+      throw new Error("Could not read wallet balances");
+    }
+
+    const rawSize = new BigNumber(size).times(
+      new BigNumber(10).pow(marketData.base.decimals),
+    );
+
+    // check that size satisfies lot size
+    if (!rawSize.modulo(marketData.lot_size).eq(0)) {
+      setError("size", { message: "INVALID LOT SIZE" });
+      return;
+    }
+
+    // check that size satisfies min size
+    if (rawSize.lt(marketData.min_size)) {
+      setError("size", { message: "INVALID MIN SIZE" });
+      return;
+    }
+
+    const rawPrice = new BigNumber(price).times(
+      new BigNumber(10).pow(marketData.quote.decimals),
+    );
+
+    // validate tick size
+    if (!rawPrice.modulo(marketData.tick_size).eq(0)) {
+      setError("price", { message: "INVALID TICK SIZE" });
+      return;
+    }
+
+    const rawBaseBalance = new BigNumber(baseBalance.data).times(
+      new BigNumber(10).pow(marketData.base.decimals),
+    );
+
+    const rawQuoteBalance = new BigNumber(quoteBalance.data).times(
+      new BigNumber(10).pow(marketData.quote.decimals),
+    );
+
+    if (side === "buy") {
+      // check that user has sufficient quote coins on bid
+      if (
+        rawQuoteBalance.lt(
+          rawSize
+            .times(rawPrice)
+            .div(new BigNumber(10).pow(marketData.base.decimals)),
+        )
+      ) {
+        setError("size", { message: "INSUFFICIENT QUOTE BALANCE" });
+        return;
+      }
+    } else {
+      // check that user has sufficient base coins on ask
+      if (rawBaseBalance.lt(rawSize)) {
+        setError("size", { message: "INSUFFICIENT BASE BALANCE" });
+        return;
+      }
+    }
+
     const orderSideMap: Record<Side, order.Side> = {
       buy: "bid",
       sell: "ask",
     };
     const orderSide = orderSideMap[side];
 
-    // validation
-    const _rawValueSize = toRawCoinAmount(
-      values.size ?? 0,
-      marketData?.base?.decimals ?? 0,
-    );
-    const rawValueSize = canBeBigInt(_rawValueSize) // if after conversion is still a decimal, then it's too small anyways
-      ? BigInt(_rawValueSize)
-      : BigInt(0);
-    const rawBaseBalance = BigInt(
-      toRawCoinAmount(
-        baseBalance.data ?? 0, // assume if null, user has 0
-        marketData?.base?.decimals ?? 0, // is this fine?
-      ),
-    );
-    const _rawValuePrice = BigInt(
-      toRawCoinAmount(values.price ?? 0, marketData?.quote?.decimals ?? 0),
-    );
-    const rawValuePrice = canBeBigInt(_rawValuePrice) // if after conversion is still a decimal, then it's too small anyways
-      ? BigInt(_rawValuePrice)
-      : BigInt(0);
-
-    const rawQuoteBalance = BigInt(
-      toRawCoinAmount(
-        quoteBalance.data ?? 0, // assume if null, user has 0
-        marketData?.quote?.decimals ?? 0, // is this fine?
-      ),
+    const payload = entryFunctions.placeLimitOrderUserEntry(
+      ECONIA_ADDR,
+      TypeTag.fromApiCoin(marketData.base).toString(),
+      TypeTag.fromApiCoin(marketData.quote).toString(),
+      BigInt(marketData.market_id), // market id
+      "0x1", // TODO get integrator ID
+      orderSide,
+      BigInt(rawSize.div(marketData.lot_size).toString()),
+      BigInt(rawPrice.div(marketData.tick_size).toString()),
+      "immediateOrCancel", // TODO don't hardcode
+      "abort", // don't hardcode this either
     );
 
-    // validate tick size
-    if (rawValuePrice % BigInt(marketData.tick_size) != BigInt(0)) {
-      setError("price", { message: "INVALID TICK SIZE" });
-      return;
-    }
-
-    // validate Lot size
-    if (rawValueSize % BigInt(marketData.lot_size) != BigInt(0)) {
-      setError("size", { message: "INVALID LOT SIZE" });
-      return;
-    }
-    // validate min size
-    if (rawValueSize < BigInt(marketData.min_size)) {
-      setError("size", { message: "INVALID MIN SIZE" });
-      return;
-    }
-
-    // limit buy -- make sure user has enough quote balance
-    if (orderSide === "bid") {
-      const isValid =
-        BigInt(
-          toRawCoinAmount(
-            rawQuoteBalance.toString(),
-            marketData?.base?.decimals ?? 0,
-          ),
-        ) >=
-        BigInt(rawValueSize) * BigInt(rawValuePrice); // how to get price? esp if market order
-      if (!isValid) {
-        setError("price", { message: "INSUFFICIENT QUOTE BALANCE" });
-        return;
-      }
-    }
-
-    // limit sell -- make sure user has enough base balance
-    if (orderSide === "ask") {
-      const isValid = rawBaseBalance >= BigInt(rawValueSize); // is gte fine?
-      if (!isValid) {
-        setError("size", { message: "INSUFFICIENT BASE BALANCE" });
-        return;
-      }
-    }
-
-    if (marketData.base == null) {
-      // TODO: handle generic markets
-    } else {
-      const payload = entryFunctions.placeLimitOrderUserEntry(
-        ECONIA_ADDR,
-        TypeTag.fromApiCoin(marketData.base).toString(),
-        TypeTag.fromApiCoin(marketData.quote).toString(),
-        BigInt(marketData.market_id), // market id
-        "0x1", // TODO get integrator ID
-        orderSide,
-        BigInt(
-          fromDecimalSize({
-            size: values.size,
-            lotSize: marketData.lot_size,
-            baseCoinDecimals: marketData.base.decimals,
-          }).toString(),
-        ),
-        BigInt(
-          fromDecimalPrice({
-            price: values.price,
-            lotSize: marketData.lot_size,
-            tickSize: marketData.tick_size,
-            baseCoinDecimals: marketData.base.decimals,
-            quoteCoinDecimals: marketData.quote.decimals,
-          }).toString(),
-        ),
-        "immediateOrCancel", // TODO don't hardcode
-        "abort", // don't hardcode this either
-      );
-
-      await signAndSubmitTransaction({
-        type: "entry_function_payload",
-        ...payload,
-      });
-    }
+    await signAndSubmitTransaction({
+      type: "entry_function_payload",
+      ...payload,
+    });
   };
 
   return (

--- a/src/typescript/frontend/src/components/trade/OrderEntry/LimitOrderEntry.tsx
+++ b/src/typescript/frontend/src/components/trade/OrderEntry/LimitOrderEntry.tsx
@@ -12,8 +12,6 @@ import { useMarketAccountBalance } from "@/hooks/useMarketAccountBalance";
 import { type ApiMarket } from "@/types/api";
 import { type Side } from "@/types/global";
 import { toRawCoinAmount } from "@/utils/coin";
-import { fromDecimalPrice, fromDecimalSize } from "@/utils/econia";
-import { canBeBigInt } from "@/utils/formatter";
 import { TypeTag } from "@/utils/TypeTag";
 
 import { OrderEntryInfo } from "./OrderEntryInfo";
@@ -66,9 +64,7 @@ export const LimitOrderEntry: React.FC<{
       throw new Error("Could not read wallet balances");
     }
 
-    const rawSize = new BigNumber(size).times(
-      new BigNumber(10).pow(marketData.base.decimals),
-    );
+    const rawSize = toRawCoinAmount(size, marketData.base.decimals);
 
     // check that size satisfies lot size
     if (!rawSize.modulo(marketData.lot_size).eq(0)) {
@@ -82,9 +78,7 @@ export const LimitOrderEntry: React.FC<{
       return;
     }
 
-    const rawPrice = new BigNumber(price).times(
-      new BigNumber(10).pow(marketData.quote.decimals),
-    );
+    const rawPrice = toRawCoinAmount(price, marketData.quote.decimals);
 
     // validate tick size
     if (!rawPrice.modulo(marketData.tick_size).eq(0)) {
@@ -92,12 +86,14 @@ export const LimitOrderEntry: React.FC<{
       return;
     }
 
-    const rawBaseBalance = new BigNumber(baseBalance.data).times(
-      new BigNumber(10).pow(marketData.base.decimals),
+    const rawBaseBalance = toRawCoinAmount(
+      baseBalance.data,
+      marketData.base.decimals,
     );
 
-    const rawQuoteBalance = new BigNumber(quoteBalance.data).times(
-      new BigNumber(10).pow(marketData.quote.decimals),
+    const rawQuoteBalance = toRawCoinAmount(
+      quoteBalance.data,
+      marketData.quote.decimals,
     );
 
     if (side === "buy") {

--- a/src/typescript/frontend/src/components/trade/OrderEntry/MarketOrderEntry.tsx
+++ b/src/typescript/frontend/src/components/trade/OrderEntry/MarketOrderEntry.tsx
@@ -1,6 +1,5 @@
-import { entryFunctions, order } from "@econia-labs/sdk";
+import { entryFunctions, type order } from "@econia-labs/sdk";
 import { useForm } from "react-hook-form";
-import { toast } from "react-toastify";
 
 import { Button } from "@/components/Button";
 import { ConnectedButton } from "@/components/ConnectedButton";
@@ -10,8 +9,6 @@ import { useMarketAccountBalance } from "@/hooks/useMarketAccountBalance";
 import { type ApiMarket } from "@/types/api";
 import { type Side } from "@/types/global";
 import { toRawCoinAmount } from "@/utils/coin";
-import { fromDecimalSize } from "@/utils/econia";
-import { canBeBigInt } from "@/utils/formatter";
 import { TypeTag } from "@/utils/TypeTag";
 
 import { OrderEntryInfo } from "./OrderEntryInfo";
@@ -44,74 +41,64 @@ export const MarketOrderEntry: React.FC<{
     marketData.quote,
   );
 
-  const onSubmit = async (values: MarketFormValues) => {
+  const onSubmit = async ({ size }: MarketFormValues) => {
+    if (marketData.base == null) {
+      throw new Error("Markets without base coin not supported");
+    }
+
+    if (baseBalance.data == null || quoteBalance.data == null) {
+      throw new Error("Could not read wallet balances");
+    }
+
+    const rawSize = toRawCoinAmount(size, marketData.base.decimals);
+
+    // check that size satisfies lot size
+    if (!rawSize.modulo(marketData.lot_size).eq(0)) {
+      setError("size", { message: "INVALID LOT SIZE" });
+      return;
+    }
+
+    // check that size satisfies min size
+    if (rawSize.lt(marketData.min_size)) {
+      setError("size", { message: "INVALID MIN SIZE" });
+      return;
+    }
+
+    const rawBaseBalance = toRawCoinAmount(
+      baseBalance.data,
+      marketData.base.decimals,
+    );
+
+    // market sell -- make sure user has enough base balance
+    if (side === "sell") {
+      // check that user has sufficient base coins on ask
+      if (rawBaseBalance.lt(rawSize)) {
+        setError("size", { message: "INSUFFICIENT BASE BALANCE" });
+        return;
+      }
+    }
+
     const orderSideMap: Record<Side, order.Side> = {
       buy: "bid",
       sell: "ask",
     };
     const orderSide = orderSideMap[side];
 
-    // validation
-    const _rawValueSize = toRawCoinAmount(
-      values.size ?? 0,
-      marketData?.base?.decimals ?? 0,
-    );
-    const rawValueSize = canBeBigInt(_rawValueSize) // if after conversion is still a decimal, then it's too small anyways
-      ? BigInt(_rawValueSize)
-      : BigInt(0);
-
-    const rawBaseBalance = BigInt(
-      toRawCoinAmount(
-        baseBalance.data ?? 0, // assume if null, user has 0
-        marketData?.base?.decimals ?? 0, // is this fine?
-      ),
+    const payload = entryFunctions.placeMarketOrderUserEntry(
+      ECONIA_ADDR,
+      TypeTag.fromApiCoin(marketData.base).toString(),
+      TypeTag.fromApiCoin(marketData.quote).toString(),
+      BigInt(marketData.market_id), // market id
+      "0x1", // TODO get integrator ID
+      orderSide,
+      BigInt(rawSize.div(marketData.lot_size).toString()),
+      "abort", // TODO don't hardcode this either
     );
 
-    // validate Lot size
-    if (rawValueSize % BigInt(marketData.lot_size) != BigInt(0)) {
-      setError("size", { message: "INVALID LOT SIZE" });
-      return;
-    }
-    // validate min size
-    if (rawValueSize < BigInt(marketData.min_size)) {
-      setError("size", { message: "INVALID MIN SIZE" });
-      return;
-    }
-
-    // market sell -- make sure user has enough base balance
-    if (orderSide === "ask") {
-      const isValid = rawBaseBalance >= rawValueSize; // is gte fine?
-      if (!isValid) {
-        setError("size", { message: "INSUFFICIENT BASE BALANCE" });
-        return;
-      }
-    }
-
-    if (marketData.base == null) {
-      // TODO: handle generic markets
-    } else {
-      const payload = entryFunctions.placeMarketOrderUserEntry(
-        ECONIA_ADDR,
-        TypeTag.fromApiCoin(marketData.base).toString(),
-        TypeTag.fromApiCoin(marketData.quote).toString(),
-        BigInt(marketData.market_id), // market id
-        "0x1", // TODO get integrator ID
-        orderSide,
-        BigInt(
-          fromDecimalSize({
-            size: values.size,
-            lotSize: marketData.lot_size,
-            baseCoinDecimals: marketData.base.decimals,
-          }).toString(),
-        ),
-        "abort", // TODO don't hardcode this either
-      );
-
-      await signAndSubmitTransaction({
-        type: "entry_function_payload",
-        ...payload,
-      });
-    }
+    await signAndSubmitTransaction({
+      type: "entry_function_payload",
+      ...payload,
+    });
   };
 
   return (

--- a/src/typescript/frontend/src/components/trade/OrderEntry/MarketOrderEntry.tsx
+++ b/src/typescript/frontend/src/components/trade/OrderEntry/MarketOrderEntry.tsx
@@ -11,11 +11,11 @@ import { type ApiMarket } from "@/types/api";
 import { type Side } from "@/types/global";
 import { toRawCoinAmount } from "@/utils/coin";
 import { fromDecimalSize } from "@/utils/econia";
+import { canBeBigInt } from "@/utils/formatter";
 import { TypeTag } from "@/utils/TypeTag";
 
 import { OrderEntryInfo } from "./OrderEntryInfo";
 import { OrderEntryInputWrapper } from "./OrderEntryInputWrapper";
-import { canBeBigInt } from "@/utils/formatter";
 
 type MarketFormValues = {
   size: string;

--- a/src/typescript/frontend/src/utils/coin.ts
+++ b/src/typescript/frontend/src/utils/coin.ts
@@ -3,8 +3,8 @@ import BigNumber from "bignumber.js";
 export const toRawCoinAmount = (
   amount: BigNumber.Value,
   decimals: BigNumber.Value,
-) => {
-  return new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toFixed();
+): BigNumber => {
+  return new BigNumber(amount).times(new BigNumber(10).pow(decimals));
 };
 
 export const fromRawCoinAmount = (

--- a/src/typescript/frontend/src/utils/formatter.ts
+++ b/src/typescript/frontend/src/utils/formatter.ts
@@ -76,12 +76,3 @@ export const averageOrOtherPriceLevel = (
   // no prices (orderbook empty) maybe should get the last sale price then?
   return { price: 0, size: 0 };
 };
-
-export const canBeBigInt = (num: string | number | bigint | boolean) => {
-  try {
-    BigInt(num);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};


### PR DESCRIPTION
Suggested changes for #393.

- Checks for missing values at the very beginning to avoid usage of optional chaining and null coalescing later on
- Moves return statements to the earliest point they can be called, preventing unnecessary calculations
- Reduces the number of conversions, especially to bigint, necessary to perform these validations
- Fixes number of decimal places for checking quote balance on limit bid orders