### PR TITLE
[ECO-378] Remove unnecessary mutable borrows in view funcs

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -6,8 +6,8 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 
 ### Added
 
-- Assorted view functions ([#287], [#301], [#308], [#321], [#334]).
-- Assorted user- and market-level events with common order ID ([#321], [#347], [#360], [#366]).
+- Assorted view functions ([#287], [#301], [#308], [#321], [#334], [#428]).
+- Assorted user- and market-level events with common order ID ([#321], [#347], [#360], [#366], [#428]).
 - Authors field on manifest ([#380]).
 
 ### Changed
@@ -42,6 +42,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#366]: https://github.com/econia-labs/econia/pull/366
 [#368]: https://github.com/econia-labs/econia/pull/368
 [#380]: https://github.com/econia-labs/econia/pull/380
+[#428]: https://github.com/econia-labs/econia/pull/428
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [unreleased]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...HEAD

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -17,5 +17,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, pending
 # https://github.com/aptos-labs/aptos-core/pull/9181 merging from `main`
 # into `mainnet`.
-rev = "mainnet"
+rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -17,5 +17,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, since
 # event unit tests for this package were added before Aptos' event unit
 # testing framework was incorporated into the `mainnet` branch.
-rev = "main"
+rev = "mainnet"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -14,8 +14,8 @@ integrator = "0x4567"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-# You may need to change this to `main` to run event unit tests, pending
-# https://github.com/aptos-labs/aptos-core/pull/9181 merging from `main`
-# into `mainnet`.
+# You may need to change this to `main` to run event unit tests, since
+# event unit tests for this package were added before Aptos' event unit
+# testing framework was incorporated into the `mainnet` branch.
 rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/doc/incentives.md
+++ b/src/move/econia/doc/incentives.md
@@ -1415,17 +1415,17 @@ collisions with the matching engine.
     <a href="incentives.md#0xc0deb00c_incentives_IncentiveParameters">IncentiveParameters</a>,
     <a href="incentives.md#0xc0deb00c_incentives_IntegratorFeeStores">IntegratorFeeStores</a>
 {
-    // Borrow mutable reference <b>to</b> integrator fee stores map for
-    // given quote <a href="">coin</a> type.
-    <b>let</b> integrator_fee_stores_map_ref_mut =
-        &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="incentives.md#0xc0deb00c_incentives_IntegratorFeeStores">IntegratorFeeStores</a>&lt;QuoteCoinType&gt;&gt;(
+    // Immutably borrow integrator fee stores map for given quote
+    // <a href="">coin</a> type.
+    <b>let</b> integrator_fee_stores_map_ref =
+        &<b>borrow_global</b>&lt;<a href="incentives.md#0xc0deb00c_incentives_IntegratorFeeStores">IntegratorFeeStores</a>&lt;QuoteCoinType&gt;&gt;(
             integrator_address).map;
-    // Borrow mutable reference <b>to</b> corresponding integrator fee
-    // store for given <a href="market.md#0xc0deb00c_market">market</a> ID.
-    <b>let</b> integrator_fee_store_ref_mut = <a href="tablist.md#0xc0deb00c_tablist_borrow_mut">tablist::borrow_mut</a>(
-        integrator_fee_stores_map_ref_mut, market_id);
+    // Immutably borrow corresponding integrator fee store for
+    // given <a href="market.md#0xc0deb00c_market">market</a> ID.
+    <b>let</b> integrator_fee_store_ref = <a href="tablist.md#0xc0deb00c_tablist_borrow">tablist::borrow</a>(
+        integrator_fee_stores_map_ref, market_id);
     // Get current tier number.
-    <b>let</b> current_tier = integrator_fee_store_ref_mut.tier;
+    <b>let</b> current_tier = integrator_fee_store_ref.tier;
     // Assert actually attempting <b>to</b> upgrade <b>to</b> new tier.
     <b>assert</b>!(new_tier &gt; current_tier, <a href="incentives.md#0xc0deb00c_incentives_E_NOT_AN_UPGRADE">E_NOT_AN_UPGRADE</a>);
     // Get cumulative activation fee for current tier.

--- a/src/move/econia/doc/market.md
+++ b/src/move/econia/doc/market.md
@@ -3131,26 +3131,30 @@ Mutates state, so kept as a private view function.
     <b>if</b> (!<a href="market.md#0xc0deb00c_market_has_open_order">has_open_order</a>(market_id, order_id)) <b>return</b> <a href="_none">option::none</a>();
     // Get <b>address</b> of resource <a href="">account</a> <b>where</b> order books are stored.
     <b>let</b> resource_address = resource_account::get_address();
-    // Mutably borrow order books map.
-    <b>let</b> order_books_map_ref_mut =
-        &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="market.md#0xc0deb00c_market_OrderBooks">OrderBooks</a>&gt;(resource_address).map;
-    // Mutably borrow <a href="market.md#0xc0deb00c_market">market</a> order book.
-    <b>let</b> order_book_ref_mut = <a href="tablist.md#0xc0deb00c_tablist_borrow_mut">tablist::borrow_mut</a>(
-        order_books_map_ref_mut, market_id);
+    // Immutably borrow order books map.
+    <b>let</b> order_books_map_ref =
+        &<b>borrow_global</b>&lt;<a href="market.md#0xc0deb00c_market_OrderBooks">OrderBooks</a>&gt;(resource_address).map;
+    // Immutably borrow <a href="market.md#0xc0deb00c_market">market</a> order book.
+    <b>let</b> order_book_ref = <a href="tablist.md#0xc0deb00c_tablist_borrow">tablist::borrow</a>(
+        order_books_map_ref, market_id);
     // Get order ID side.
     <b>let</b> side = <a href="market.md#0xc0deb00c_market_get_posted_order_id_side">get_posted_order_id_side</a>(order_id);
     // Get open orders for given side.
-    <b>let</b> orders_ref_mut = <b>if</b> (side == <a href="market.md#0xc0deb00c_market_ASK">ASK</a>) &<b>mut</b> order_book_ref_mut.asks <b>else</b>
-        &<b>mut</b> order_book_ref_mut.bids;
+    <b>let</b> orders_ref = <b>if</b> (side == <a href="market.md#0xc0deb00c_market_ASK">ASK</a>) &order_book_ref.asks <b>else</b>
+        &order_book_ref.bids;
     <b>let</b> avlq_access_key = // Get AVL queue access key.
         <a href="market.md#0xc0deb00c_market_get_order_id_avl_queue_access_key">get_order_id_avl_queue_access_key</a>(order_id);
-    // Remove and unpack order <b>with</b> given access key, discarding
-    // order access key.
-    <b>let</b> <a href="market.md#0xc0deb00c_market_Order">Order</a>{size, price, <a href="user.md#0xc0deb00c_user">user</a>, custodian_id, order_access_key: _} =
-        <a href="avl_queue.md#0xc0deb00c_avl_queue_remove">avl_queue::remove</a>(orders_ref_mut, avlq_access_key);
+    // Immutably borrow order <b>with</b> given access key.
+    <b>let</b> order_ref = <a href="avl_queue.md#0xc0deb00c_avl_queue_borrow">avl_queue::borrow</a>(orders_ref, avlq_access_key);
     // Pack and <b>return</b> an order view in an <a href="">option</a>.
-    <a href="_some">option::some</a>(<a href="market.md#0xc0deb00c_market_OrderView">OrderView</a>{market_id, side, order_id, remaining_size: size,
-                           price, <a href="user.md#0xc0deb00c_user">user</a>, custodian_id})
+    <a href="_some">option::some</a>(<a href="market.md#0xc0deb00c_market_OrderView">OrderView</a>{
+        market_id,
+        side,
+        order_id,
+        remaining_size: order_ref.size,
+        price: order_ref.price,
+        <a href="user.md#0xc0deb00c_user">user</a>: order_ref.<a href="user.md#0xc0deb00c_user">user</a>,
+        custodian_id: order_ref.custodian_id})
 }
 </code></pre>
 

--- a/src/move/econia/sources/incentives.move
+++ b/src/move/econia/sources/incentives.move
@@ -566,17 +566,17 @@ module econia::incentives {
         IncentiveParameters,
         IntegratorFeeStores
     {
-        // Borrow mutable reference to integrator fee stores map for
-        // given quote coin type.
-        let integrator_fee_stores_map_ref_mut =
-            &mut borrow_global_mut<IntegratorFeeStores<QuoteCoinType>>(
+        // Immutably borrow integrator fee stores map for given quote
+        // coin type.
+        let integrator_fee_stores_map_ref =
+            &borrow_global<IntegratorFeeStores<QuoteCoinType>>(
                 integrator_address).map;
-        // Borrow mutable reference to corresponding integrator fee
-        // store for given market ID.
-        let integrator_fee_store_ref_mut = tablist::borrow_mut(
-            integrator_fee_stores_map_ref_mut, market_id);
+        // Immutalbly borrow corresponding integrator fee store for
+        // given market ID.
+        let integrator_fee_store_ref = tablist::borrow(
+            integrator_fee_stores_map_ref, market_id);
         // Get current tier number.
-        let current_tier = integrator_fee_store_ref_mut.tier;
+        let current_tier = integrator_fee_store_ref.tier;
         // Assert actually attempting to upgrade to new tier.
         assert!(new_tier > current_tier, E_NOT_AN_UPGRADE);
         // Get cumulative activation fee for current tier.

--- a/src/move/econia/sources/incentives.move
+++ b/src/move/econia/sources/incentives.move
@@ -571,7 +571,7 @@ module econia::incentives {
         let integrator_fee_stores_map_ref =
             &borrow_global<IntegratorFeeStores<QuoteCoinType>>(
                 integrator_address).map;
-        // Immutalbly borrow corresponding integrator fee store for
+        // Immutably borrow corresponding integrator fee store for
         // given market ID.
         let integrator_fee_store_ref = tablist::borrow(
             integrator_fee_stores_map_ref, market_id);

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -4401,7 +4401,7 @@ module econia::market {
         market_id: u64
     ): vector<CancelOrderEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_test(market_id).
                 cancel_order_events))
     }
@@ -4413,7 +4413,7 @@ module econia::market {
         swapper: address
     ): vector<CancelOrderEvent>
     acquires SwapperEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_swapper_event_handles_for_market_test(market_id, swapper).
                 cancel_order_events))
     }
@@ -4425,7 +4425,7 @@ module econia::market {
         swapper: address
     ): vector<FillEvent>
     acquires SwapperEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_swapper_event_handles_for_market_test(market_id, swapper).
                 fill_events))
     }
@@ -4436,7 +4436,7 @@ module econia::market {
         market_id: u64
     ): vector<PlaceSwapOrderEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_test(market_id).
                 place_swap_order_events))
     }
@@ -4448,7 +4448,7 @@ module econia::market {
         swapper: address
     ): vector<PlaceSwapOrderEvent>
     acquires SwapperEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_swapper_event_handles_for_market_test(market_id, swapper).
                 place_swap_order_events))
     }

--- a/src/move/econia/sources/registry.move
+++ b/src/move/econia/sources/registry.move
@@ -2481,7 +2481,7 @@ module econia::registry {
         assert!(get_market_id_base_coin<BC, QC>(
                     lot_size_2, tick_size_2, min_size_2) == option::none(), 0);
         // Assert events.
-        let market_registration_events = event::emitted_events(
+        let market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
         assert!(market_registration_events == vector[], 0);
         // Register markets.
@@ -2491,7 +2491,7 @@ module econia::registry {
         register_market_base_coin_internal<BC, QC, UC>(
             lot_size_2, tick_size_2, min_size_2, assets::mint_test(fee));
         // Assert events.
-        market_registration_events = event::emitted_events(
+        market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
         assert!(market_registration_events == vector[
             MarketRegistrationEvent{
@@ -2541,14 +2541,14 @@ module econia::registry {
         // Drop underwriter capability.
         drop_underwriter_capability_test(underwriter_capability);
         // Assert events.
-        let recognized_market_events = event::emitted_events(
+        let recognized_market_events = event::emitted_events_by_handle(
             &borrow_global<RecognizedMarkets>(@econia).
             recognized_market_events);
         assert!(recognized_market_events == vector[], 0);
         // Set both as recognized markets.
         set_recognized_markets(econia, vector[1, 2]);
         // Assert events.
-        recognized_market_events = event::emitted_events(
+        recognized_market_events = event::emitted_events_by_handle(
             &borrow_global<RecognizedMarkets>(@econia).
             recognized_market_events);
         assert!(recognized_market_events == vector[
@@ -2642,7 +2642,7 @@ module econia::registry {
         // Remove both recognized markets.
         remove_recognized_markets(econia, vector[1, 2]);
         // Assert events.
-        recognized_market_events = event::emitted_events(
+        recognized_market_events = event::emitted_events_by_handle(
             &borrow_global<RecognizedMarkets>(@econia).
             recognized_market_events);
         assert!(vector::length(&recognized_market_events) == 4, 0);
@@ -2691,7 +2691,7 @@ module econia::registry {
             underwriter_id: NO_UNDERWRITER
         }, 0);
         // Assert events.
-        market_registration_events = event::emitted_events(
+        market_registration_events = event::emitted_events_by_handle(
             &borrow_global<Registry>(@econia).market_registration_events);
         assert!(vector::length(&market_registration_events) == 3, 0);
         assert!(vector::pop_back(&mut market_registration_events) ==
@@ -2705,7 +2705,7 @@ module econia::registry {
                 min_size: min_size_3,
                 underwriter_id: NO_UNDERWRITER
             }, 0);
-        recognized_market_events = event::emitted_events(
+        recognized_market_events = event::emitted_events_by_handle(
             &borrow_global<RecognizedMarkets>(@econia).
             recognized_market_events);
         assert!(vector::length(&recognized_market_events) == 5, 0);
@@ -2727,7 +2727,7 @@ module econia::registry {
         // Set the second market as the recognized market, thus removing
         // the third market as recognized, and assert event.
         set_recognized_markets(econia, vector[2]);
-        recognized_market_events = event::emitted_events(
+        recognized_market_events = event::emitted_events_by_handle(
             &borrow_global<RecognizedMarkets>(@econia).
             recognized_market_events);
         assert!(vector::length(&recognized_market_events) == 6, 0);

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -3406,7 +3406,7 @@ module econia::user {
         custodian_id: u64
     ): vector<CancelOrderEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 cancel_order_events))
@@ -3420,7 +3420,7 @@ module econia::user {
         custodian_id: u64
     ): vector<ChangeOrderSizeEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 change_order_size_events))
@@ -3466,7 +3466,7 @@ module econia::user {
         custodian_id: u64
     ): vector<FillEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 fill_events))
@@ -3558,7 +3558,7 @@ module econia::user {
         custodian_id: u64
     ): vector<PlaceLimitOrderEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 place_limit_order_events))
@@ -3572,7 +3572,7 @@ module econia::user {
         custodian_id: u64
     ): vector<PlaceMarketOrderEvent>
     acquires MarketEventHandles {
-        event::emitted_events(
+        event::emitted_events_by_handle(
             &(borrow_market_event_handles_for_market_account_test(
                 market_id, user, custodian_id).
                 place_market_order_events))


### PR DESCRIPTION
@chen-robert

This PR removes unnecessary mutable borrows in view functions.

Note that https://github.com/aptos-labs/aptos-core/pull/9369 changed an event unit testing function signature, and so tests are updated here to enable a test run.

All tests pass.