### PR TITLE
[ECO-379] Check order price field against lookup key

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -6,7 +6,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 
 ### Added
 
-- Assorted view functions ([#287], [#301], [#308], [#321], [#334], [#428]).
+- Assorted view functions ([#287], [#301], [#308], [#321], [#334], [#428], [#429]).
 - Assorted user- and market-level events with common order ID ([#321], [#347], [#360], [#366], [#428]).
 - Authors field on manifest ([#380]).
 
@@ -43,6 +43,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#368]: https://github.com/econia-labs/econia/pull/368
 [#380]: https://github.com/econia-labs/econia/pull/380
 [#428]: https://github.com/econia-labs/econia/pull/428
+[#429]: https://github.com/econia-labs/econia/pull/429
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [unreleased]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...HEAD

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -17,5 +17,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, since
 # event unit tests for this package were added before Aptos' event unit
 # testing framework was incorporated into the `mainnet` branch.
-rev = "main"
+rev = "mainnet"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -17,5 +17,5 @@ git = "https://github.com/aptos-labs/aptos-core.git"
 # You may need to change this to `main` to run event unit tests, since
 # event unit tests for this package were added before Aptos' event unit
 # testing framework was incorporated into the `mainnet` branch.
-rev = "mainnet"
+rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/econia/doc/market.md
+++ b/src/move/econia/doc/market.md
@@ -2216,6 +2216,16 @@ Order ID corresponds to an order that did not post.
 
 
 
+<a name="0xc0deb00c_market_E_ORDER_PRICE_MISMATCH"></a>
+
+Order price field does not match AVL queue insertion key price.
+
+
+<pre><code><b>const</b> <a href="market.md#0xc0deb00c_market_E_ORDER_PRICE_MISMATCH">E_ORDER_PRICE_MISMATCH</a>: u64 = 32;
+</code></pre>
+
+
+
 <a name="0xc0deb00c_market_E_POST_OR_ABORT_CROSSES_SPREAD"></a>
 
 Post-or-abort limit order price crosses spread.
@@ -5583,6 +5593,7 @@ book.
 
 
 * <code>test_get_price_levels()</code>
+* <code>test_get_price_levels_mismatch()</code>
 
 
 <pre><code><b>fun</b> <a href="market.md#0xc0deb00c_market_get_price_levels_for_side">get_price_levels_for_side</a>(order_book_ref_mut: &<b>mut</b> <a href="market.md#0xc0deb00c_market_OrderBook">market::OrderBook</a>, side: bool, n_price_levels_max: u64): <a href="">vector</a>&lt;<a href="market.md#0xc0deb00c_market_PriceLevel">market::PriceLevel</a>&gt;
@@ -5617,10 +5628,16 @@ book.
                 // If order at head of the queue is in price level:
                 <b>if</b> (<a href="_contains">option::contains</a>(
                         &<a href="avl_queue.md#0xc0deb00c_avl_queue_get_head_key">avl_queue::get_head_key</a>(avlq_ref_mut), &price)) {
-                    // Pop order, storing only its size.
-                    <b>let</b> <a href="market.md#0xc0deb00c_market_Order">Order</a>{size: order_size, price: _, <a href="user.md#0xc0deb00c_user">user</a>: _,
-                              custodian_id: _, order_access_key: _} =
-                        <a href="avl_queue.md#0xc0deb00c_avl_queue_pop_head">avl_queue::pop_head</a>(avlq_ref_mut);
+                    // Pop order, storing only its size and price.
+                    <b>let</b> <a href="market.md#0xc0deb00c_market_Order">Order</a>{
+                        size: order_size,
+                        price: order_price,
+                        <a href="user.md#0xc0deb00c_user">user</a>: _,
+                        custodian_id: _,
+                        order_access_key: _
+                    } = <a href="avl_queue.md#0xc0deb00c_avl_queue_pop_head">avl_queue::pop_head</a>(avlq_ref_mut);
+                    // Verify order price equals insertion key.
+                    <b>assert</b>!(order_price == price, <a href="market.md#0xc0deb00c_market_E_ORDER_PRICE_MISMATCH">E_ORDER_PRICE_MISMATCH</a>);
                     // Increment tracker for price level size. Note
                     // that no overflow is checked because an open
                     // order's size is a u64, and an AVL queue can


### PR DESCRIPTION
@chen-robert

This PR adds a check for an order's price field against its corresponding AVL queue insertion key, during price level computation.

A failure test is included.

This PR is branched from #428, and should be merged after it merges