### PR TITLE
[ECO-343] Add local testnet dockerfile for e2e testing

### DIFF
--- a/src/rust/e2e/local-testnet/Dockerfile
+++ b/src/rust/e2e/local-testnet/Dockerfile
@@ -1,0 +1,5 @@
+FROM homebrew/brew:latest
+
+RUN brew install aptos
+
+CMD aptos node run-local-testnet --with-faucet

--- a/src/rust/e2e/local-testnet/README.md
+++ b/src/rust/e2e/local-testnet/README.md
@@ -1,0 +1,34 @@
+# About
+
+This Dockerfile uses `brew` to install the `aptos` CLI in a simple image.
+Once you've built the image, you can use it to run a container with a fresh local testnet.
+
+# Build image
+
+```bash
+docker build --tag aptos-cli .
+```
+
+# Run container
+
+```bash
+docker run \
+    --name local-testnet \
+    --publish 8080:8080 \
+    --publish 8081:8081 \
+    aptos-cli
+```
+
+# Connect to the testnet
+
+Once the testnet and faucet have started up, you can access the testnet REST API on port 8080 and the faucet on port 8081:
+
+```bash
+aptos init --profile local --rest-url http://localhost:8080 --faucet-url http://localhost:8081
+```
+
+# Stop the local testnet
+
+```bash
+docker stop local-testnet
+```


### PR DESCRIPTION
This PR adds a local testnet dockerfile for e2e testing, with a README.

I tried installing via CLI script before settling on the `brew` install methodt: https://aptos.dev/tools/aptos-cli/install-cli/automated-install/

The script install method ended up throwing errors about the environment platform, and forced me to use a `--platform` specification during the build phase. I had difficulties trying to modify the path in the image after the scripted install, so I settled on the brew methodology here, which essentially works out of the box albeit with longer build times and an image that is larger than it has to be.

An alternative version of this Dockerimage would involve a `--release` cargo build of the Aptos CLI from source from within the container, such that only the platform-specific binary file ends up in the image. However this would involve more steps and would likely still involve longer build times. 

Given that this local testnet is only for e2e testing, I am not concerned with the potential performance disadvantages that may come with a brew install inside of an emulated environment (Docker container)