### PR TITLE
[ECO-371] Update rust CI configuration

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,22 +2,14 @@ name: Rust CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
-      - "src/rust/api/**"
-      - "src/rust/db/**"
-      - "src/rust/types/**"
-      - "src/rust/Cargo.toml"
-      - "src/rust/Cargo.lock"
+      - "src/rust/**"
 
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
-      - "src/rust/api/**"
-      - "src/rust/db/**"
-      - "src/rust/types/**"
-      - "src/rust/Cargo.toml"
-      - "src/rust/Cargo.lock"
+      - "src/rust/**"
 
   workflow_dispatch:
 
@@ -48,21 +40,37 @@ jobs:
           prefix-key: "rustci"
           shared-key: "ci"
 
-      - name: Rustfmt
-        run: cargo fmt --check
+      - uses: actions-rs/cargo@v1
+        name: Check formatting
+        with:
+          command: fmt --check --all-features --all-targets
 
-      - name: Cargo sort
-        run: cargo install cargo-sort && cargo sort --grouped --check --workspace
+      - uses: actions-rs/cargo@v1
+        name: Install cargo-sort
+        with:
+          command: install cargo-sort
 
-      - name: Check
-        run: cargo check --all-features --all-targets
+      - uses: actions-rs/cargo@v1
+        name: Check with cargo-sort
+        with:
+          command: sort --grouped --check --workspace
 
-      - name: Clippy
-        run: cargo clippy --all-features --all-targets
+      - uses: actions-rs/cargo@v1
+        name: Check
+        with:
+          command: check --all-features --all-targets
 
-      - name: Build
-        run: cargo build --all-features --all-targets
+      - uses: actions-rs/cargo@v1
+        name: Clippy
+        with:
+          command: clippy --all-features --all-targets
 
-      - name: Run tests
-        run: cargo test --all-features --all-targets
+      - uses: actions-rs/cargo@v1
+        name: Build
+        with:
+          command: build --all-features --all-targets
 
+      - uses: actions-rs/cargo@v1
+        name: Test
+        with:
+          command: test --all-features --all-targets


### PR DESCRIPTION
- Use `actions-rs/cargo`
- Update outdated branch name that made the CI not trigger