### PR TITLE
[ECO-384] Add new decimal helpers to Python SDK

### DIFF
--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -139,7 +139,7 @@ So, our market parameters would be:
 
 This gives us a market with a price granularity of 0.1 cent and minimum order size of 0.5 `eAPT`!
 We'd get an error if we tried to use a more granular price, or more granular size without changing price granularity.
-This is because our tick size is 1, which represents the minimum--the highest possible granularity of the quote asset.
+This is because our tick size is 1, which represents the most possible price precision for the given size and the highest possible granularity of the quote asset.
 
 ## `examples.trade`
 

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -82,12 +82,12 @@ Market configuration (beyond base type and quote type) consists of 3 integer val
 
 In order to proceed, we must decide the granularity of base and quote sizes as well as the minimum limit order size for our market.
 Consider that "price" in the exchange is an integer expressed in terms of "ticks per lot", which means that tick size and lot size affect the prices that can be expressed.
-That is: price granularity is a function of lot size _and_ tick size.
+**That is: price granularity is a function of lot size _and_ tick size.**
 In general the desire is to have one _tick_ be "small" relative to one **_lot_** in terms of value, since the minimum expressible price is 1 tick per lot. The second smallest possible price is 2 ticks per lot, and so on.
 Let's use `eAPT` and `eUSDC` used in the faucet below as example base and quote types, respectively, for a market.
 We know that `eAPT` (the base type) has 8 decimals and `eUSDC` (the quote type) has 6 decimals:
 
-```
+```python
 >>> base_decimals = 8
 >>> quote_decimals = 6
 ```
@@ -97,8 +97,10 @@ Let's try using 0.001 `eAPT` for the granularity of base coin sizes, and 0.01 `e
 Does this work?
 Let's find out!
 
-```
->>> get_min_quote_per_base_nominal("0.001", "0.01")
+```python
+>>> lot_size_unit = "0.001"
+>>> tick_size_unit = "0.01"
+>>> get_min_quote_per_base_nominal(lot_size_unit, tick_size_unit)
 10.0
 ```
 
@@ -106,11 +108,23 @@ Here, we're asking what the smallest representable price for 1 `eAPT` is in term
 
 There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 1 tick per lot.
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
-The granularity of price in human terms is $10 per `eAPT`.
-That is, the minimum price is $10/`eAPT`, the second-lowest expressible price is $20/`eAPT`, and so on.
+The granularity of price in human terms is \$10 per `eAPT`.
+That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is \$20/`eAPT`, and so on.
 Given that (real) `APT` is right now $7, we can assess that this configuration would not be workable or appropriate!
 
-The problem is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
+Note that if you have a price granularity and lot size in mind, `get_tick_size_integer_for_price_granularity` can be used to determine a tick size.
+For example, we could choose a price granularity of 0.01 `USDC` (one penny) and the lot size from above:
+```python
+>>> get_tick_size_integer_for_price_granularity( \
+  lot_size_unit, \
+  "0.01", \
+  quote_decimals, \
+)
+10
+```
+
+This is useful, but let's proceed with the manual approach because it will explain to us better what lot size and tick size mean and how they relate to price granularity.
+Our problem (price too coarse) is fixable by using a more granular tick size, say 0.00001 instead of 0.01.
 Checking our price granularity now shows better results:
 
 ```
@@ -120,7 +134,7 @@ Checking our price granularity now shows better results:
 42949672.95
 ```
 
-That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is $1.
+That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is \$1.
 For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's $42,949,672.95 per `eAPT` so this is fine!
 Be careful: using a more granular price results in a lower maximum price, which may be relevant in some cases.
 Now that we have the minimum base and quote sizes we'd like to use, we're ready to configure the market.

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -110,10 +110,11 @@ There are 1000 lots in 1 `eAPT` (=1/0.001) and the minimum expressible price is 
 Since 1 tick is worth 1 cent, this means that the minimum representable price for 1000 lots (1 `eAPT`) is 1000 ticks, or 10 `eUSDC`.
 The granularity of price in human terms is \$10 per `eAPT`.
 That is, the minimum price is \$10/`eAPT`, the second-lowest expressible price is \$20/`eAPT`, and so on.
-Given that (real) `APT` is right now $7, we can assess that this configuration would not be workable or appropriate!
+Given that (real) `APT` is right now \$7, we can assess that this configuration would not be workable or appropriate!
 
 Note that if you have a price granularity and lot size in mind, `get_tick_size_integer_for_price_granularity` can be used to determine a tick size.
 For example, we could choose a price granularity of 0.01 `USDC` (one penny) and the lot size from above:
+
 ```python
 >>> get_tick_size_integer_for_price_granularity( \
   lot_size_unit, \
@@ -135,7 +136,7 @@ Checking our price granularity now shows better results:
 ```
 
 That's a price granularity of 1 cent, since the result here is in quote units and 1 `eUSDC` is \$1.
-For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's $42,949,672.95 per `eAPT` so this is fine!
+For good measure, we also checked the maximum price per `eAPT` using `get_max_quote_per_base_nominal`; it's \$42,949,672.95 per `eAPT` so this is fine!
 Be careful: using a more granular price results in a lower maximum price, which may be relevant in some cases.
 Now that we have the minimum base and quote sizes we'd like to use, we're ready to configure the market.
 Let's get the lot size and tick size:

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -278,6 +278,7 @@ python3
 >>> from econia_sdk.utils.decimals import *
 ```
 
+Take a look at the code [here] to see what's available in that package.
 We'd like the value of one increment in order size to be worth about a penny, say \$0.00732.
 That means our lot size (in unit terms) should be 0.001 `APT`, which is worth said amount.
 To get the lot size in subunit terms so as to configure the market, we can use the SDK:
@@ -298,6 +299,19 @@ Let's now get that in subunit terms using the SDK:
 >>> tick_size_unit = "0.00001"
 >>> quote_decimals = 6
 >>> get_tick_size_integer(tick_size_unit, quote_decimals)
+10
+```
+
+Note that we can also get the same result by coming up with a price granularity target and using `get_tick_size_integer_for_price_granularity`.
+If we choose a price granularity of one penny (0.01 `USDC`) then the function call would be as follows:
+
+```python
+>>> price_granularity = "0.01"
+>>> get_tick_size_integer_for_price_granularity( \
+  lot_size_unit, \
+  price_granularity, \
+  quote_decimals \
+)
 10
 ```
 
@@ -654,6 +668,7 @@ Whether in a [`MarketAccount`] or an [`OrderBook`], the inactive node stack appr
 [avl queue height spec]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/avl_queue.md#height
 [market module documentation]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md
 [`critical_height`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#0xc0deb00c_market_CRITICAL_HEIGHT
+[here]: https://github.com/econia-labs/econia/blob/main/src/python/sdk/econia_sdk/utils/decimals.py
 [`market::order`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/market.md#0xc0deb00c_market_Order
 [`marketaccount`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/user.md#0xc0deb00c_user_MarketAccount
 [`n_nodes_max`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/avl_queue.md#0xc0deb00c_avl_queue_N_NODES_MAX

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -666,9 +666,9 @@ Whether in a [`MarketAccount`] or an [`OrderBook`], the inactive node stack appr
 
 [avl queue]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/avl_queue.md
 [avl queue height spec]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/avl_queue.md#height
+[here]: https://github.com/econia-labs/econia/blob/main/src/python/sdk/econia_sdk/utils/decimals.py
 [market module documentation]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md
 [`critical_height`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#0xc0deb00c_market_CRITICAL_HEIGHT
-[here]: https://github.com/econia-labs/econia/blob/main/src/python/sdk/econia_sdk/utils/decimals.py
 [`market::order`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/market.md#0xc0deb00c_market_Order
 [`marketaccount`]: https://github.com/econia-labs/econia/tree/main/src/move/econia/doc/user.md#0xc0deb00c_user_MarketAccount
 [`n_nodes_max`]: https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/avl_queue.md#0xc0deb00c_avl_queue_N_NODES_MAX

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -261,7 +261,7 @@ Here, `APT` is considered the "base" asset and `USDC` is considered the "quote a
 | Quote asset | Order price | `USDC` | 6             | \$1.00     |
 
 We'd like to find a market configuration that makes sense given the above economic state.
-Configuring a market requires three _integer_ values beyond the base and quote type:
+Configuring a market requires three _integer_ values beyond the base and quote type, since the Econia Move package uses only integer arithmetic:
 
 | Parameter          | Meaning                  | Units                      |
 | ------------------ | ------------------------ | -------------------------- |

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -261,7 +261,7 @@ Here, `APT` is considered the "base" asset and `USDC` is considered the "quote a
 | Quote asset | Order price | `USDC` | 6             | \$1.00     |
 
 We'd like to find a market configuration that makes sense given the above economic state.
-Configuring a market requires three values beyond the base and quote type:
+Configuring a market requires three _integer_ values beyond the base and quote type:
 
 | Parameter          | Meaning                  | Units                      |
 | ------------------ | ------------------------ | -------------------------- |
@@ -331,7 +331,7 @@ Since the two assets have almost the same nominal price, price granularity will 
 
 | Variable                | Value          |
 | ----------------------- | -------------- |
-| Nominal lot size        | 0.001 `sAPT`   |
+| Nominal size precision  | 0.001 `sAPT`   |
 | Nominal price precision | 0.000001 `APT` |
 | Nominal minimum size    | 0.5 `sAPT`     |
 | Base decimals           | 8              |
@@ -377,7 +377,7 @@ However we recall that the most granular possible price isn't necessarily desira
 Some coarseness is desirable for that reason, therefore the market creator might instead use less price granularity and choose to preserve size precision.
 Although it is possible for user interfaces to summarize orders into price levels that don't actually exist, this approach would represent to the user information that is not accurate, and is not recommended.
 
-Let's check the maximum price of this market, keeping in mind that it should revert to 1 since the assets have equal value:
+Let's check the maximum price of this market, keeping in mind that it should hover around 1 since the assets have almost the same value:
 
 ```python
 >>> get_max_price_nominal(price_precision_nominal)

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -250,7 +250,7 @@ One increment or decrement in order size should be a meaningful but not overwhel
 
 Let's create a market with these key properties in mind, and find a configuration that makes sense in light of these concerns.
 
-### Creating a hypothetical market
+### Creating hypothetical markets
 
 Consider a hypothetical trading pair `APT/USDC`, `APT` denominated in `USDC`.
 Here, `APT` is considered the "base" asset and `USDC` is considered the "quote asset", meaning that orders sized in `APT` are quoted in `USDC` per `APT`:
@@ -279,89 +279,41 @@ python3
 ```
 
 Take a look at the code [here] to see what's available in that package.
+
 We'd like the value of one increment in order size to be worth about a penny, say \$0.00732.
 That means our lot size (in unit terms) should be 0.001 `APT`, which is worth said amount.
-To get the lot size in subunit terms so as to configure the market, we can use the SDK:
+We'd also like the market to have a price granularity of one-tenth of a penny (0.001 `USDC`).
+Last, we'd like the market to have a minimum order size of 0.5 `APT` (worth \$3.66).
+We're given the base (`APT`) and quote (`USDC`) decimals: 8 and 6 respectively.
+
+The above configuration can be plugged into `get_market_parameters_integer` from the SDK to obtain the market configuration:
 
 ```python
->>> lot_size_unit = "0.001"
 >>> base_decimals = 8
->>> lot_size = get_lot_size_integer(lot_size_unit, base_decimals)
->>> lot_size
-100000
-```
-
-Now to configure the tick size; we know that this is the granularity in value of one lot, which is worth \$0.00732 per above.
-Therefore, we want a tick size of 0.00001 to achieve the lot value granularity required to express a price of \$0.00732 for one lot.
-Let's now get that in subunit terms using the SDK:
-
-```python
->>> tick_size_unit = "0.00001"
 >>> quote_decimals = 6
->>> get_tick_size_integer(tick_size_unit, quote_decimals)
-10
+>>> size_precision_nominal = "0.001"
+>>> price_precision_nominal = "0.001"
+>>> min_size_nominal = "0.5"
+>>> (lot_size, tick_size, min_size) = get_market_parameters_integer(
+... size_precision_nominal,
+... price_precision_nominal,
+... min_size_nominal,
+... base_decimals,
+... quote_decimals,
+... )
+>>> (lot_size, tick_size, min_size)
+(100000, 1, 500)
 ```
 
-Note that we can also get the same result by coming up with a price granularity target and using `get_tick_size_integer_for_price_granularity`.
-If we choose a price granularity of one penny (0.01 `USDC`) then the function call would be as follows:
+It's easy to tell if this is reasonable by checking the maximum price given our price precision.
 
 ```python
->>> price_granularity = "0.01"
->>> get_tick_size_integer_for_price_granularity( \
-  lot_size_unit, \
-  price_granularity, \
-  quote_decimals \
-)
-10
+>>> get_max_price_nominal(price_precision_nominal)
+Decimal('4294967.295')
 ```
 
-It's easy to tell if this lot size and tick size combination is reasonable by checking the minimum and maximum price under these conditions in nominal (unit) terms.
-Note that the minimum price is also equivalent to price granularity, which tells us the granularity of value for a whole unit of APT as opposed to just one lot (equal here to 100000 subunits of `APT`).
-Now, using the SDK:
-
-```python
->>> get_min_quote_per_base_nominal(lot_size_unit, tick_size_unit)
-0.01
->>> get_max_quote_per_base_nominal(lot_size_unit, tick_size_unit)
-42949672.95
-```
-
-It looks like our price granularity is one penny and our maximum price is plenty high: if we configure a market this way, it will support `APT` prices up to \$42M `USDC` per `APT`.
-Since the current price of `APT` is \$7.32, this price granularity might be too coarse for higher-frequency traders.
-It's a good thing we checked!
-Fixing this is easy enough: we could increase our lot size which would make our size granularity more coarse than we desire, or we could decrease our tick size by one order of magnitude:
-
-```python
->>> tick_size_unit_new = "0.000001"
->>> get_tick_size_integer(tick_size_unit_new, quote_decimals)
-1
-```
-
-Great!
-That just so happens to be the smallest possible tick size in this case.
-Now let's plug this tick size back into the minimum and maximum price formulas to check our work:
-
-```python
->>> get_min_quote_per_base_nominal(lot_size_unit, tick_size_unit_new)
-0.001
->>> get_max_quote_per_base_nominal(lot_size_unit, tick_size_unit_new)
-4294967.295
-```
-
-Notice the maximum price has gone down by one order of magnitude, but it's still plenty high: this market would support `APT` prices up to \$4.2M `USDC` per `APT`.
-We're almost done at this point: we just need a minimum order size.
-Let's require a minimum limit order value of 0.5 `APT` (our base type), which has a market value of \$3.66 ($0.5 * \$7.32$).
-Using the SDK:
-
-```python
->>> get_min_size_integer("0.5", base_decimals, lot_size)
-500
-```
-
-Above is the minimum number of lots that a limit order must have before it can be placed.
-Remember that market orders can be of any size!
-We are done configuring the market now.
-These are our results:
+This means the maximum price for 1 `APT` in our market is \$4,294,967.295 which is plenty high.
+We are done configuring the market now, these are our results:
 
 | Parameter    | Units                | Value  | Meaning                  |
 | ------------ | -------------------- | ------ | ------------------------ |
@@ -369,172 +321,70 @@ These are our results:
 | Tick size    | Subunits (of `USDC`) | 1      | Lot value granularity    |
 | Minimum size | Lots (of `APT`)      | 500    | Minimum limit order lots |
 
-Always remember to check the minimum and maximum price of your configuration to ensure adequate price granularity and room for movement both upwards and downwards!
-
-### Noteworthy examples
-
-Consider the trading pair `wBTC/USDC`:
-as of the time of this writing, one `BTC` costs approximately 17792.27 `USD`, so initial choices for lot size and tick size might be:
-
-1. 0.00001 `wBTC` lot size (a value of 0.1779227 `USDC`).
-1. 0.01 `USDC` tick size.
-
-Notably, these choices yield a price granularity that's far too coarse (using the SDK from above):
-
-```python
->>> lot_size = "0.00001"
->>> tick_size = "0.01"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-1000.0
-```
-
-That means only prices that are a multiple of \$1000 can be expressed in this configuration.
-Thus a different combination must be chosen, for example, by decreasing decimal tick size by a factor of 1000:
-
-1. 0.00001 `wBTC` decimal lot size (a value of 0.1779227 `USDC`).
-1. 0.00001 `USDC` decimal tick size.
-
-Let's check the minimum and maximum expressible prices with this configuration:
-
-```python
->>> lot_size = "0.00001"
->>> tick_size = "0.00001" # changed by / 1000
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-1.0
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-4294967295.0
-```
-
-That's a minimum price (and price granularity) of \$1, as well as a maximum price that's plenty high.
-This could work; if a price granularity of one penny is desired, then lower the tick size by a further factor of 100:
-
-```python
->>> lot_size = "0.00001"
->>> tick_size = "0.0000001" # changed by / 1000 / 100
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-0.01
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-42949672.95
-```
-
-**...but wait a second!** `USDC` *has 6 decimals and above, we've used 7*.
-We can see that this tick size is problematic by using `get_tick_size_integer` from the SDK:
-
-```
->>> get_tick_size_integer("0.0000001", 6)
-Traceback (most recent call last):
-...
-ValueError: Decimal unit too small to represent with 1 subunit
-```
-
-Thus, holding lot size constant, the most price granularity possible is \$0.10 which corresponds to a tick size of 0.000001 `USDC` (the minimum possible) and lot size of 0.00001 `WBTC`.
-
-If we increase lot size by a factor of 10 to 0.0001 `WBTC` which corresponds to an order value granularity of \$1.779 instead of \$0.1779, and keep the above tick size, then we have a price granularity of one penny:
-
-```python
->>> lot_size = "0.0001" # changed by * 10
->>> tick_size = "0.000001"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-0.01
-```
-
-To finish, let's calculate the lot and tick sizes as well as a minimum size (worth \$5 of the base, `WBTC`) for this market:
-
-```python
->>> base_decimals = 9
->>> lot_size_decimal = "0.0001"
->>> quote_decimals = 6
->>> tick_size_decimal = "0.000001"
->>> lot_size = get_lot_size_integer(lot_size_decimal, base_decimals)
->>> lot_size
-100000
->>> tick_size = get_tick_size_integer(tick_size_decimal, quote_decimals)
->>> tick_size
-1
->>> min_size_float = 5/17792.27
->>> min_size_decimal = f"{min_size_float}"
->>> min_size = get_min_size_integer(min_size_decimal, base_decimals, lot_size)
->>> min_size
-3
-```
-
-Therefore our final market parameters are as follows:
-
-| Parameter    | Units                | Value  | Meaning                  |
-| ------------ | -------------------- | ------ | ------------------------ |
-| Lot size     | Subunits (of `WBTC`) | 100000 | Order size granularity   |
-| Tick size    | Subunits (of `USDC`) | 1      | Lot value granularity    |
-| Minimum size | Lots (of `WBTC`)     | 3      | Minimum limit order lots |
+Always remember to check the maximum price of your configuration to ensure adequate price granularity and room for movement both upwards and downwards!
+Note that price granularity is equivalent to the minimum price (in nominal terms) for a market.
 
 ______________________________________________________________________
 
 Next, consider a liquid staking derivative `sAPT` trading against `APT`, `sAPT/APT`, both having 8 decimals.
-Since the two assets have almost the same nominal price, price granularity will need to be higher here:
+Since the two assets have almost the same nominal price, price granularity will need to be much higher here.
 
-| Variable          | Value          |
-| ----------------- | -------------- |
-| Decimal lot size  | 0.01 `sAPT`    |
-| Decimal tick size | 0.000001 `APT` |
-| Base decimals     | 8              |
-| Quote decimals    | 8              |
+| Variable                | Value          |
+| ----------------------- | -------------- |
+| Nominal lot size        | 0.001 `sAPT`   |
+| Nominal price precision | 0.000001 `APT` |
+| Nominal minimum size    | 0.5 `sAPT`     |
+| Base decimals           | 8              |
+| Quote decimals          | 8              |
 
-Let's check the minimum and maximum price here using the SDK:
-
-```python
->>> lot_size = "0.01"
->>> tick_size = "0.000001"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-0.0001
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-429496.7295
-```
-
-This gives us a price precision of 1/100th of a penny, with room to go even more precise should we desire.
-However we recall that the most granular possible price isn't necessarily desirable due to almost every order then occupying its own price level, cluttering user interfaces.
-Some coarseness is desirable for that reason.
-Although it is possible for user interfaces to summarize orders into price levels that don't actually exist, this approach would represent to the user information that is not accurate, and is not recommended.
-Should we use the maximum precision of 0.00000001 `APT` then we observe that the maximum price lowers but remains high enough for this pair, where the assets have almost the same value:
-
-```python
->>> lot_size = "0.01"
->>> tick_size = "0.00000001"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-1e-06 # 0.000001
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-4294.967295
-```
-
-Last, let's calculate market parameters again using \$5 as our minimum order size:
+Let's check the market parameters using the SDK:
 
 ```python
 >>> base_decimals = 8
->>> lot_size_decimal = "0.01"
 >>> quote_decimals = 8
->>> tick_size_decimal = "0.00000001"
->>> lot_size = get_lot_size_integer(lot_size_decimal, base_decimals)
->>> lot_size
-1000000
->>> tick_size = get_tick_size_integer(tick_size_decimal, quote_decimals)
->>> tick_size
-1
->>> min_size_float = 5/7.23 # price of sAPT = $7.23
->>> min_size_decimal = f"{min_size_float}"
->>> get_min_size_integer(min_size_decimal, base_decimals, lot_size)
-70
+>>> size_precision_nominal = "0.001"
+>>> price_precision_nominal = "0.000001"
+>>> min_size_nominal = "0.5"
+>>> (lot_size, tick_size, min_size) = get_market_parameters_integer(
+... size_precision_nominal,
+... price_precision_nominal,
+... min_size_nominal,
+... base_decimals,
+... quote_decimals,
+... )
+...
+ValueError: The price is too granular given the size granularity.
 ```
 
-Thus our final market parameters are:
+It's possible for a price precision to be too granular because the minimum tick size is 1 subunit of quote.
+We have to choose between less price precision, or less size precision (the latter is illustrated below):
 
-| Parameter    | Units                | Value   | Meaning                  |
-| ------------ | -------------------- | ------- | ------------------------ |
-| Lot size     | Subunits (of `sAPT`) | 1000000 | Order size granularity   |
-| Tick size    | Subunits (of `APT`)  | 1       | Lot value granularity    |
-| Minimum size | Lots (of `sAPT`)     | 70      | Minimum limit order lots |
+```python
+>>> size_precision_nominal = "0.01" # more coarse by an order of magnitude
+>>> (lot_size, tick_size, min_size) = get_market_parameters_integer(
+... size_precision_nominal,
+... price_precision_nominal,
+... min_size_nominal,
+... base_decimals,
+... quote_decimals
+... )
+>>> (lot_size, tick_size, min_size)
+(1000000, 1, 50)
+```
 
-______________________________________________________________________
+This gives us a price precision of 1/10000th of a penny, with no room to go more precise should we desire.
+However we recall that the most granular possible price isn't necessarily desirable due to almost every order then occupying its own price level, cluttering user interfaces.
+Some coarseness is desirable for that reason, therefore the market creator might instead use less price granularity and choose to preserve size precision.
+Although it is possible for user interfaces to summarize orders into price levels that don't actually exist, this approach would represent to the user information that is not accurate, and is not recommended.
 
-Last, consider `wBTC` trading against a hypothetical stable coin `USDX` with 10 decimals: `wBTC/USDX`.
-Here, a market registrant may again opt for high price precision, but if they specify too much, they may not be able to encode the corresponding integer price in 32 bits:
+Let's check the maximum price of this market, keeping in mind that it should revert to 1 since the assets have equal value:
+
+```python
+>>> get_max_price_nominal(price_precision_nominal)
+Decimal('4294.967295')
+```
+
+Always remember to check the maximum price for a given price precision before using it to register a market.
 
 :::tip
 
@@ -542,73 +392,14 @@ Prices in Econia are represented as 32-bit integers, such that the maximum possi
 
 :::
 
-| Variable                | Value                          |
-| ----------------------- | ------------------------------ |
-| Decimal lot size        | 0.0001 `wBTC`                  |
-| Quote asset decimals    | 10                             |
-| Decimal tick size       | 0.0000000001 `USDX` per `wBTC` |
-| Decimal price           | 17792.280012 `USDX` per `wBTC` |
-| Order value granularity | \$1.779                        |
+That would be a maximum price of 4294.967295 `sAPT` per `APT`, which is plenty high.
+Thus our final market parameters are:
 
-```python
->>> lot_size = "0.0001"
->>> tick_size = "0.0000000001"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-1e-06 # 0.000001
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-4294.967295
-```
-
-Observe that the maximum expressible price under the above conditions is less than the current price, and that the price granularity is far too granular.
-Tick size can be increased by a factor of 10000 such that the current (and future) price fits into a 32-bit integer:
-
-```python
->>> lot_size = "0.0001"
->>> tick_size = "0.000001" # changed by * 10000
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-0.01
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-42949672.95
-```
-
-Notice that price granularity has become more coarse as a result of this change, which was desirable.
-Another option would have been to decrease lot size by a factor of 10000:
-
-```python
->>> lot_size = "0.00000001" # changed by / 10000
->>> tick_size = "0.0000000001"
->>> get_min_quote_per_base_nominal(lot_size, tick_size)
-0.01
->>> get_max_quote_per_base_nominal(lot_size, tick_size)
-42949672.95
-```
-
-Last and finally, let's calculate market parameters using a \$5 minimum order size using the lot and tick sizes immediately above:
-
-```python
->>> base_decimals = 9
->>> lot_size_decimal = "0.00000001"
->>> quote_decimals = 10
->>> tick_size_decimal = "0.0000000001"
->>> lot_size = get_lot_size_integer(lot_size_decimal, base_decimals)
->>> lot_size
-10
->>> tick_size = get_tick_size_integer(tick_size_decimal, quote_decimals)
->>> tick_size
-1
->>> min_size_float = 5/17792.27 # price of WBTC = $17792.27
->>> min_size_decimal = f"{min_size_float}"
->>> get_min_size_integer(min_size_decimal, base_decimals, lot_size)
-28103
-```
-
-In summary, these market parameters are:
-
-| Parameter    | Units                | Value | Meaning                  |
-| ------------ | -------------------- | ----- | ------------------------ |
-| Lot size     | Subunits (of `WBTC`) | 10    | Order size granularity   |
-| Tick size    | Subunits (of `USDX`) | 1     | Lot value granularity    |
-| Minimum size | Lots (of `WBTC`)     | 28103 | Minimum limit order lots |
+| Parameter    | Units                | Value   | Meaning                  |
+| ------------ | -------------------- | ------- | ------------------------ |
+| Lot size     | Subunits (of `sAPT`) | 1000000 | Order size granularity   |
+| Tick size    | Subunits (of `APT`)  | 1       | Lot value granularity    |
+| Minimum size | Lots (of `sAPT`)     | 50      | Minimum limit order lots |
 
 ## Adversarial considerations
 

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -1,5 +1,6 @@
 import math
 from decimal import Decimal
+from typing import Tuple
 
 
 def _verify_decimal_input(decimal_input: str):
@@ -12,7 +13,7 @@ def _verify_integer_input(integer_input: int):
         raise ValueError("Integer input should be an integer")
 
 
-def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
+def get_lot_size_integer(smallest_base_unit: str, base_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the lot size.
@@ -23,16 +24,16 @@ def get_lot_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
-    _verify_decimal_input(smallest_decimal_unit)
-    _verify_integer_input(coin_decimals)
-    smallest_decimal = Decimal(smallest_decimal_unit)
-    smallest_subunits = 10 ** (coin_decimals + math.log10(smallest_decimal))
+    _verify_decimal_input(smallest_base_unit)
+    _verify_integer_input(base_decimals)
+    smallest_decimal = Decimal(smallest_base_unit)
+    smallest_subunits = 10 ** (base_decimals + math.log10(smallest_decimal))
     if smallest_subunits < 1:
         raise ValueError("Decimal unit too small to represent with 1 subunit")
     return math.ceil(smallest_subunits)
 
 
-def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int:
+def get_tick_size_integer(smallest_quote_unit: str, quote_decimals: int) -> int:
     """
     Given a decimal representation of the smallest possible unit and the
     whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
@@ -43,7 +44,110 @@ def get_tick_size_integer(smallest_decimal_unit: str, coin_decimals: int) -> int
     * `coin_decimals`: The number of decimals one whole unit of the coin
       has (e.g. USDC has 6 decimals, ETH has 18).
     """
-    return get_lot_size_integer(smallest_decimal_unit, coin_decimals)
+    return get_lot_size_integer(smallest_quote_unit, quote_decimals)
+
+
+def get_tick_size_integer_for_price_granularity(
+    size_precision_nominal: str,
+    price_precision_nominal: str,
+    quote_decimals: int,
+) -> int:
+    """
+    Returns the tick size integer to achieve a price precision given a size
+    granularity, both in nominal terms.
+
+    Parameters:
+    * `size_precision_nominal`: Decimal (e.g. "0.001" for one thousandth) of
+      the smallest possible size (of base) relative to a whole unit.
+    * `price_precision_nominal`: The ratio of quote per base by which price
+      is incremented and/or decremented (e.g. "0.01" USD/BTC expresses a
+      price granularity of one penny).
+    * `base decimals`: The number of decimals in the base for conversion to
+       integer subunit terms.
+    """
+    _verify_decimal_input(size_precision_nominal)
+    _verify_decimal_input(price_precision_nominal)
+    _verify_integer_input(quote_decimals)
+    tick_size = Decimal(price_precision_nominal) \
+      * Decimal(size_precision_nominal) \
+      * (10 ** quote_decimals)
+    if tick_size < 1:
+        raise ValueError("The price is too granular")
+    return math.ceil(tick_size)
+
+
+def get_market_parameters_nominal(
+    lot_size_integer: int,
+    tick_size_integer: int,
+    min_size_integer: int,
+    base_decimals: int,
+    quote_decimals: int,
+) -> Tuple[float, float, float]:
+    """
+    Returns the tuple of market parameters in nominal terms, rather than integer
+    terms, given the three parameters as integers plus base and quote decimals.
+
+    Parameters:
+    * `lot_size_integer`: The size granularity in terms of base subunits.
+    * `tick_size_integer`: The tick granularity in terms of quote subunits.
+    * `min_size_integer`: The minimum size in terms of lots of base.
+    * `base_decimals`: The number of decimals in the nominal base unit.
+    * `quote_decimals`: The number of decimals in the nominal quote unit.
+    """
+    _verify_integer_input(lot_size_integer)
+    _verify_integer_input(tick_size_integer)
+    _verify_integer_input(min_size_integer)
+    _verify_integer_input(base_decimals)
+    _verify_integer_input(quote_decimals)
+    lot_size_nominal = lot_size_integer / (10 ** base_decimals)
+    tick_size_nominal = tick_size_integer / (10 ** quote_decimals)
+    min_size_nominal = (min_size_integer * lot_size_integer) / (10 ** base_decimals)
+    return (lot_size_nominal, tick_size_nominal, min_size_nominal)
+
+
+def get_price_integer(
+    nominal_price: str,
+    lot_size: int,
+    tick_size: int,
+    base_decimals: int,
+    quote_decimals: int,
+  ) -> int:
+    """
+    Returns the "ticks per lot" price given a nominal price and other configuration variables.
+
+    Parameters:
+    * `nominal_price`: The price of one nominal unit of base in terms of nominal quote units.
+    * `lot_size`: The subunits of base that make up one lot.
+    * `tick_size`: The subunits of quote that make up one tick.
+    * `base_decimals`: The number of decimals in one nominal unit of base.
+    * `quote_decimals`: The number of decimals in one nominal unit of quote.
+    """
+    _verify_decimal_input(nominal_price)
+    _verify_integer_input(lot_size)
+    _verify_integer_input(tick_size)
+    _verify_integer_input(base_decimals)
+    _verify_integer_input(quote_decimals)
+    result = Decimal(nominal_price) * Decimal((10 ** quote_decimals) / (10 ** base_decimals))
+    result = result * Decimal((1 / tick_size) / (1 / lot_size))
+    result_floor = math.floor(result)
+    result_ceil = math.ceil(result)
+    if (result_floor != result_ceil):
+        raise ValueError("The price is not expressible as an integer with the parameters")
+    return result_ceil
+
+def get_price_nominal(integer_price: int, lot_size: int, tick_size: int) -> float:
+    """
+    Returns the "quote per base" price given an integer price and other configuration variables.
+
+    Parameters:
+    * `integer_price`: The number of ticks of quote per lot representing the price.
+    * `lot_size`: The subunits of base that make up one lot.
+    * `tick_size`: The subunits of quote that make up one tick.
+    """
+    _verify_integer_input(integer_price)
+    _verify_integer_input(lot_size)
+    _verify_integer_input(tick_size)
+    return (integer_price * tick_size) / lot_size
 
 
 def get_min_size_integer(

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -2,7 +2,6 @@ import math
 from decimal import Decimal
 from typing import Tuple
 
-
 MAX_TICKS_INTEGER = (2**32) - 1
 
 
@@ -114,10 +113,12 @@ def get_price_integer(
     quote_decimals: int,
 ) -> int:
     """
-    Returns the "ticks per lot" price given a nominal price and other configuration variables.
+    Returns the "ticks per lot" price given a nominal price and other configuration
+    variables.
 
     Parameters:
-    * `nominal_price`: The price of one nominal unit of base in terms of nominal quote units.
+    * `nominal_price`: The price of one nominal unit of base in terms of nominal quote
+      units.
     * `lot_size_integer`: The subunits of base that make up one lot.
     * `tick_size_integer`: The subunits of quote that make up one tick.
     * `base_decimals`: The number of decimals in one nominal unit of base.
@@ -149,7 +150,8 @@ def get_price_nominal(
     quote_decimals: int,
 ) -> Decimal:
     """
-    Returns the "quote per base" price given an integer price and other configuration variables.
+    Returns the "quote per base" price given an integer price and other configuration
+    variables.
 
     Parameters:
     * `integer_price`: The number of ticks of quote per lot representing the price.

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -3,6 +3,9 @@ from decimal import Decimal
 from typing import Tuple
 
 
+MAX_TICKS_INTEGER = (2**32) - 1
+
+
 def _verify_decimal_input(decimal_input: str):
     if type(decimal_input) is not str:
         raise ValueError("Decimal input should be a string")
@@ -31,9 +34,11 @@ def _get_tick_size_integer(
     _verify_decimal_input(size_precision_nominal)
     _verify_decimal_input(price_precision_nominal)
     _verify_integer_input(quote_decimals)
-    tick_size = Decimal(price_precision_nominal) \
-      * Decimal(size_precision_nominal) \
-      * (10 ** quote_decimals)
+    tick_size = (
+        Decimal(price_precision_nominal)
+        * Decimal(size_precision_nominal)
+        * (10**quote_decimals)
+    )
     if tick_size < 1:
         raise ValueError("The price is too granular given the size granularity")
     return math.ceil(tick_size)
@@ -52,8 +57,8 @@ def get_market_parameters_integer(
     can be directly used to register a market (along with the base/quote types).
 
     Parameters:
-    * `lot_size_nominal`: The size granularity in nominal base terms.
-    * `tick_size_nominal`: The tick granularity in nominal quote terms.
+    * `size_precision_nominal`: The size precision in nominal base terms.
+    * `price_precision_nominal`: The price precision in nominal quote/base terms.
     * `min_size_nominal`: The minimum size in nominal base terms.
     * `base_decimals`: The number of decimals in the nominal base unit.
     * `quote_decimals`: The number of decimals in the nominal quote unit.
@@ -62,9 +67,7 @@ def get_market_parameters_integer(
     """
     lot_size = _get_lot_size_integer(size_precision_nominal, base_decimals)
     tick_size = _get_tick_size_integer(
-        size_precision_nominal,
-        price_precision_nominal,
-        quote_decimals
+        size_precision_nominal, price_precision_nominal, quote_decimals
     )
     min_size = _get_min_size_integer(min_size_nominal, base_decimals, lot_size)
     return (lot_size, tick_size, min_size)
@@ -95,9 +98,11 @@ def get_market_parameters_nominal(
     _verify_integer_input(min_size_integer)
     _verify_integer_input(base_decimals)
     _verify_integer_input(quote_decimals)
-    lot_size_nominal = Decimal(lot_size_integer) / (10 ** base_decimals)
-    tick_size_nominal = Decimal(tick_size_integer) / (10 ** quote_decimals)
-    min_size_nominal = Decimal(min_size_integer * lot_size_integer) / (10 ** base_decimals)
+    lot_size_nominal = Decimal(lot_size_integer) / (10**base_decimals)
+    tick_size_nominal = Decimal(tick_size_integer) / (10**quote_decimals)
+    min_size_nominal = Decimal(min_size_integer * lot_size_integer) / (
+        10**base_decimals
+    )
     return (lot_size_nominal, tick_size_nominal, min_size_nominal)
 
 
@@ -107,14 +112,14 @@ def get_price_integer(
     tick_size_integer: int,
     base_decimals: int,
     quote_decimals: int,
-  ) -> int:
+) -> int:
     """
     Returns the "ticks per lot" price given a nominal price and other configuration variables.
 
     Parameters:
     * `nominal_price`: The price of one nominal unit of base in terms of nominal quote units.
-    * `lot_size`: The subunits of base that make up one lot.
-    * `tick_size`: The subunits of quote that make up one tick.
+    * `lot_size_integer`: The subunits of base that make up one lot.
+    * `tick_size_integer`: The subunits of quote that make up one tick.
     * `base_decimals`: The number of decimals in one nominal unit of base.
     * `quote_decimals`: The number of decimals in one nominal unit of quote.
     """
@@ -123,13 +128,18 @@ def get_price_integer(
     _verify_integer_input(tick_size_integer)
     _verify_integer_input(base_decimals)
     _verify_integer_input(quote_decimals)
-    result = Decimal(nominal_price) * Decimal((10 ** quote_decimals) / (10 ** base_decimals))
+    result = Decimal(nominal_price) * Decimal(
+        (10**quote_decimals) / (10**base_decimals)
+    )
     result = result * Decimal((1 / tick_size_integer) / (1 / lot_size_integer))
     result_floor = math.floor(result)
     result_ceil = math.ceil(result)
-    if (result_floor != result_ceil):
-        raise ValueError("The price is not expressible as an integer with the parameters")
+    if result_floor != result_ceil:
+        raise ValueError(
+            "The price is not expressible as an integer with the parameters"
+        )
     return result_ceil
+
 
 def get_price_nominal(
     integer_price: int,
@@ -143,16 +153,18 @@ def get_price_nominal(
 
     Parameters:
     * `integer_price`: The number of ticks of quote per lot representing the price.
-    * `lot_size`: The subunits of base that make up one lot.
-    * `tick_size`: The subunits of quote that make up one tick.
+    * `lot_size_integer`: The subunits of base that make up one lot.
+    * `tick_size_integer`: The subunits of quote that make up one tick.
+    * `base_decimals`: The number of decimals in one nominal unit of base.
+    * `quote_decimals`: The number of decimals in one nominal unit of quote.
     """
     _verify_integer_input(integer_price)
     _verify_integer_input(lot_size_integer)
     _verify_integer_input(tick_size_integer)
     _verify_integer_input(base_decimals)
     _verify_integer_input(quote_decimals)
-    quote_units = Decimal(integer_price * tick_size_integer) / (10 ** quote_decimals)
-    base_units = Decimal(lot_size_integer) / (10 ** base_decimals)
+    quote_units = Decimal(integer_price * tick_size_integer) / (10**quote_decimals)
+    base_units = Decimal(lot_size_integer) / (10**base_decimals)
     return quote_units / base_units
 
 
@@ -176,10 +188,7 @@ def get_max_price_nominal(price_precision_nominal: str) -> Decimal:
     can be thought of as maximum price.
 
     Parameters:
-    * `smallest_decimal_size_base`: The decimal size of one lot of base,
-      as a string i.e "0.001" for one-thousandth.
-    * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
-      as a string i.e "0.001" for one-thousandth.
+    * `price_precision_nominal`: The price precision in nominal quote/base terms.
     """
     _verify_decimal_input(price_precision_nominal)
-    return Decimal(price_precision_nominal) * ((2**32)-1)
+    return Decimal(price_precision_nominal) * MAX_TICKS_INTEGER

--- a/src/python/sdk/econia_sdk/utils/decimals.py
+++ b/src/python/sdk/econia_sdk/utils/decimals.py
@@ -13,17 +13,7 @@ def _verify_integer_input(integer_input: int):
         raise ValueError("Integer input should be an integer")
 
 
-def get_lot_size_integer(smallest_base_unit: str, base_decimals: int) -> int:
-    """
-    Given a decimal representation of the smallest possible unit and the
-    whole unit's decimals (e.g. ETH has 18 decimals), return the lot size.
-
-    Parameters:
-    * `smallest_decimal_unit`: Decimal (e.g. "0.001" for one thousandth) of
-      the smallest possible unit relative to a whole unit.
-    * `coin_decimals`: The number of decimals one whole unit of the coin
-      has (e.g. USDC has 6 decimals, ETH has 18).
-    """
+def _get_lot_size_integer(smallest_base_unit: str, base_decimals: int) -> int:
     _verify_decimal_input(smallest_base_unit)
     _verify_integer_input(base_decimals)
     smallest_decimal = Decimal(smallest_base_unit)
@@ -33,38 +23,11 @@ def get_lot_size_integer(smallest_base_unit: str, base_decimals: int) -> int:
     return math.ceil(smallest_subunits)
 
 
-def get_tick_size_integer(smallest_quote_unit: str, quote_decimals: int) -> int:
-    """
-    Given a decimal representation of the smallest possible unit and the
-    whole unit's decimals (e.g. ETH has 18 decimals), return the tick size.
-
-    Parameters:
-    * `smallest_decimal_unit`: Decimal (e.g. "0.001" for one thousandth) of
-      the smallest possible unit relative to a whole unit.
-    * `coin_decimals`: The number of decimals one whole unit of the coin
-      has (e.g. USDC has 6 decimals, ETH has 18).
-    """
-    return get_lot_size_integer(smallest_quote_unit, quote_decimals)
-
-
-def get_tick_size_integer_for_price_granularity(
+def _get_tick_size_integer(
     size_precision_nominal: str,
     price_precision_nominal: str,
     quote_decimals: int,
 ) -> int:
-    """
-    Returns the tick size integer to achieve a price precision given a size
-    granularity, both in nominal terms.
-
-    Parameters:
-    * `size_precision_nominal`: Decimal (e.g. "0.001" for one thousandth) of
-      the smallest possible size (of base) relative to a whole unit.
-    * `price_precision_nominal`: The ratio of quote per base by which price
-      is incremented and/or decremented (e.g. "0.01" USD/BTC expresses a
-      price granularity of one penny).
-    * `base decimals`: The number of decimals in the base for conversion to
-       integer subunit terms.
-    """
     _verify_decimal_input(size_precision_nominal)
     _verify_decimal_input(price_precision_nominal)
     _verify_integer_input(quote_decimals)
@@ -72,8 +35,39 @@ def get_tick_size_integer_for_price_granularity(
       * Decimal(size_precision_nominal) \
       * (10 ** quote_decimals)
     if tick_size < 1:
-        raise ValueError("The price is too granular")
+        raise ValueError("The price is too granular given the size granularity")
     return math.ceil(tick_size)
+
+
+def get_market_parameters_integer(
+    size_precision_nominal: str,
+    price_precision_nominal: str,
+    min_size_nominal: str,
+    base_decimals: int,
+    quote_decimals: int,
+) -> Tuple[int, int, int]:
+    """
+    Returns the tuple of market parameters in integer terms, rather than nominal
+    terms, given the three nominal parameters plus base and quote decimals. These
+    can be directly used to register a market (along with the base/quote types).
+
+    Parameters:
+    * `lot_size_nominal`: The size granularity in nominal base terms.
+    * `tick_size_nominal`: The tick granularity in nominal quote terms.
+    * `min_size_nominal`: The minimum size in nominal base terms.
+    * `base_decimals`: The number of decimals in the nominal base unit.
+    * `quote_decimals`: The number of decimals in the nominal quote unit.
+
+    Returns: (lot_size_integer, tick_size_integer, min_size_integer)
+    """
+    lot_size = _get_lot_size_integer(size_precision_nominal, base_decimals)
+    tick_size = _get_tick_size_integer(
+        size_precision_nominal,
+        price_precision_nominal,
+        quote_decimals
+    )
+    min_size = _get_min_size_integer(min_size_nominal, base_decimals, lot_size)
+    return (lot_size, tick_size, min_size)
 
 
 def get_market_parameters_nominal(
@@ -82,7 +76,7 @@ def get_market_parameters_nominal(
     min_size_integer: int,
     base_decimals: int,
     quote_decimals: int,
-) -> Tuple[float, float, float]:
+) -> Tuple[Decimal, Decimal, Decimal]:
     """
     Returns the tuple of market parameters in nominal terms, rather than integer
     terms, given the three parameters as integers plus base and quote decimals.
@@ -93,22 +87,24 @@ def get_market_parameters_nominal(
     * `min_size_integer`: The minimum size in terms of lots of base.
     * `base_decimals`: The number of decimals in the nominal base unit.
     * `quote_decimals`: The number of decimals in the nominal quote unit.
+
+    Returns: (lot_size_nominal, tick_size_nominal, min_size_nominal)
     """
     _verify_integer_input(lot_size_integer)
     _verify_integer_input(tick_size_integer)
     _verify_integer_input(min_size_integer)
     _verify_integer_input(base_decimals)
     _verify_integer_input(quote_decimals)
-    lot_size_nominal = lot_size_integer / (10 ** base_decimals)
-    tick_size_nominal = tick_size_integer / (10 ** quote_decimals)
-    min_size_nominal = (min_size_integer * lot_size_integer) / (10 ** base_decimals)
+    lot_size_nominal = Decimal(lot_size_integer) / (10 ** base_decimals)
+    tick_size_nominal = Decimal(tick_size_integer) / (10 ** quote_decimals)
+    min_size_nominal = Decimal(min_size_integer * lot_size_integer) / (10 ** base_decimals)
     return (lot_size_nominal, tick_size_nominal, min_size_nominal)
 
 
 def get_price_integer(
     nominal_price: str,
-    lot_size: int,
-    tick_size: int,
+    lot_size_integer: int,
+    tick_size_integer: int,
     base_decimals: int,
     quote_decimals: int,
   ) -> int:
@@ -123,19 +119,25 @@ def get_price_integer(
     * `quote_decimals`: The number of decimals in one nominal unit of quote.
     """
     _verify_decimal_input(nominal_price)
-    _verify_integer_input(lot_size)
-    _verify_integer_input(tick_size)
+    _verify_integer_input(lot_size_integer)
+    _verify_integer_input(tick_size_integer)
     _verify_integer_input(base_decimals)
     _verify_integer_input(quote_decimals)
     result = Decimal(nominal_price) * Decimal((10 ** quote_decimals) / (10 ** base_decimals))
-    result = result * Decimal((1 / tick_size) / (1 / lot_size))
+    result = result * Decimal((1 / tick_size_integer) / (1 / lot_size_integer))
     result_floor = math.floor(result)
     result_ceil = math.ceil(result)
     if (result_floor != result_ceil):
         raise ValueError("The price is not expressible as an integer with the parameters")
     return result_ceil
 
-def get_price_nominal(integer_price: int, lot_size: int, tick_size: int) -> float:
+def get_price_nominal(
+    integer_price: int,
+    lot_size_integer: int,
+    tick_size_integer: int,
+    base_decimals: int,
+    quote_decimals: int,
+) -> Decimal:
     """
     Returns the "quote per base" price given an integer price and other configuration variables.
 
@@ -145,27 +147,18 @@ def get_price_nominal(integer_price: int, lot_size: int, tick_size: int) -> floa
     * `tick_size`: The subunits of quote that make up one tick.
     """
     _verify_integer_input(integer_price)
-    _verify_integer_input(lot_size)
-    _verify_integer_input(tick_size)
-    return (integer_price * tick_size) / lot_size
+    _verify_integer_input(lot_size_integer)
+    _verify_integer_input(tick_size_integer)
+    _verify_integer_input(base_decimals)
+    _verify_integer_input(quote_decimals)
+    quote_units = Decimal(integer_price * tick_size_integer) / (10 ** quote_decimals)
+    base_units = Decimal(lot_size_integer) / (10 ** base_decimals)
+    return quote_units / base_units
 
 
-def get_min_size_integer(
+def _get_min_size_integer(
     smallest_decimal_size: str, base_coin_decimals: int, lot_size: int
 ) -> int:
-    """
-    Returns the minimum size, in number of lots, to represent the smallest
-    decimal size according to the base coin's decimals and lot size.
-
-    Parameters:
-    * `smallest_decimal_size`: Decimal (e.g. "0.001" for one thousandth) of
-      the smallest possible size relative to a whole unit. Note that this
-      maybe different (larger) than the smallest possible unit (lot size).
-      This should be of the base coin, not the quote coin!
-    * `base_coin_decimals`: The number of decimals one whole unit of the
-      base has (e.g. USDC has 6 decimals, ETH has 18).
-    * `lot_size`: The size in subunits of one lot of base coin.
-    """
     _verify_decimal_input(smallest_decimal_size)
     _verify_integer_input(base_coin_decimals)
     _verify_integer_input(lot_size)
@@ -176,35 +169,7 @@ def get_min_size_integer(
     return math.ceil(smallest_subunits)
 
 
-def get_min_quote_per_base_nominal(
-    smallest_decimal_size_base: str,
-    smallest_decimal_size_quote: str,
-) -> float:
-    """
-    Returns the minimum units of quote that one can obtain for a unit of
-    base, given the granularity of base and granularity of quote. This
-    can be thought of as price granularity--how much the price must move
-    by in order to move at all. If the price granularity is 10 USDC for
-    example, then only prices divisible by 10 are expressible: $10/unit,
-    $20/unit, $30/unit, any so on.
-
-    Parameters:
-    * `smallest_decimal_size_base`: The decimal size of one lot of base,
-      as a string i.e "0.001" for one-thousandth.
-    * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
-      as a string i.e "0.001" for one-thousandth.
-    """
-    _verify_decimal_input(smallest_decimal_size_base)
-    _verify_decimal_input(smallest_decimal_size_quote)
-    return float(
-        (1 / Decimal(smallest_decimal_size_base)) * Decimal(smallest_decimal_size_quote)
-    )
-
-
-def get_max_quote_per_base_nominal(
-    smallest_decimal_size_base: str,
-    smallest_decimal_size_quote: str,
-) -> float:
+def get_max_price_nominal(price_precision_nominal: str) -> Decimal:
     """
     Returns the maximum units of quote that once can obtain for a unit of
     base, given the granularity of base and granularity of quote. This
@@ -216,9 +181,5 @@ def get_max_quote_per_base_nominal(
     * `smallest_decimal_size_quote`: The decimal size of one tick of quote,
       as a string i.e "0.001" for one-thousandth.
     """
-    _verify_decimal_input(smallest_decimal_size_base)
-    _verify_decimal_input(smallest_decimal_size_quote)
-    lots_per_base_unit = 1 / Decimal(smallest_decimal_size_base)
-    max_ticks_per_lot = (2**32) - 1
-    max_quote_per_lot = Decimal(smallest_decimal_size_quote) * max_ticks_per_lot
-    return float(max_quote_per_lot * lots_per_base_unit)
+    _verify_decimal_input(price_precision_nominal)
+    return Decimal(price_precision_nominal) * ((2**32)-1)

--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "econia-sdk"
-version = "1.0.3"
+version = "1.0.4"
 description = ""
 authors = ["Econia Labs <developers@econialabs.com>"]
 readme = "README.md"


### PR DESCRIPTION
Clients would like helpers for calculating a tick size given a desired price granularity (and other configuration variables). They would also like helpers for converting between decimal price and integer price since this can be confusing. Here I've added those helpers as well as included blurbs about the new tick size helper in our documentation.