### PR TITLE
[ECO-419] Fix cargo workspace config and rust warnings

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -5476,6 +5476,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
+name = "rust-sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-sdk",
+ "clap 4.3.21",
+ "econia-sdk",
+ "rand 0.7.3",
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["aggregator", "api", "db", "types", "sdk"]
+members = ["aggregator", "api", "db", "types", "sdk", "sdk/example"]
 exclude = ["dependencies"]
 
 [workspace.dependencies]

--- a/src/rust/sdk/example/Cargo.toml
+++ b/src/rust/sdk/example/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-sdk"
+name = "sdk-example"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/rust/sdk/example/src/main.rs
+++ b/src/rust/sdk/example/src/main.rs
@@ -341,7 +341,7 @@ async fn main() -> EconiaResult<()> {
     let market_id = if let Some(market_id) = market_id {
         println!("Market already exists, ID: {market_id}");
 
-        let (account_address, mut econia_client) =
+        let (_, mut econia_client) =
             account(&faucet_client, &args.node_url, econia_address.clone()).await;
         fund(&e_apt, 10u64.pow(19), &mut econia_client, faucet_address).await?;
         fund(&e_usdc, 10u64.pow(19), &mut econia_client, faucet_address).await?;

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -343,7 +343,7 @@ impl EconiaClient {
             .events
             .iter()
             .filter(|e| matches!(&e.typ, MoveType::Struct(s) if s.address.inner() == &self.econia_address))
-            .map(|e| serde_json::from_value((e.data.clone())))
+            .map(|e| serde_json::from_value(e.data.clone()))
             .collect::<Result<Vec<EconiaEvent>, serde_json::Error>>()?;
 
         Ok(EconiaTransaction {

--- a/src/rust/types/src/events.rs
+++ b/src/rust/types/src/events.rs
@@ -1,13 +1,9 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{DateTime, Utc};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{
-    error::TypeError,
-    order::{CancelReason, Restriction, SelfMatchBehavior, Side},
-};
+use crate::order::{CancelReason, Restriction, SelfMatchBehavior, Side};
 
 fn from_str<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where


### PR DESCRIPTION
- Fix import and parentheses warnings.
- Fix cargo workspaces configuration.