### PR TITLE
[ECO-450] Add v2 processor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/typescript/frontend/public/static"]
 	path = src/typescript/frontend/public/static
 	url = git@github.com:tradingview/charting_library.git
+[submodule "src/rust/dependencies/aptos-indexer-processors"]
+	path = src/rust/dependencies/aptos-indexer-processors
+	url = https://github.com/aptos-labs/aptos-indexer-processors.git


### PR DESCRIPTION
We need to fork the v2 processor example repository from Aptos so that we can add to it our new processor, then run it with Docker. Here I've run `git submodule add https://github.com/aptos-labs/aptos-indexer-processors.git` which has added the submodule. I believe that's all I need to do.