### PR TITLE
ECO-248: fix websocket connect issue

### DIFF
--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -65,8 +65,6 @@ export default function Market({ allMarketData, marketData }: Props) {
         return;
       }
 
-      console.log(ws.current.readyState, "state");
-
       // Subscribe to orderbook price level updates
       ws.current.send(
         JSON.stringify({

--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -164,7 +164,7 @@ export default function Market({ allMarketData, marketData }: Props) {
         prevAddress.current = undefined;
       }
     }
-  }, [marketData?.market_id, account?.address, ws.current?.readyState]);
+  }, [marketData?.market_id, account?.address]);
 
   // Handle incoming WebSocket messages
   useEffect(() => {

--- a/src/typescript/frontend/src/pages/trade/[market_name].tsx
+++ b/src/typescript/frontend/src/pages/trade/[market_name].tsx
@@ -56,9 +56,16 @@ export default function Market({ allMarketData, marketData }: Props) {
   useEffect(() => {
     ws.current = new WebSocket(WS_URL);
     ws.current.onopen = () => {
-      if (marketData?.market_id == null || ws.current == null) {
+      // because useEffects can fire more than once and onopen is an async function, we still want to check readystate when we send a message
+      if (
+        marketData?.market_id == null ||
+        ws.current == null ||
+        ws.current.readyState !== WebSocket.OPEN
+      ) {
         return;
       }
+
+      console.log(ws.current.readyState, "state");
 
       // Subscribe to orderbook price level updates
       ws.current.send(
@@ -82,19 +89,26 @@ export default function Market({ allMarketData, marketData }: Props) {
 
   // Handle wallet connect and disconnect
   useEffect(() => {
-    if (marketData?.market_id == null || ws.current == null) {
+    if (
+      marketData?.market_id == null ||
+      ws.current == null ||
+      ws.current.readyState !== WebSocket.OPEN
+    ) {
       return;
     }
     if (account?.address != null) {
+      //  commenting this out because it doesn't seem to be doing what it's supposed to
+      //  maybe if we made it synchronous it would work?
+
       // If the WebSocket connection is not ready,
       // wait for the WebSocket connection to be opened.
-      if (ws.current.readyState === WebSocket.CONNECTING) {
-        const interval = setInterval(() => {
-          if (ws.current?.readyState === WebSocket.OPEN) {
-            clearInterval(interval);
-          }
-        }, 500);
-      }
+      // if (ws.current.readyState === WebSocket.CONNECTING) {
+      //   const interval = setInterval(() => {
+      //     if (ws.current?.readyState === WebSocket.OPEN) {
+      //       clearInterval(interval);
+      //     }
+      //   }, 500);
+      // }
 
       // Subscribe to orders by account channel
       ws.current.send(
@@ -152,7 +166,7 @@ export default function Market({ allMarketData, marketData }: Props) {
         prevAddress.current = undefined;
       }
     }
-  }, [marketData?.market_id, account?.address]);
+  }, [marketData?.market_id, account?.address, ws.current?.readyState]);
 
   // Handle incoming WebSocket messages
   useEffect(() => {


### PR DESCRIPTION
I think I fixed it, I can't seem to reproduce the error now.
Would like to get some opinions on the current fix -- seems hacky as we need to check websocket status everytime we want to send a message.
But we have to do this because websocket functions are async and when `onopen` is called the websocket reference could be stale. Even though ryosuke mentioned that hooks are called twice in dev mode, this problem occurred in prod.

Additionally, we are properly cleaning up the websocket anyways so I'm not entirely sure why the `onopen` could be called after we close the websocket. see: https://github.com/econia-labs/econia/blob/0d18abfe9cb0f3aab5c0875859480f4e94f3e124/src/typescript/frontend/src/pages/trade/%5Bmarket_name%5D.tsx#L83C5-L83C5