### PR TITLE
ECO-453: query icons regardless if api fails

### DIFF
--- a/src/typescript/frontend/src/components/StatsBar.tsx
+++ b/src/typescript/frontend/src/components/StatsBar.tsx
@@ -32,8 +32,6 @@ type MarketStats = {
   pairData: {
     baseAsset: string;
     quoteAsset: string;
-    baseAssetIcon: string;
-    quoteAssetIcon: string;
     baseVolume: number;
     quoteVolume: number;
   };
@@ -79,6 +77,23 @@ export const StatsBar: React.FC<{
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { coinListClient } = useAptos();
 
+  const { data: iconData } = useQuery(
+    ["iconData", selectedMarket],
+    async () => {
+      const baseAssetIcon = selectedMarket.base
+        ? coinListClient.getCoinInfoByFullName(
+            TypeTag.fromApiCoin(selectedMarket.base).toString(),
+          )?.logo_url
+        : DEFAULT_TOKEN_ICON;
+      const quoteAssetIcon =
+        coinListClient.getCoinInfoByFullName(
+          TypeTag.fromApiCoin(selectedMarket.quote).toString(),
+        )?.logo_url ?? DEFAULT_TOKEN_ICON;
+
+      return { baseAssetIcon, quoteAssetIcon };
+    },
+  );
+
   const { data } = useQuery(
     ["marketStats", selectedMarket],
     async () => {
@@ -90,16 +105,6 @@ export const StatsBar: React.FC<{
       ).then((res) => res.json());
       const res = await resProm;
       const priceRes = await priceProm;
-
-      const baseAssetIcon = selectedMarket.base
-        ? coinListClient.getCoinInfoByFullName(
-            TypeTag.fromApiCoin(selectedMarket.base).toString(),
-          )?.logo_url
-        : DEFAULT_TOKEN_ICON;
-      const quoteAssetIcon =
-        coinListClient.getCoinInfoByFullName(
-          TypeTag.fromApiCoin(selectedMarket.quote).toString(),
-        )?.logo_url ?? DEFAULT_TOKEN_ICON;
 
       return {
         lastPrice: toDecimalPrice({
@@ -121,8 +126,6 @@ export const StatsBar: React.FC<{
             ? selectedMarket.base.symbol
             : selectedMarket.name.split("-")[0],
           quoteAsset: selectedMarket.quote.symbol,
-          baseAssetIcon,
-          quoteAssetIcon,
           baseVolume: res.volume,
           quoteVolume: 68026950.84, // TODO: Mock data
         },
@@ -151,8 +154,8 @@ export const StatsBar: React.FC<{
         <div className="flex overflow-x-clip whitespace-nowrap">
           <div className="flex items-center">
             <MarketIconPair
-              baseAssetIcon={data?.pairData.baseAssetIcon}
-              quoteAssetIcon={data?.pairData.quoteAssetIcon}
+              baseAssetIcon={iconData?.baseAssetIcon}
+              quoteAssetIcon={iconData?.quoteAssetIcon}
             />
             <div className="min-w-[160px]">
               <button

--- a/src/typescript/frontend/src/components/trade/DepositWithdrawModal/SelectMarketContent.tsx
+++ b/src/typescript/frontend/src/components/trade/DepositWithdrawModal/SelectMarketContent.tsx
@@ -113,6 +113,7 @@ export const SelectMarketContent: React.FC<{
         header: () => <div className="pl-8">Name</div>,
         cell: (info) => {
           const { baseAssetIcon, quoteAssetIcon } = info.row.original;
+          console.log("market select icons", baseAssetIcon, quoteAssetIcon);
           return (
             <div className="flex pl-8">
               <MarketIconPair


### PR DESCRIPTION
the reason why it broke is because query icons was grouped in with data api calls but those are broken at the moment.