### PR TITLE
[ECO-475][Bug] Fix postgrest role

### DIFF
--- a/src/docker/compose.dss-local.yaml
+++ b/src/docker/compose.dss-local.yaml
@@ -27,7 +27,7 @@ services:
       - postgres
     environment:
       PGRST_DB_URI: "postgres://econia:econia@postgres:5432/econia"
-      PGRST_DB_ANON_ROLE: postgres
+      PGRST_DB_ANON_ROLE: anon
       PGRST_DB_SCHEMA: public
     image: postgrest/postgrest
     ports:


### PR DESCRIPTION
Right now our docker compose file uses the `postgres` role which doesn't exist in the database. We should be using the `anon` role which was created in a recent commit. This commit updates the role to that and also updates the processor submodule commit to the latest.