### PR TITLE
[ECO-482] add place/cancel limit order events

### DIFF
--- a/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/down.sql
+++ b/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/down.sql
@@ -17,6 +17,15 @@ DROP FUNCTION notify_fill_event ();
 DROP TABLE fill_events;
 
 
+DROP TRIGGER place_limit_order_events_trigger ON place_limit_order_events;
+
+
+DROP FUNCTION notify_place_limit_order_event ();
+
+
+DROP TABLE place_limit_order_events;
+
+
 DROP TABLE IF EXISTS processor_status;
 
 

--- a/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/down.sql
+++ b/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/down.sql
@@ -26,6 +26,15 @@ DROP FUNCTION notify_place_limit_order_event ();
 DROP TABLE place_limit_order_events;
 
 
+DROP TRIGGER cancel_order_events_trigger ON cancel_order_events;
+
+
+DROP FUNCTION notify_cancel_order_event ();
+
+
+DROP TABLE cancel_order_events;
+
+
 DROP TABLE IF EXISTS processor_status;
 
 

--- a/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/up.sql
+++ b/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/up.sql
@@ -76,6 +76,38 @@ CREATE TRIGGER fill_events_trigger
 AFTER INSERT ON fill_events FOR EACH ROW
 EXECUTE PROCEDURE notify_fill_event ();
 
+
+CREATE TABLE
+  place_limit_order_events (
+    txn_version NUMERIC(20) NOT NULL,
+    event_idx NUMERIC(20) NOT NULL,
+    PRIMARY KEY (txn_version, event_idx),
+    time timestamptz NOT NULL,
+    market_id NUMERIC(20) NOT NULL,
+    maker_address VARCHAR(70) NOT NULL,
+    maker_custodian_id NUMERIC(20) NOT NULL,
+    maker_order_id NUMERIC(40) NOT NULL,
+    maker_side BOOLEAN NOT NULL,
+    integrator_address VARCHAR(70) NOT NULL,
+    initial_size NUMERIC(20) NOT NULL,
+    price NUMERIC(20) NOT NULL,
+    restriction NUMERIC(20) NOT NULL,
+    self_match_behavior NUMERIC(20) NOT NULL,
+    posted_size NUMERIC(20) NOT NULL
+  );
+
+CREATE FUNCTION notify_place_limit_order_event () RETURNS TRIGGER AS $$
+BEGIN
+   PERFORM pg_notify('place_limit_order_event'::text, row_to_json(NEW)::text);
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER place_limit_order_events_trigger
+AFTER INSERT ON place_limit_order_events FOR EACH ROW
+EXECUTE PROCEDURE notify_place_limit_order_event ();
+
 CREATE ROLE anon;
 GRANT USAGE ON SCHEMA public TO anon;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;

--- a/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/up.sql
+++ b/src/rust/dbv2/migrations/2023-08-25-111710_add_market_registration_events/up.sql
@@ -108,6 +108,32 @@ CREATE TRIGGER place_limit_order_events_trigger
 AFTER INSERT ON place_limit_order_events FOR EACH ROW
 EXECUTE PROCEDURE notify_place_limit_order_event ();
 
+
+CREATE TABLE
+  cancel_order_events (
+    txn_version NUMERIC(20) NOT NULL,
+    event_idx NUMERIC(20) NOT NULL,
+    PRIMARY KEY (txn_version, event_idx),
+    time timestamptz NOT NULL,
+    market_id NUMERIC(20) NOT NULL,
+    maker_address VARCHAR(70) NOT NULL,
+    maker_custodian_id NUMERIC(20) NOT NULL,
+    maker_order_id NUMERIC(40) NOT NULL,
+    reason NUMERIC(20) NOT NULL
+  );
+
+CREATE FUNCTION notify_cancel_order_event () RETURNS TRIGGER AS $$
+BEGIN
+   PERFORM pg_notify('cancel_order_event'::text, row_to_json(NEW)::text);
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER cancel_order_events_trigger
+AFTER INSERT ON cancel_order_events FOR EACH ROW
+EXECUTE PROCEDURE notify_cancel_order_event ();
+
+
 CREATE ROLE anon;
 GRANT USAGE ON SCHEMA public TO anon;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;

--- a/src/rust/dbv2/src/models.rs
+++ b/src/rust/dbv2/src/models.rs
@@ -42,3 +42,22 @@ pub struct FillEvent {
     pub taker_order_id: BigDecimal,
     pub taker_quote_fees_paid: BigDecimal,
 }
+
+#[derive(Clone, Debug, Queryable, Selectable, Insertable)]
+#[diesel(table_name = crate::schema::place_limit_order_events)]
+pub struct PlaceLimitOrderEvent {
+    pub txn_version: BigDecimal,
+    pub event_idx: BigDecimal,
+    pub time: DateTime<Utc>,
+    pub market_id: BigDecimal,
+    pub maker_address: String,
+    pub maker_custodian_id: BigDecimal,
+    pub maker_order_id: BigDecimal,
+    pub maker_side: bool,
+    pub integrator_address: String,
+    pub initial_size: BigDecimal,
+    pub price: BigDecimal,
+    pub restriction: BigDecimal,
+    pub self_match_behavior: BigDecimal,
+    pub posted_size: BigDecimal,
+}

--- a/src/rust/dbv2/src/models.rs
+++ b/src/rust/dbv2/src/models.rs
@@ -61,3 +61,16 @@ pub struct PlaceLimitOrderEvent {
     pub self_match_behavior: BigDecimal,
     pub posted_size: BigDecimal,
 }
+
+#[derive(Clone, Debug, Queryable, Selectable, Insertable)]
+#[diesel(table_name = crate::schema::cancel_order_events)]
+pub struct CancelOrderEvent {
+    pub txn_version: BigDecimal,
+    pub event_idx: BigDecimal,
+    pub time: DateTime<Utc>,
+    pub market_id: BigDecimal,
+    pub maker_address: String,
+    pub maker_custodian_id: BigDecimal,
+    pub maker_order_id: BigDecimal,
+    pub reason: BigDecimal,
+}

--- a/src/rust/dbv2/src/schema.rs
+++ b/src/rust/dbv2/src/schema.rs
@@ -45,3 +45,23 @@ diesel::table! {
         taker_quote_fees_paid -> Numeric,
     }
 }
+
+diesel::table! {
+    place_limit_order_events (txn_version, event_idx) {
+        txn_version -> Numeric,
+        event_idx -> Numeric,
+        time -> Timestamptz,
+        market_id -> Numeric,
+        #[max_length = 70]
+        maker_address -> Varchar,
+        maker_custodian_id -> Numeric,
+        maker_order_id -> Numeric,
+        maker_side -> Bool,
+        integrator_address -> Varchar,
+        initial_size -> Numeric,
+        price -> Numeric,
+        restriction -> Numeric,
+        self_match_behavior -> Numeric,
+        posted_size -> Numeric,
+    }
+}

--- a/src/rust/dbv2/src/schema.rs
+++ b/src/rust/dbv2/src/schema.rs
@@ -65,3 +65,17 @@ diesel::table! {
         posted_size -> Numeric,
     }
 }
+
+diesel::table! {
+    cancel_order_events (txn_version, event_idx) {
+        txn_version -> Numeric,
+        event_idx -> Numeric,
+        time -> Timestamptz,
+        market_id -> Numeric,
+        #[max_length = 70]
+        maker_address -> Varchar,
+        maker_custodian_id -> Numeric,
+        maker_order_id -> Numeric,
+        reason -> Numeric,
+    }
+}


### PR DESCRIPTION
This diff adds the necessary tables and structures to support insertion of place/cancel limit order events in the processor downstream.