### PR TITLE
[ECO-498] Implement testnet competition throttling

### DIFF
--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -12,10 +12,5 @@ user_0 = "0x2345"
 user_1 = "0x3456"
 integrator = "0x4567"
 
-[dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
-# You may need to change this to `main` to run event unit tests, since
-# event unit tests for this package were added before Aptos' event unit
-# testing framework was incorporated into the `mainnet` branch.
-rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+[dependencies.EconiaTestnetCompetitionThrottler]
+local = "../testnet-competition-throttler"

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -3180,6 +3180,8 @@ module econia::market {
         assert!(base_fill >= min_base, E_MIN_BASE_NOT_TRADED);
         // Assert minimum quote coin trade amount met.
         assert!(quote_traded >= min_quote, E_MIN_QUOTE_NOT_TRADED);
+        // Throttle the trade.
+        throttler::throttle::throttle_trade(market_id, taker, base_fill);
         // Return optional base coin, quote coins, trade amounts,
         // self match taker cancel flag, if liquidity is gone, and if
         // limit price was violated.

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -1188,6 +1188,14 @@ module econia::user {
                                          type_info::type_of<GenericAsset>();
         // Assert coin type is not generic asset.
         assert!(!coin_type_is_generic_asset, E_COIN_TYPE_IS_GENERIC_ASSET);
+        // Throttle the deposit.
+        throttler::throttle::throttle_transfer(
+            market_id,
+            user_address,
+            false,
+            coin::decimals<CoinType>() == 8,
+            coin::value(&coins),
+        );
         deposit_asset<CoinType>( // Deposit asset.
             user_address,
             market_id,

--- a/src/move/faucet/Move.toml
+++ b/src/move/faucet/Move.toml
@@ -6,7 +6,5 @@ upgrade_policy = 'compatible'
 [addresses]
 econia_faucet = "_"
 
-[dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+[dependencies.EconiaTestnetCompetitionThrottler]
+local = "../testnet-competition-throttler"

--- a/src/move/faucet/sources/faucet.move
+++ b/src/move/faucet/sources/faucet.move
@@ -71,5 +71,13 @@ module econia_faucet::faucet {
         ).mint_cap;
         // Deposit to caller's coin store the minted coins.
         coin::deposit(account_addr, coin::mint(amount, mint_cap_ref));
+        // Throttle the mint.
+        throttler::throttle::throttle_transfer(
+            0,
+            account_addr,
+            true,
+            coin::decimals<CoinType>() == 8,
+            amount,
+        );
     }
 }

--- a/src/move/testnet-competition-throttler/Move.toml
+++ b/src/move/testnet-competition-throttler/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "EconiaTestnetCompetitionThrottler"
+version = "0.1.0"
+upgrade_policy = "compatible"
+authors = ["Econia Labs (developers@econialabs.com)"]
+
+[addresses]
+throttler = "_"
+admin = "_"
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "testnet"
+subdir = "aptos-move/framework/aptos-framework"

--- a/src/move/testnet-competition-throttler/README.md
+++ b/src/move/testnet-competition-throttler/README.md
@@ -1,0 +1,41 @@
+# Testnet competition throttler
+
+This Move package defines a throttler for the Econia testnet trading competition.
+
+It provides public functions that can be added to Econia and to the Econia faucet through an on-chain upgrade, then reverted with a subsequent on-chain upgrade.
+
+The `SCREAMING_SNAKE_CASE` constants referenced below are defined at the top of `sources/throttle.move`.
+
+## Applicability
+
+- Throttling only applies to `THROTTLED_MARKET_ID`.
+- Throttling does not apply to exempt accounts.
+- Throttling only applies when the throttler is active.
+- An admin has exclusive permission to deactivate/reactivate the throttler, and to add/remove accounts from the exempt accounts list.
+
+## Minting
+
+- A user must wait `WAIT_TIME_IN_MINUTES` between each `eAPT` mint.
+- A user must wait `WAIT_TIME_IN_MINUTES` between each `eUSDC` mint.
+- A user may only mint up to `MAX_TRANSFER_APT` at each `eAPT` mint.
+- A user may only mint up to `MAX_TRANSFER_USDC` at each `eUSDC` mint.
+
+## Depositing
+
+- A user must wait `WAIT_TIME_IN_MINUTES` between each `eAPT` deposit into their Econia market account.
+- A user must wait `WAIT_TIME_IN_MINUTES` between each `eUSDC` deposit into their Econia market account.
+- A user may only deposit up to `MAX_TRANSFER_APT` at each `eAPT` deposit.
+- A user may only deposit up to `MAX_TRANSFER_USDC` at each `eUSDC` deposit.
+
+## Trading
+
+- A user may only trade up to `MAX_TRADE_VOLUME_APT` in a single trade.
+
+## Errors
+
+If a user violates a mint, deposit, or trading rule, the throttler will respond with one of the error codes defined at the top of `sources/throttle.move`.
+
+## View functions
+
+- Assorted view functions can be accessed via https://explorer.aptoslabs.com/account/0xd000000d7cfcb4964a12ed895d2ecb2d57615f28047d4edec9fc61490eb775ce/modules/view/throttle/?network=testnet.
+- These view functions can be accessed from directly inside the explorer UI.

--- a/src/move/testnet-competition-throttler/sources/throttle.move
+++ b/src/move/testnet-competition-throttler/sources/throttle.move
@@ -1,0 +1,205 @@
+module throttler::throttle {
+
+    // Constants for trading competition rules. >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+    /// Maximum amount of APT that can change hands in a single trade.
+    const MAX_TRADE_VOLUME_APT: u64 =  200;
+    /// Maximum amount of APT that can be deposited/minted at a time.
+    const MAX_TRANSFER_APT: u64 =  20;
+    /// Maximum amount of USDC that can be deposited/minted at a time.
+    const MAX_TRANSFER_USDC: u64 =  100;
+    /// The market ID that activity is throttled on.
+    const THROTTLED_MARKET_ID: u64 = 3;
+    /// How long user must wait between faucet mints or market account
+    /// deposits for a given asset.
+    const WAIT_TIME_IN_MINUTES: u64 = 5;
+
+    // Constants for trading competition rules. <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    // Trading competition participant error codes. >>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+    /// You have not waited long enough between a deposit or mint.
+    const E_WAIT_TIME: u64 = 0;
+    /// You have tried to mint or deposit too much.
+    const E_TRANSFER_AMOUNT: u64 = 1;
+    /// You have tried to trade too much during a single trade.
+    const E_TRADE_AMOUNT: u64 = 2;
+
+    // Trading competition participant error codes. <<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    use aptos_framework::timestamp;
+    use aptos_std::simple_map;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use std::signer;
+    use std::vector;
+
+    const SECONDS_PER_MINUTE: u64 = 60;
+    const SUBUNIT_CONVERSION_FACTOR_APT: u64 = 100000000;
+    const SUBUNIT_CONVERSION_FACTOR_USDC: u64 = 1000000;
+
+    /// You do not have permission to modify the throttler.
+    const E_NOT_ADMIN: u64 = 3;
+
+    #[view]
+    public fun config_parameters(): ConfigView {
+        ConfigView {
+            max_trade_volume_apt: MAX_TRADE_VOLUME_APT,
+            max_transfer_apt: MAX_TRANSFER_APT,
+            max_transfer_usdc: MAX_TRANSFER_USDC,
+            throttled_market_id: THROTTLED_MARKET_ID,
+            wait_time_in_minutes: WAIT_TIME_IN_MINUTES,
+        }
+    }
+
+    #[view]
+    public fun exempt_accounts(): vector<address> acquires Throttler {
+        borrow_global<Throttler>(@throttler).exempt_accounts
+    }
+
+    #[view]
+    public fun n_throttled_accounts(): u64 acquires Throttler {
+        let throttled_accounts_ref =
+            &borrow_global<Throttler>(@throttler).throttled_accounts;
+        smart_table::length(throttled_accounts_ref)
+    }
+
+    #[view]
+    public fun throttled_accounts():
+    vector<ThrottledAccount>
+    acquires Throttler {
+        let throttled_accounts_ref =
+            &borrow_global<Throttler>(@throttler).throttled_accounts;
+        let simple_map = smart_table::to_simple_map(throttled_accounts_ref);
+        simple_map::values(&simple_map)
+    }
+
+    struct ConfigView has copy, drop, store {
+        max_trade_volume_apt: u64,
+        max_transfer_apt: u64,
+        max_transfer_usdc: u64,
+        throttled_market_id: u64,
+        wait_time_in_minutes: u64,
+    }
+
+    struct Throttler has key {
+        is_active: bool,
+        exempt_accounts: vector<address>,
+        throttled_accounts: SmartTable<address, ThrottledAccount>,
+    }
+
+    /// All times in seconds.
+    struct ThrottledAccount has copy, drop, store {
+        account_address: address,
+        last_mint_time_apt: u64,
+        last_mint_time_usdc: u64,
+        last_deposit_time_apt: u64,
+        last_deposit_time_usdc: u64,
+    }
+
+    fun init_module(throttler: &signer) {
+        move_to(throttler, Throttler {
+            is_active: true,
+            exempt_accounts: vector[],
+            throttled_accounts: smart_table::new(),
+        })
+    }
+
+    public fun throttle_transfer(
+        market_id: u64,
+        account: address,
+        is_mint: bool,
+        is_apt: bool,
+        amount_in_subunits: u64,
+    ) acquires Throttler {
+        if (!is_mint && market_id != THROTTLED_MARKET_ID) return;
+        let throttler_ref_mut = borrow_global_mut<Throttler>(@throttler);
+        if (!throttler_ref_mut.is_active) return;
+        if (vector::contains(&throttler_ref_mut.exempt_accounts, &account))
+            return;
+        let throttled_accounts_ref_mut =
+            &mut throttler_ref_mut.throttled_accounts;
+        let new_account =
+            !smart_table::contains(throttled_accounts_ref_mut, account);
+        if (new_account) smart_table::add(
+            throttled_accounts_ref_mut,
+            account,
+            ThrottledAccount {
+                account_address: account,
+                last_mint_time_apt: 0,
+                last_mint_time_usdc: 0,
+                last_deposit_time_apt: 0,
+                last_deposit_time_usdc: 0,
+            }
+        );
+        let account_ref_mut = smart_table::borrow_mut(
+            throttled_accounts_ref_mut,
+            account
+        );
+        let last_time_ref_mut = if (is_mint) {
+            if (is_apt) &mut account_ref_mut.last_mint_time_apt else
+            &mut account_ref_mut.last_mint_time_usdc
+        } else {
+            if (is_apt) &mut account_ref_mut.last_deposit_time_apt else
+            &mut account_ref_mut.last_deposit_time_usdc
+        };
+        let now = timestamp::now_seconds();
+        let eligible = (now - *last_time_ref_mut) >
+            (WAIT_TIME_IN_MINUTES * SECONDS_PER_MINUTE);
+        assert!(eligible, E_WAIT_TIME);
+        let (conversion_factor, max_nominal) = if (is_apt)
+            (SUBUNIT_CONVERSION_FACTOR_APT , MAX_TRANSFER_APT ) else
+            (SUBUNIT_CONVERSION_FACTOR_USDC, MAX_TRANSFER_USDC);
+        assert!(
+            amount_in_subunits * conversion_factor <= max_nominal,
+            E_TRANSFER_AMOUNT
+        );
+        *last_time_ref_mut = now;
+    }
+
+    public fun throttle_trade(
+        market_id: u64,
+        taker: address,
+        apt_trade_amount_in_octas: u64,
+    ) acquires Throttler {
+        if (market_id != THROTTLED_MARKET_ID) return;
+        let throttler_ref = borrow_global<Throttler>(@throttler);
+        if (!throttler_ref.is_active) return;
+        if (vector::contains(&throttler_ref.exempt_accounts, &taker)) return;
+        let trade_amount_nominal =
+            apt_trade_amount_in_octas * SUBUNIT_CONVERSION_FACTOR_APT;
+        assert!(trade_amount_nominal < MAX_TRADE_VOLUME_APT, E_TRADE_AMOUNT);
+    }
+
+    public entry fun deactivate(admin: &signer) acquires Throttler {
+        assert!(signer::address_of(admin) == @admin, E_NOT_ADMIN);
+        borrow_global_mut<Throttler>(@throttler).is_active = false;
+    }
+
+    public entry fun reactivate(admin: &signer) acquires Throttler {
+        assert!(signer::address_of(admin) == @admin, E_NOT_ADMIN);
+        borrow_global_mut<Throttler>(@throttler).is_active = true;
+    }
+
+    public entry fun add_exempt_account(
+        admin: &signer,
+        account: address,
+    ) acquires Throttler {
+        assert!(signer::address_of(admin) == @admin, E_NOT_ADMIN);
+        let throttler_ref_mut = borrow_global_mut<Throttler>(@throttler);
+        let accounts_ref_mut = &mut throttler_ref_mut.exempt_accounts;
+        if (!vector::contains(accounts_ref_mut, &account))
+            vector::push_back(accounts_ref_mut, account);
+    }
+
+    public entry fun remove_exempt_account(
+        admin: &signer,
+        account: address,
+    ) acquires Throttler {
+        assert!(signer::address_of(admin) == @admin, E_NOT_ADMIN);
+        let throttler_ref_mut = borrow_global_mut<Throttler>(@throttler);
+        let accounts_ref_mut = &mut throttler_ref_mut.exempt_accounts;
+        let (found, index) = vector::index_of(accounts_ref_mut, &account);
+        if (found) {vector::remove(accounts_ref_mut, index);};
+    }
+
+}


### PR DESCRIPTION
This PR adds a testnet trading competition throttler that can be upgradeably inserted and removed from the Econia and Econia faucet packages.