### PR TITLE
[ECO-517] Exempt throttling for internal deposits

### DIFF
--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -1194,8 +1194,7 @@ module econia::user {
             user_address,
             false,
             coin::decimals<CoinType>() == 8,
-            coin::value(&coins),
-        );
+            coin::value(&coins));
         deposit_asset<CoinType>( // Deposit asset.
             user_address,
             market_id,
@@ -1974,8 +1973,13 @@ module econia::user {
         deposit_asset<BaseType>( // Deposit base asset.
             user_address, market_id, custodian_id, base_amount,
             optional_base_coins, underwriter_id);
-        deposit_coins<QuoteType>( // Deposit quote coins.
-            user_address, market_id, custodian_id, quote_coins);
+        deposit_asset<QuoteType>( // Deposit quote coins.
+            user_address,
+            market_id,
+            custodian_id,
+            coin::value(&quote_coins),
+            option::some(quote_coins),
+            NO_UNDERWRITER);
     }
 
     /// Emit limit order events to a user's market event handles.
@@ -4012,6 +4016,7 @@ module econia::user {
         Collateral,
         MarketAccounts
     {
+        econia::assets::init_coin_types_test();
         // Attempt invalid invocation.
         deposit_coins<BC>(@user, 0, 0, coin::zero());
     }


### PR DESCRIPTION
This PR exempts throttling for internal deposits, where the matching engine deposits coins into a user's market account