### PR TITLE
[ECO-521] Add e2e framework

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -180,7 +180,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -389,8 +389,8 @@ name = "aptos-crypto-derive"
 version = "0.0.3"
 source = "git+https://github.com/aptos-labs/aptos-core?branch=main#4bddd6ca5b65b12f1890ead29392e76b971ad031"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -518,8 +518,8 @@ name = "aptos-log-derive"
 version = "0.1.0"
 source = "git+https://github.com/aptos-labs/aptos-core?branch=main#4bddd6ca5b65b12f1890ead29392e76b971ad031"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1089,7 +1089,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.32",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1101,8 +1101,8 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.16",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1137,8 +1137,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1170,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6368f9ae5c6ec403ca910327ae0c9437b0a85255b6950c90d497e6177f6e5e"
 dependencies = [
  "proc-macro-hack",
- "quote 1.0.32",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1207,9 +1207,9 @@ version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1311,8 +1311,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1633,9 +1633,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1688,7 +1688,7 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static 1.4.0",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1705,6 +1705,19 @@ dependencies = [
  "serde_json",
  "toml",
  "yaml-rust",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static 1.4.0",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1967,8 +1980,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1980,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.32",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2031,8 +2044,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2042,9 +2055,9 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2054,8 +2067,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -2093,9 +2106,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
  "diesel_table_macro_syntax",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2104,7 +2117,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.27",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2188,11 +2201,24 @@ dependencies = [
  "anyhow",
  "aptos-sdk",
  "clap 4.3.21",
+ "colored",
+ "e2e-proc-macro",
  "econia-sdk",
+ "futures",
+ "indicatif",
+ "metadata",
  "rand 0.7.3",
  "reqwest",
  "sqlx",
  "tokio",
+]
+
+[[package]]
+name = "e2e-proc-macro"
+version = "0.1.0"
+dependencies = [
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2258,6 +2284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,9 +2305,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2314,7 +2346,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2335,7 +2367,7 @@ checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2531,9 +2563,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2859,7 +2891,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3071,8 +3103,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3105,8 +3137,8 @@ checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3116,8 +3148,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
 ]
 
 [[package]]
@@ -3138,6 +3170,19 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3191,7 +3236,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3420,6 +3465,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "metadata"
+version = "0.1.0"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,7 +3497,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4112,8 +4161,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4180,6 +4229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,9 +4276,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4281,8 +4336,8 @@ checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4294,8 +4349,8 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4326,8 +4381,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4376,7 +4431,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4446,9 +4501,9 @@ checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4536,9 +4591,9 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4626,9 +4681,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5dd58846a1f582215370384c3090c62c9ef188e9d798ffc67ea90d0a1a8a3b8"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4667,8 +4722,8 @@ dependencies = [
  "indexmap 1.9.3",
  "mime",
  "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "regex",
  "syn 1.0.109",
  "thiserror",
@@ -4685,6 +4740,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -4740,8 +4801,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4752,8 +4813,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -4780,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -4910,11 +4971,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
 ]
 
 [[package]]
@@ -5095,9 +5156,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5283,7 +5344,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5367,7 +5428,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5538,9 +5599,9 @@ version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5851,8 +5912,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "208e3165167afd7f3881b16c1ef3f2af69fa75980897aac8874a0696516d12c2"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "sqlx-core",
  "sqlx-macros-core",
  "syn 1.0.109",
@@ -5869,8 +5930,8 @@ dependencies = [
  "heck 0.4.1",
  "hex",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "serde 1.0.175",
  "serde_json",
  "sha2 0.10.7",
@@ -6046,8 +6107,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6064,8 +6125,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -6099,19 +6160,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -6131,7 +6192,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6210,9 +6271,9 @@ version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6341,7 +6402,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6350,9 +6411,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6439,8 +6500,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6463,9 +6524,9 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6752,7 +6813,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
 dependencies = [
- "quote 1.0.32",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6839,9 +6900,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -6863,7 +6924,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.32",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -6873,9 +6934,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6987,7 +7048,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6996,7 +7066,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7005,14 +7090,20 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -7022,9 +7113,21 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7034,9 +7137,21 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7046,9 +7161,21 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7123,7 +7250,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.27",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2209,6 +2209,8 @@ dependencies = [
  "metadata",
  "rand 0.7.3",
  "reqwest",
+ "serde 1.0.175",
+ "serde_json",
  "sqlx",
  "tokio",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,6 +4,8 @@ members = [
   "aggregator",
   "dbv2",
   "e2e",
+  "e2e/e2e-proc-macro",
+  "e2e/metadata",
   "types",
   "sdk",
   "sdk/example",

--- a/src/rust/e2e/Cargo.toml
+++ b/src/rust/e2e/Cargo.toml
@@ -20,4 +20,6 @@ colored = "2.0.4"
 indicatif = "0.17.6"
 futures.workspace = true
 rand = "0.7"
+serde.workspace = true
+serde_json.workspace = true
 

--- a/src/rust/e2e/Cargo.toml
+++ b/src/rust/e2e/Cargo.toml
@@ -7,11 +7,17 @@ edition = "2021"
 
 [dependencies]
 econia-sdk = { path = "../sdk" }
+e2e-proc-macro = { path = "./e2e-proc-macro" }
+metadata = { path = "./metadata" }
 aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", branch = "main" }
 
 anyhow.workspace = true
 clap.workspace = true
-rand = "0.7"
 reqwest = "0.11"
 sqlx = { workspace = true, features = ["postgres"] }
 tokio = { workspace = true, features = ["full"] }
+colored = "2.0.4"
+indicatif = "0.17.6"
+futures.workspace = true
+rand = "0.7"
+

--- a/src/rust/e2e/e2e-proc-macro/Cargo.toml
+++ b/src/rust/e2e/e2e-proc-macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "e2e-proc-macro"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+quote = "1.0.33"
+syn = "2.0.37"
+
+[lib]
+proc-macro = true

--- a/src/rust/e2e/e2e-proc-macro/src/lib.rs
+++ b/src/rust/e2e/e2e-proc-macro/src/lib.rs
@@ -1,0 +1,60 @@
+use proc_macro::TokenStream;
+use syn::{
+    parse_macro_input,
+    punctuated::{Pair, Punctuated},
+    token::Comma,
+    ItemFn, Pat,
+};
+
+#[proc_macro_attribute]
+pub fn e2e_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = if attr.is_empty() {
+        String::from("default")
+    } else {
+        attr.to_string()
+    };
+
+    let mut input = parse_macro_input!(item as ItemFn);
+
+    let args_without_type: Punctuated<Pat, Comma> = input
+        .sig
+        .inputs
+        .iter()
+        .map(|e| match e {
+            syn::FnArg::Typed(pat) => Pair::new(pat.pat.as_ref().clone(), Some(Comma::default())),
+            syn::FnArg::Receiver(_) => panic!("Unexpected receiver"),
+        })
+        .collect();
+
+    let output = match input.sig.output.clone() {
+        syn::ReturnType::Default => quote::quote! { () },
+        syn::ReturnType::Type(_, ty) => quote::quote! { #ty },
+    };
+    input.sig.output = syn::parse_quote! {
+        -> Metadata<#output>
+    };
+
+    let ItemFn {
+        vis,
+        sig,
+        block,
+        ..
+    } = input;
+    let inputs = sig.inputs.clone();
+    let ident = sig.ident.clone();
+
+    quote::quote! {
+        #vis
+        #sig {
+            let result = {
+                let core_fn = |#inputs| {
+                    async {
+                        #block
+                    }
+                };
+                core_fn(#args_without_type)
+            };
+            Metadata::new(#attr, stringify!(#ident), result.await)
+        }
+    }.into()
+}

--- a/src/rust/e2e/e2e-proc-macro/src/lib.rs
+++ b/src/rust/e2e/e2e-proc-macro/src/lib.rs
@@ -35,10 +35,7 @@ pub fn e2e_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let ItemFn {
-        vis,
-        sig,
-        block,
-        ..
+        vis, sig, block, ..
     } = input;
     let inputs = sig.inputs.clone();
     let ident = sig.ident.clone();
@@ -56,5 +53,6 @@ pub fn e2e_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
             Metadata::new(#attr, stringify!(#ident), result.await)
         }
-    }.into()
+    }
+    .into()
 }

--- a/src/rust/e2e/metadata/Cargo.toml
+++ b/src/rust/e2e/metadata/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "metadata"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/src/rust/e2e/metadata/src/lib.rs
+++ b/src/rust/e2e/metadata/src/lib.rs
@@ -6,7 +6,11 @@ pub struct Metadata<T> {
 
 impl<T> Metadata<T> {
     pub fn new(namespace: impl Into<String>, name: impl Into<String>, result: T) -> Self {
-        Self { namespace: namespace.into(), name: name.into(), result }
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+            result,
+        }
     }
 
     pub fn namespace(&self) -> &str {

--- a/src/rust/e2e/metadata/src/lib.rs
+++ b/src/rust/e2e/metadata/src/lib.rs
@@ -1,0 +1,27 @@
+pub struct Metadata<T> {
+    namespace: String,
+    name: String,
+    result: T,
+}
+
+impl<T> Metadata<T> {
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>, result: T) -> Self {
+        Self { namespace: namespace.into(), name: name.into(), result }
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.name
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn result(&self) -> &T {
+        &self.result
+    }
+
+    pub fn decompose(self) -> (String, String, T) {
+        (self.namespace, self.name, self.result)
+    }
+}

--- a/src/rust/e2e/src/main.rs
+++ b/src/rust/e2e/src/main.rs
@@ -1,177 +1,84 @@
-use std::{str::FromStr, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin};
 
-use anyhow::{ensure, Result};
-use aptos_sdk::{
-    bcs,
-    move_types::{
-        ident_str,
-        language_storage::{ModuleId, StructTag, TypeTag},
-    },
-    rest_client::{aptos_api_types::MoveModuleId, FaucetClient},
-    types::{
-        account_address::AccountAddress, transaction::EntryFunction, LocalAccount, APTOS_COIN_TYPE,
-    },
-};
+use anyhow::Result;
 use clap::Parser;
-use econia_sdk::{entry::*, errors::EconiaError, EconiaClient, EconiaResult};
-use sqlx::{query, PgPool};
+use colored::Colorize;
+use futures::{stream::FuturesUnordered, StreamExt};
+use indicatif::ProgressStyle;
+use market_registration::test_market_registration;
+use metadata::Metadata;
+use utils::{init, Args, State};
 
-const TIMEOUT: Duration = Duration::from_secs(1);
+mod market_registration;
+mod utils;
 
-#[derive(Parser, Debug)]
-pub struct Args {
-    /// The URL of the Aptos node
-    pub node_url: String,
-
-    /// The URL of the faucet
-    pub faucet_url: String,
-
-    /// The address of the Econia contract
-    pub econia_address: String,
-
-    /// The address of the Aptos faucet
-    pub faucet_address: String,
-
-    /// The database URL
-    pub db_url: String,
+fn message(success: bool, name: &str) -> String {
+    let status = if success { "OK".green() } else { "FAIL".red() };
+    let name = if name.len() > 20 {
+        format!("{}...", &name[..17])
+    } else {
+        name.to_string()
+    };
+    format!("{name}: {status}")
 }
 
-pub struct Init {
-    e_apt: TypeTag,
-    e_usdc: TypeTag,
-    faucet_address: AccountAddress,
-    faucet_client: FaucetClient,
-    econia_address: AccountAddress,
-    econia_client: EconiaClient,
-    db_pool: PgPool,
-}
+async fn run_tests(state: State) -> Result<()> {
+    let mut successes: HashMap<String, Vec<String>> = HashMap::new();
+    let mut fails: HashMap<String, Vec<(String, anyhow::Error)>> = HashMap::new();
+    {
+        let mut v: FuturesUnordered<Pin<Box<dyn Future<Output = Metadata<Result<()>>>>>> =
+            FuturesUnordered::new();
+        v.push(Box::pin(test_market_registration(&state)));
 
-/// Creates the initial variables needed
-async fn init(args: &Args) -> Init {
-    // Create eAPT and eUSDC `TypeTag`s
-    let faucet_address = AccountAddress::from_hex_literal(&args.faucet_address).unwrap();
-    let e_apt = TypeTag::Struct(Box::new(
-        StructTag::from_str(&format!("0x{faucet_address}::example_apt::ExampleAPT")).unwrap(),
-    ));
-    let e_usdc = TypeTag::Struct(Box::new(
-        StructTag::from_str(&format!("0x{faucet_address}::example_usdc::ExampleUSDC")).unwrap(),
-    ));
-
-    // Create a `FaucetClient`
-    let faucet_client = FaucetClient::new(
-        reqwest::Url::parse(&args.faucet_url).unwrap(),
-        reqwest::Url::parse(&args.node_url).unwrap(),
-    );
-
-    // Transform the Econia address from `String` to `AccountAddress`
-    let econia_address =
-        AccountAddress::from_hex_literal(&args.econia_address).expect("Could not parse address.");
-
-    let (_, econia_client) = account(&faucet_client, &args.node_url, econia_address.clone()).await;
-
-    let db_pool = PgPool::connect(&args.db_url)
-        .await
-        .expect("Could not connect to the database.");
-
-    Init {
-        e_apt,
-        e_usdc,
-        faucet_address,
-        faucet_client,
-        econia_address,
-        econia_client,
-        db_pool,
+        let i = indicatif::ProgressBar::new(v.len() as u64);
+        i.set_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise:.green}] {wide_bar:.blue/blue} {pos}/{len} {msg:<26}",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+        );
+        while let Some(result) = v.next().await {
+            let (namespace, name, result) = result.decompose();
+            i.set_message(message(result.is_ok(), &name));
+            if result.is_ok() {
+                successes
+                    .entry(namespace)
+                    .and_modify(|v| v.push(name.to_string()))
+                    .or_insert(vec![name.to_string()]);
+            } else {
+                if !fails.contains_key(&namespace) {
+                    fails.insert(namespace.clone(), vec![]);
+                }
+                fails
+                    .entry(namespace)
+                    .and_modify(|v| v.push((name.to_string(), result.err().unwrap())));
+            }
+            i.inc(1);
+        }
+        i.finish();
     }
-}
 
-/// Creates an account (locally and on the chain) and funds it with APT
-pub async fn account(
-    faucet_client: &FaucetClient,
-    node_url: &str,
-    econia_address: AccountAddress,
-) -> (AccountAddress, EconiaClient) {
-    let account = LocalAccount::generate(&mut rand::thread_rng());
-    let account_address = account.address();
-    faucet_client.create_account(account_address).await.unwrap();
-    faucet_client
-        .fund(account_address, 100_000_000_000)
-        .await
-        .unwrap();
+    println!("Sccesses:");
+    successes.iter().for_each(|(namespace, v)| {
+        println!("-> {namespace}");
+        v.iter().for_each(|name| println!("  -> {}", name.green()))
+    });
 
-    let econia_client = EconiaClient::connect(
-        reqwest::Url::parse(&node_url).unwrap(),
-        econia_address.clone(),
-        account,
-        None,
-    )
-    .await
-    .unwrap();
+    println!("Fails:");
+    fails.iter().for_each(|(namespace, v)| {
+        println!("-> {namespace}");
+        v.iter()
+            .for_each(|(name, err)| println!("  -> {} (error: {:?})", name.red(), err))
+    });
 
-    (account_address, econia_client)
-}
-
-/// Funds an amount with the coin specified
-pub async fn fund(
-    coin: &TypeTag,
-    amount: u64,
-    econia_client: &mut EconiaClient,
-    faucet_address: AccountAddress,
-) -> EconiaResult<()> {
-    let module_id = ModuleId::from(
-        MoveModuleId::from_str(&format!("{}::faucet", faucet_address))
-            .map_err(|a| EconiaError::InvalidModuleId(a.to_string()))?,
-    );
-    let entry = EntryFunction::new(
-        module_id.clone(),
-        ident_str!("mint").to_owned(),
-        vec![coin.clone().into()],
-        vec![bcs::to_bytes(&amount)?],
-    );
-    econia_client.submit_tx(entry).await?;
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    let state = init(&args).await;
 
-    let Init {
-        e_apt,
-        e_usdc,
-        faucet_address,
-        faucet_client,
-        econia_address,
-        mut econia_client,
-        db_pool,
-    } = init(&args).await;
-
-    let lot_size = 10u64.pow(8 - 3); // eAPT has 8 decimals, want 1/1000th granularity
-    let tick_size = 10u64.pow(6 - 3); // eAPT has 6 decimals, want 1/1000th granularity
-    let min_size = 1;
-
-    let entry = register_market_base_coin_from_coinstore(
-        econia_address,
-        &e_apt,
-        &e_usdc,
-        &APTOS_COIN_TYPE,
-        lot_size,
-        tick_size,
-        min_size,
-    )
-    .unwrap();
-
-    econia_client.submit_tx(entry).await?;
-
-    std::thread::sleep(TIMEOUT);
-
-    let result = query!("SELECT COUNT(*) AS count FROM market_registration_events")
-        .fetch_one(&db_pool)
-        .await?;
-
-    ensure!(
-        result.count == Some(1),
-        "Market not inserted into the database"
-    );
-
-    Ok(())
+    run_tests(state).await
 }

--- a/src/rust/e2e/src/main.rs
+++ b/src/rust/e2e/src/main.rs
@@ -59,7 +59,7 @@ async fn run_tests(state: State) -> Result<()> {
         i.finish();
     }
 
-    println!("Sccesses:");
+    println!("Successes:");
     successes.iter().for_each(|(namespace, v)| {
         println!("-> {namespace}");
         v.iter().for_each(|name| println!("  -> {}", name.green()))

--- a/src/rust/e2e/src/market_registration.rs
+++ b/src/rust/e2e/src/market_registration.rs
@@ -12,7 +12,9 @@ use crate::utils::*;
 pub async fn test_market_registration<'a>(state: &'a State) -> Result<()> {
     let lot_size = 10u64.pow(8 - 3); // eAPT has 8 decimals, want 1/1000th granularity
     let tick_size = 10u64.pow(6 - 3); // eAPT has 6 decimals, want 1/1000th granularity
-    let min_size = 1;
+    let min_size = state
+        .market_size
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     let entry = register_market_base_coin_from_coinstore(
         state.econia_address.clone(),

--- a/src/rust/e2e/src/market_registration.rs
+++ b/src/rust/e2e/src/market_registration.rs
@@ -1,0 +1,45 @@
+use anyhow::{ensure, Result};
+use aptos_sdk::types::APTOS_COIN_TYPE;
+use e2e_proc_macro::e2e_test;
+use econia_sdk::entry::register_market_base_coin_from_coinstore;
+use sqlx::query;
+
+use metadata::Metadata;
+
+use crate::utils::*;
+
+#[e2e_test]
+pub async fn test_market_registration<'a>(state: &'a State) -> Result<()> {
+    let lot_size = 10u64.pow(8 - 3); // eAPT has 8 decimals, want 1/1000th granularity
+    let tick_size = 10u64.pow(6 - 3); // eAPT has 6 decimals, want 1/1000th granularity
+    let min_size = 1;
+
+    let entry = register_market_base_coin_from_coinstore(
+        state.econia_address.clone(),
+        &state.e_apt,
+        &state.e_usdc,
+        &APTOS_COIN_TYPE,
+        lot_size,
+        tick_size,
+        min_size,
+    )
+    .unwrap();
+
+    let (_, mut econia_client) =
+        account(&state.faucet_client, &state.node_url, state.econia_address).await;
+
+    econia_client.submit_tx(entry).await?;
+
+    std::thread::sleep(TIMEOUT);
+
+    let result = query!("SELECT COUNT(*) AS count FROM market_registration_events")
+        .fetch_one(&state.db_pool)
+        .await?;
+
+    ensure!(
+        result.count.is_some() && result.count.unwrap() > 1,
+        "Market not inserted into the database"
+    );
+
+    Ok(())
+}

--- a/src/rust/e2e/src/utils.rs
+++ b/src/rust/e2e/src/utils.rs
@@ -1,0 +1,133 @@
+use std::{time::Duration, str::FromStr};
+
+use anyhow::Result;
+use aptos_sdk::{
+    bcs,
+    move_types::{
+        ident_str,
+        language_storage::{ModuleId, StructTag, TypeTag},
+    },
+    rest_client::{aptos_api_types::MoveModuleId, FaucetClient},
+    types::{
+        account_address::AccountAddress, transaction::EntryFunction, LocalAccount
+    },
+};
+use clap::Parser;
+use econia_sdk::EconiaClient;
+use sqlx::PgPool;
+
+pub const TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The URL of the Aptos node
+    pub node_url: String,
+
+    /// The URL of the faucet
+    pub faucet_url: String,
+
+    /// The address of the Econia contract
+    pub econia_address: String,
+
+    /// The address of the Aptos faucet
+    pub faucet_address: String,
+
+    /// The database URL
+    pub db_url: String,
+}
+
+pub struct State {
+    pub e_apt: TypeTag,
+    pub e_usdc: TypeTag,
+    pub faucet_address: AccountAddress,
+    pub faucet_client: FaucetClient,
+    pub econia_address: AccountAddress,
+    pub econia_client: EconiaClient,
+    pub db_pool: PgPool,
+    pub node_url: String,
+}
+
+/// Creates the initial variables needed
+pub async fn init(args: &Args) -> State {
+    // Create eAPT and eUSDC `TypeTag`s
+    let faucet_address = AccountAddress::from_hex_literal(&args.faucet_address).unwrap();
+    let e_apt = TypeTag::Struct(Box::new(
+        StructTag::from_str(&format!("0x{faucet_address}::example_apt::ExampleAPT")).unwrap(),
+    ));
+    let e_usdc = TypeTag::Struct(Box::new(
+        StructTag::from_str(&format!("0x{faucet_address}::example_usdc::ExampleUSDC")).unwrap(),
+    ));
+
+    // Create a `FaucetClient`
+    let faucet_client = FaucetClient::new(
+        reqwest::Url::parse(&args.faucet_url).unwrap(),
+        reqwest::Url::parse(&args.node_url).unwrap(),
+    );
+
+    // Transform the Econia address from `String` to `AccountAddress`
+    let econia_address =
+        AccountAddress::from_hex_literal(&args.econia_address).expect("Could not parse address.");
+
+    let (_, econia_client) = account(&faucet_client, &args.node_url, econia_address.clone()).await;
+
+    let db_pool = PgPool::connect(&args.db_url)
+        .await
+        .expect("Could not connect to the database.");
+
+    State {
+        e_apt,
+        e_usdc,
+        faucet_address,
+        faucet_client,
+        econia_address,
+        econia_client,
+        db_pool,
+        node_url: args.node_url.clone()
+    }
+}
+
+/// Creates an account (locally and on the chain) and funds it with APT
+pub async fn account(
+    faucet_client: &FaucetClient,
+    node_url: &str,
+    econia_address: AccountAddress,
+) -> (AccountAddress, EconiaClient) {
+    let account = LocalAccount::generate(&mut rand::thread_rng());
+    let account_address = account.address();
+    faucet_client.create_account(account_address).await.unwrap();
+    faucet_client
+        .fund(account_address, 100_000_000_000)
+        .await
+        .unwrap();
+
+    let econia_client = EconiaClient::connect(
+        reqwest::Url::parse(&node_url).unwrap(),
+        econia_address.clone(),
+        account,
+        None,
+    )
+    .await
+    .unwrap();
+
+    (account_address, econia_client)
+}
+
+/// Funds an amount with the coin specified
+pub async fn fund(
+    coin: &TypeTag,
+    amount: u64,
+    econia_client: &mut EconiaClient,
+    faucet_address: AccountAddress,
+) -> Result<()> {
+    let module_id = ModuleId::from(
+        MoveModuleId::from_str(&format!("{}::faucet", faucet_address))?
+    );
+    let entry = EntryFunction::new(
+        module_id.clone(),
+        ident_str!("mint").to_owned(),
+        vec![coin.clone().into()],
+        vec![bcs::to_bytes(&amount)?],
+    );
+    econia_client.submit_tx(entry).await?;
+    Ok(())
+}


### PR DESCRIPTION
Add an e2e framework.

There are 3 crates added in this PR:

| Name  | Description |
| --- | --- |
| `e2e` | The main crate. Contains the different tests as well as the main function that runs all those tests.|
| `e2e-proc-macro` | A crate that contains the `e2e_test` proc macro. This macro transforms the return type of a function by wrapping it into `Metadata`. It can also accept a namespace as an argument (this is used to group tests into named spaces). |
| `metadata` | A crate containing a simple `Metadata` struct. This contains the name of the function, as well as the namespace of the test. |

To create a new test, you can look at `e2e/src/market_registration.rs` for inspiration.