### PR TITLE
[ECO-562] Evict empty orders during matching

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -7,6 +7,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 ### Added
 
 - Abort for order size change below min size ([#500])
+- Add check to evict empty orders during matching ([#504])
 
 ## [v4.1.0]
 
@@ -51,6 +52,7 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#428]: https://github.com/econia-labs/econia/pull/428
 [#429]: https://github.com/econia-labs/econia/pull/429
 [#500]: https://github.com/econia-labs/econia/pull/500
+[#504]: https://github.com/econia-labs/econia/pull/504
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [v4.1.0]: https://github.com/econia-labs/econia/releases/tag/v4.1.0-audited

--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -6,8 +6,8 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 
 ### Added
 
-- Abort for order size change below min size ([#500])
-- Add check to evict empty orders during matching ([#504])
+- Abort for order size change below min size ([#500]).
+- Add check to evict empty orders during matching ([#504]).
 
 ## [v4.1.0]
 


### PR DESCRIPTION
The matching engine returns silently if it encounters an order of size 0, which should never happen in production.

Add an extra check to evict an order of size 0 if one ends up on the book, rather than returning silently. Also add an associated test.