### PR TITLE
Fix docker compose and sql error

### DIFF
--- a/src/docker/compose.database.yaml
+++ b/src/docker/compose.database.yaml
@@ -9,7 +9,9 @@ services:
       context: ../../
       dockerfile: src/docker/database/Dockerfile.diesel
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+        restart: true
 
   postgres:
     environment:

--- a/src/docker/compose.dss-global.yaml
+++ b/src/docker/compose.dss-global.yaml
@@ -41,7 +41,8 @@ services:
       - postgres
     environment:
       - PGWS_DB_URI=postgres://econia:econia@postgres/econia
-      - PGWS_JWT_SECRET=econia_is_dope
+      - PGWS_JWT_SECRET=econia_is_dooooooooooooooooooope
       - PGWS_CHECK_LISTENER_INTERVAL=1000
+      - PGWS_LISTEN_CHANNEL=econiaws
     ports:
-      - 3000:8083
+      - 3000:3000

--- a/src/docker/database/Dockerfile.postgres
+++ b/src/docker/database/Dockerfile.postgres
@@ -15,3 +15,6 @@ RUN apt autoremove -y git make
 WORKDIR ..
 
 RUN rm -rf ./pgjwt
+
+HEALTHCHECK --interval=5s --timeout=3s \
+    CMD pg_isready -h localhost -p 5432 -U econia || exit 1

--- a/src/rust/dbv2/migrations/2023-09-20-193413_add_limit_order_events/up.sql
+++ b/src/rust/dbv2/migrations/2023-09-20-193413_add_limit_order_events/up.sql
@@ -57,7 +57,7 @@ CREATE TABLE
 
 CREATE FUNCTION notify_place_limit_order_event () RETURNS TRIGGER AS $$
 BEGIN
-   PERFORM pg_notify('econiaws', json_build_object('channel', 'place_limit_order_event', 'payload', NEW::text));
+   PERFORM pg_notify('econiaws', json_build_object('channel', 'place_limit_order_event', 'payload', NEW)::text);
    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -86,7 +86,7 @@ CREATE TABLE
 
 CREATE FUNCTION notify_cancel_order_event () RETURNS TRIGGER AS $$
 BEGIN
-   PERFORM pg_notify('econiaws', json_build_object('channel', 'cancel_order_event', 'payload', NEW::text));
+   PERFORM pg_notify('econiaws', json_build_object('channel', 'cancel_order_event', 'payload', NEW)::text);
    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Some bugs were found when running the stack in global mode, as well as when running it after running `docker volume prune -af`. Here are the fixes:

- Add `HEALTHCHECK` to the `postgres` service to avoid the `diesel` service from failing due to the `postgres` service not being ready.
- Update `compose.dss-global.yaml`'s `ws` service with the environment variables from `compose.dss-local.yaml`.
- Fix a typo in the `src/rust/dbv2/migrations/2023-09-20-193413_add_limit_order_events/up.sql` file which made WebSockets events for some events not work.