### PR TITLE
[ECO-567] Embed DSS REST API in docs site

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/rest-api.md
+++ b/doc/doc-site/docs/off-chain/dss/rest-api.md
@@ -1,6 +1,11 @@
-# REST API
+---
+title: REST API
+hide_table_of_contents: true
+---
 
-See auto-generated REST API docs [here](https://econia.dev/api).
+import ApiDocMdx from '@theme/ApiDocMdx';
+
+<ApiDocMdx id="dss-rest-api" />
 
 <!---
 To update, see instructions in `/src/doc/doc-site/README.md`.

--- a/doc/doc-site/docusaurus.config.js
+++ b/doc/doc-site/docusaurus.config.js
@@ -24,13 +24,11 @@ module.exports = {
       {
         specs: [
           {
+            id: 'dss-rest-api',
             spec: './openapi.json',
             route: '/api/',
           },
         ],
-        theme: {
-          primaryColor: '#1890ff',
-        },
       },
     ],
     [


### PR DESCRIPTION
* Embed the DSS REST API directly in the docs site topic page
* Remove theme overriding so that link colors are consitent with the rest of the docs site