### PR TITLE
[ECO-595][ECO-596][ECO-597] Add recognized market, change size, swap event triggers to `trade.py`

### DIFF
--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -207,6 +207,11 @@ cd ./econia/src/python/sdk && poetry install # only if necessary
 poetry run trade # we're off to the races!
 ```
 
+There will be a few more prompts; enter nothing for them until you reach this printout:
+```
+Press enter to initialize (or obtain) the market.
+```
+
 ### Understanding the example script
 
 #### Step #1: Setup the market
@@ -288,7 +293,46 @@ Limit orders make an asset available for purchase at a given price.
 When a market order comes along and pays the price of a limit order, this is called a "fill" event.
 We're about to witness such a fill event in the coming steps.
 
-#### Step #4: Setup the account "B"
+#### Step #4: Change order sizes (as Account A)
+```
+Press enter to change Account A's order sizes.
+TRANSACTIONS EXECUTED (first-to-last):
+  * Increase bid order size (#1): 0x47bf742b9ec506d1ccfb26cec23e8a4a68b9e8803f5cca88a7b8cdbf51b08359
+  * Decrease ask order size (#1): 0x532f26500b7d0f0147b1ee534857b7b775a945bf82905401e8bf95fee3f64637
+```
+
+Limit orders can be size-changed by their owner, including size increases.
+**If the size increases, the order is sent to the back of the time priority queue at its price!**
+This ensures price-time priority is preserved within the exchange.
+Here, the script has increase the size of the one bid order created above.
+It's also decreased the size of the one ask order created above.
+Both of these transactions emit `ChangeOrderSizeEvent`.
+
+#### Step #5: Self-trade with swap orders (as Account A)
+```
+Press enter to swap with Account A.
+TRANSACTIONS EXECUTED (first-to-last):
+  * Execute BID swap order for Account A: 0x8b7506df5e75320d35ffaf29410a993c168bda38c3c24145d42dad2cf39afd6b
+  * Execute ASK swap order for Account A: 0x3ae0c79f9dca26552d42b700b4de319d0dda65f12acc8d2328d0c9f057792c4e
+```
+
+It's possible for an account to trade against itself, such as with the swap orders above.
+Swaps are trades performed without a market account involved.
+Since the limit orders have the `CancelMaker` self-match behavior, the above swaps do not emit fill events.
+However, the swaps do result in `PlaceSwapOrderEvent` emissions even though the trade doesn't fill anything.
+
+#### Step #6: Re-create limit orders (as Account A)
+
+```
+Press enter to place limit orders with Account A (again).
+TRANSACTIONS EXECUTED (first-to-last):
+  * Place limit BID/BUY order (1000 lots) (1000 ticks/lot): 0x53933e783433ff0d205901cfc113cdcfcd8b419fd096f5f80754292c9c2bfd68
+  * Place limit ASK/SELL order (1000 lots) (2000 ticks/lot): 0x8c88653058da8cfaddda4322e58995935528cea74878bd4924e194a3d29e718d
+```
+
+See step #3 above.
+
+#### Step #7: Setup the account "B"
 
 ```
 Press enter to setup an Account B with funds.
@@ -306,7 +350,7 @@ TRANSACTIONS EXECUTED (first-to-last):
 
 Same as step #2, but for a new account.
 
-#### Step 5: Place market orders (as account B)
+#### Step #8: Place market orders (as account B)
 
 ```
 Press enter to place market orders (buy and sell) with Account B.
@@ -323,7 +367,7 @@ CURRENT BEST PRICE LEVELS:
 Here after Account B has placed their market orders in both directions, the best price level in both directions has gone down in total size.
 This is expected, because some of the liquidity available has been taken at the agreed-upon prices in both the "buy base asset" (bid) and "sell base asset" (ask) cases.
 
-#### Step 6: Cancel all limit orders (as account A)
+#### Step #9: Cancel all limit orders (as account A)
 
 ```
 Press enter to cancel all of Account A's outstanding orders
@@ -338,7 +382,7 @@ There is no eAPT being bought or sold right now!
 This one is straightforward, but it's worth nothing that there are no longer orders on the book unlike in the step above.
 That's because in this case, all of the liquidity in the order book has been cancelled by our cancelling all of Account A's orders (since Account A's orders were all the orders on the book).
 
-#### Step 7: Place multiple competitive limit orders (as account A)
+#### Step #10: Place multiple competitive limit orders (as account A)
 
 ```
 Press enter to place competitive limit orders (top-of-book) with Account A.
@@ -366,7 +410,7 @@ Likewise the lowest price the base asset (tETH) is being sold for right now is 1
 
 We'll see the sequence of these limit orders clearer in the next step, where Account B places spread-crossing limit orders.
 
-#### Step #8: Place spread-crossing limit orders (as account B)
+#### Step #11: Place spread-crossing limit orders (as account B)
 
 ```
 Press enter to place spread-crossing limit order with Account B (no remainder).

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -75,14 +75,7 @@ poetry install
 poetry run trade
 ```
 
-The script will have a few prompts, respond to each of them as follows:
-
-| Prompt         | Value                                                                |
-| -------------- | -------------------------------------------------------------------- |
-| Econia address | `0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40` |
-| Faucet address | `0xffff094ef8ccfa9137adcb13a2fae2587e83c348b32c63f811cc19fcc9fc5878` |
-| Node URL       | http://0.0.0.0:8080/v1                                               |
-| Faucet URL     | http://0.0.0.0:8081                                                  |
+The script will have a few prompts, respond to each of them with nothing for all of them.
 
 Next, the script will step through various operations such as order creation, cancellation and fulfillment; press `ENTER` to advance each step.
 The script should execute to completion (it says `THE END!`) if everything is working.
@@ -92,6 +85,9 @@ Verify that the database is accessible by navigating to `http://0.0.0.0:3001`, a
 - `http://0.0.0.0:3001/cancel_order_events`
 - `http://0.0.0.0:3001/fill_events`
 - `http://0.0.0.0:3001/place_limit_order_events`
+- `http://0.0.0.0:3001/change_order_size_events`
+- `http://0.0.0.0:3001/place_market_order_events`
+- `http://0.0.0.0:3001/place_swap_order_events`
 
 If each of these tables is visible and containing data then that means the processor, database and PostgREST are all working together!
 

--- a/src/python/sdk/examples/trade.py
+++ b/src/python/sdk/examples/trade.py
@@ -165,11 +165,11 @@ def start():
     bids_price, asks_price = get_best_prices(viewer, market_id)
     if bids_price is not None or asks_price is not None:
         input("\n\nPress enter to clean-up open orders on the market.")
-        account_ = setup_new_account(viewer, faucet_client, market_id, 9, 10_000 * 100)
+        account_ = setup_new_account(viewer, faucet_client, market_id, 1000000, 1000000)
         if bids_price is not None:
-            place_market_order(Side.ASK, account_, market_id, 9000)
+            place_market_order(Side.ASK, account_, market_id, 1000000)
         if asks_price is not None:
-            place_market_order(Side.BID, account_, market_id, 9000)
+            place_market_order(Side.BID, account_, market_id, 1000000)
 
         dump_txns()
         n_clears = len(get_fill_events(viewer, account_.account_address, market_id, 0))
@@ -252,7 +252,7 @@ def start():
 
     input("\n\nPress enter to swap with Account A.")
     calldata = swap_between_coinstores_entry(
-        account_A.account_address,
+        ECONIA_ADDR,
         TypeTag(StructTag.from_str(COIN_TYPE_EAPT)),
         TypeTag(StructTag.from_str(COIN_TYPE_EUSDC)),
         market_id,
@@ -262,16 +262,15 @@ def start():
         U64_MAX,
         0,
         U64_MAX,
-        U64_MAX
+        U64_MAX >> 32
     )
     exec_txn(
         EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
         calldata,
         "Execute BID swap order for Account A"
     )
-
     calldata = swap_between_coinstores_entry(
-        account_A.account_address,
+        ECONIA_ADDR,
         TypeTag(StructTag.from_str(COIN_TYPE_EAPT)),
         TypeTag(StructTag.from_str(COIN_TYPE_EUSDC)),
         market_id,
@@ -288,6 +287,7 @@ def start():
         calldata,
         "Execute ASK swap order for Account A"
     )
+    dump_txns()
 
     input("\n\nPress enter to setup an Account B with funds.")
     account_B = setup_new_account(viewer, faucet_client, market_id)

--- a/src/python/sdk/examples/trade.py
+++ b/src/python/sdk/examples/trade.py
@@ -33,13 +33,14 @@ from econia_sdk.view.user import (
 )
 
 """
-HOW TO RUN THIS SCRIPT: `poetry install && poetry run trade` in .../econia/src/python/sdk
+HOW TO RUN THIS SCRIPT: `poetry install && poetry run trade` in /econia/src/python/sdk
 
-See instructions in /src/docker/README.md to see how to run this script against a local
-deployment of Econia (including the backend service stack).
+See instructions in /econia/src/docker/README.md to see how to run this script against
+a local deployment of Econia, including the data service stack.
 
-There are several prompts; entering nothing for all of them will default to running
-against a local deployment without performing a market recognization.
+There are several prompts; entering nothing for all of them will result in:
+- Running against a local deployment of the data service stack.
+- No market will be listed as recognized.
 """
 
 U64_MAX = (2**64) - 1
@@ -111,7 +112,7 @@ def get_aptos_node_url() -> str:
             "Enter the URL of an Aptos node (enter nothing to default to local OR re-run with APTOS_NODE_URL environment variable)\n"
         ).strip()
         if url_in == "":
-            return NODE_URL_LOCAL  # devnet default
+            return NODE_URL_LOCAL
         else:
             return url_in
     else:
@@ -125,7 +126,7 @@ def get_aptos_faucet_url() -> str:
             "Please enter the URL of an Aptos faucet (enter nothing to default to local OR re-run with APTOS_FAUCET_URL environment variable)\n"
         ).strip()
         if url_in == "":
-            return FAUCET_URL_LOCAL  # devnet default
+            return FAUCET_URL_LOCAL
         else:
             return url_in
     else:
@@ -213,7 +214,7 @@ def start():
     (bids, asks) = get_order_ids(account_A.account_address, market_id)
     bid_size = 0
     for (i, bid) in enumerate(bids):
-        bid_size_new = bid["size"] // (i + 2)
+        bid_size_new = bid["size"] * (i + 2)
         bid_size = (bid_size + bid_size_new,)
         exec_txn(
             EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
@@ -224,7 +225,7 @@ def start():
                 bid["market_order_id"],
                 bid_size_new,
             ),
-            f"Change bid size (#{i + 1})",
+            f"Increase bid order size (#{i + 1})",
         )
     ask_size = 0
     for (i, ask) in enumerate(asks):
@@ -239,7 +240,7 @@ def start():
                 ask["market_order_id"],
                 ask_size_new,
             ),
-            f"Change ask size (#{i + 1})",
+            f"Decrease ask order size (#{i + 1})",
         )
     dump_txns()
 

--- a/src/python/sdk/examples/trade.py
+++ b/src/python/sdk/examples/trade.py
@@ -174,7 +174,7 @@ def start():
         viewer, account_A.account_address, market_id, 0
     )
     report_place_limit_order_event(
-        list(filter(lambda ev: ev["data"]["side"] == Side.BID, events))[0]
+        next(filter(lambda ev: ev["data"]["side"] == Side.BID, events))
     )
     # Ask to sell 1 whole eAPT
     sell_base_lots = 1 * (10**3)
@@ -186,7 +186,7 @@ def start():
         viewer, account_A.account_address, market_id, 0
     )
     report_place_limit_order_event(
-        list(filter(lambda ev: ev["data"]["side"] == Side.ASK, events))[0]
+        next(filter(lambda ev: ev["data"]["side"] == Side.ASK, events))
     )
     print(f"Account A has finished placing limit orders.")
     fills = get_fill_events(viewer, account_A.account_address, market_id, 0)
@@ -391,7 +391,7 @@ def setup_new_account(
     client = EconiaClient(NODE_URL, ECONIA_ADDR, account)
 
     # Fund with APT, "eAPT" and "eUSDC"
-    faucet.fund_account(account.address(), 1 * (10**8))
+    faucet.fund_account(account.address().hex(), 1 * (10**8))
     fund_APT(account, base_wholes)
     fund_USDC(account, quote_wholes)
 
@@ -493,11 +493,11 @@ def setup_market(faucet_client: FaucetClient, viewer: EconiaViewer) -> int:
     if market_id == None:
         account_XCH = Account.generate()
         # The faucet only gives out 1 APT at a time, have to go multiple times
-        faucet_client.fund_account(account_XCH.address(), 1 * (10**8))
-        faucet_client.fund_account(account_XCH.address(), 1 * (10**8))
-        faucet_client.fund_account(account_XCH.address(), 1 * (10**8))
-        faucet_client.fund_account(account_XCH.address(), 1 * (10**8))
-        faucet_client.fund_account(account_XCH.address(), 1 * (10**8))
+        faucet_client.fund_account(account_XCH.address().hex(), 1 * (10**8))
+        faucet_client.fund_account(account_XCH.address().hex(), 1 * (10**8))
+        faucet_client.fund_account(account_XCH.address().hex(), 1 * (10**8))
+        faucet_client.fund_account(account_XCH.address().hex(), 1 * (10**8))
+        faucet_client.fund_account(account_XCH.address().hex(), 1 * (10**8))
         print("Market does not exist yet, creating one...")
         calldata = register_market_base_coin_from_coinstore(
             ECONIA_ADDR,
@@ -518,7 +518,7 @@ def setup_market(faucet_client: FaucetClient, viewer: EconiaViewer) -> int:
         )
         events = get_market_registration_events(viewer)
         report_market_creation_event(
-            list(filter(lambda e: e["data"]["market_id"] == market_id, events))[0]
+            next(filter(lambda e: e["data"]["market_id"] == market_id, events))
         )
     if market_id == None:
         exit()
@@ -601,7 +601,7 @@ def report_fill_events(fill_events: list[dict]):
     print("LAST ORDER EXECUTION BREAKDOWN: FillEvent(s)")
     if len(fill_events) != 0:
         last_events = find_all_fill_events_with_last_taker_order_id(fill_events)
-        last_events_maker_side = last_events[0]["data"]["maker_side"]
+        last_events_maker_side = last_events[0]["data"]["maker_side"] # type: ignore
         n_last_events = len(last_events)
         if last_events_maker_side == Side.ASK:
             print(
@@ -630,7 +630,7 @@ def report_fill_events(fill_events: list[dict]):
 
 
 def report_order_for_last_fill(fill_events: list[dict], open_orders: list[dict]):
-    order_id = fill_events[-1]["data"]["taker_order_id"]
+    order_id = fill_events[-1]["data"]["taker_order_id"] # type: ignore
     open_order = list(filter(lambda ev: ev["order_id"] == order_id, open_orders))
     if len(open_order) == 1:
         print("  * The order WAS NOT fully satisfied by initial execution")
@@ -646,8 +646,8 @@ def find_all_fill_events_with_last_taker_order_id(
     index = len(events) - 1
     returns = []
     while index > 0:
-        last_fill_order_id = events[-1]["data"]["taker_order_id"]
-        ev = events[index]
+        last_fill_order_id = events[-1]["data"]["taker_order_id"] # type: ignore
+        ev = events[index] # type: ignore
         if ev["data"]["taker_order_id"] == last_fill_order_id:
             returns.append(ev)
         index = index - 1

--- a/src/python/sdk/examples/trade.py
+++ b/src/python/sdk/examples/trade.py
@@ -10,19 +10,14 @@ from aptos_sdk.type_tag import StructTag, TypeTag
 
 from econia_sdk.entry.market import (
     cancel_all_orders_user,
+    change_order_size_user,
     place_limit_order_user_entry,
     place_market_order_user_entry,
     register_market_base_coin_from_coinstore,
-    change_order_size_user,
-    swap_between_coinstores_entry
+    swap_between_coinstores_entry,
 )
-from econia_sdk.entry.user import (
-    deposit_from_coinstore,
-    register_market_account,
-)
-from econia_sdk.entry.registry import (
-    set_recognized_market
-)
+from econia_sdk.entry.registry import set_recognized_market
+from econia_sdk.entry.user import deposit_from_coinstore, register_market_account
 from econia_sdk.lib import EconiaClient, EconiaViewer
 from econia_sdk.types import Restriction, SelfMatchBehavior, Side
 from econia_sdk.view.market import get_open_orders_all, get_price_levels
@@ -35,7 +30,6 @@ from econia_sdk.view.user import (
     get_fill_events,
     get_market_account,
     get_place_limit_order_events,
-    get_market_account,
 )
 
 """
@@ -48,19 +42,14 @@ There are several prompts; entering nothing for all of them will default to runn
 against a local deployment without performing a market recognization.
 """
 
-U64_MAX = (2**64)-1
+U64_MAX = (2**64) - 1
 NODE_URL_LOCAL = "http://0.0.0.0:8080/v1"
 FAUCET_URL_LOCAL = "http://0.0.0.0:8081"
-ECONIA_ADDR_LOCAL = (
-    "0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40"
-)
-ECONIA_KEY_LOCAL = (
-    "0x8eeb9bd1808d99ef54758060f5067b5707be379058cfd83cd983fe7e47063a09"
-)
-FAUCET_ADDR_LOCAL = (
-    "0xffff094ef8ccfa9137adcb13a2fae2587e83c348b32c63f811cc19fcc9fc5878"
-)
+ECONIA_ADDR_LOCAL = "0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40"
+ECONIA_KEY_LOCAL = "0x8eeb9bd1808d99ef54758060f5067b5707be379058cfd83cd983fe7e47063a09"
+FAUCET_ADDR_LOCAL = "0xffff094ef8ccfa9137adcb13a2fae2587e83c348b32c63f811cc19fcc9fc5878"
 COIN_TYPE_APT = "0x1::aptos_coin::AptosCoin"
+
 
 def get_minimum_size() -> int:
     min_size_s = input(
@@ -69,10 +58,11 @@ def get_minimum_size() -> int:
     if min_size_s == "":
         return 500
     min_size = int(min_size_s)
-    if (min_size <= 0):
+    if min_size <= 0:
         raise ValueError("Minimum size must be at least 1 lot")
     else:
         return min_size
+
 
 def get_econia_address() -> AccountAddress:
     addr = environ.get("ECONIA_ADDR")
@@ -87,9 +77,10 @@ def get_econia_address() -> AccountAddress:
     else:
         return AccountAddress.from_hex(addr)
 
+
 def get_econia_account() -> Optional[Account]:
     private_key = input(
-        "Enter the 0x-prefixed private key of the Econia deployment (enter \".\" to use local OR enter nothing to skip recognizing the market)\n"
+        'Enter the 0x-prefixed private key of the Econia deployment (enter "." to use local OR enter nothing to skip recognizing the market)\n'
     ).strip()
     if private_key == "":
         return None
@@ -97,6 +88,7 @@ def get_econia_account() -> Optional[Account]:
         return Account.load_key(ECONIA_KEY_LOCAL)
     else:
         return Account.load_key(private_key)
+
 
 def get_faucet_address() -> AccountAddress:
     addr = environ.get("FAUCET_ADDR")
@@ -138,6 +130,7 @@ def get_aptos_faucet_url() -> str:
             return url_in
     else:
         return url
+
 
 MIN_SIZE = get_minimum_size()
 ECONIA_ADDR = (
@@ -220,8 +213,8 @@ def start():
     (bids, asks) = get_order_ids(account_A.account_address, market_id)
     bid_size = 0
     for (i, bid) in enumerate(bids):
-        bid_size_new = (bid["size"] // (i + 2))
-        bid_size = bid_size + bid_size_new,
+        bid_size_new = bid["size"] // (i + 2)
+        bid_size = (bid_size + bid_size_new,)
         exec_txn(
             EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
             change_order_size_user(
@@ -231,12 +224,12 @@ def start():
                 bid["market_order_id"],
                 bid_size_new,
             ),
-            f"Change bid size (#{i + 1})"
+            f"Change bid size (#{i + 1})",
         )
     ask_size = 0
     for (i, ask) in enumerate(asks):
-        ask_size_new = (ask["size"] // (i + 2))
-        ask_size = ask_size + ask_size_new,
+        ask_size_new = ask["size"] // (i + 2)
+        ask_size = (ask_size + ask_size_new,)
         exec_txn(
             EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
             change_order_size_user(
@@ -246,7 +239,7 @@ def start():
                 ask["market_order_id"],
                 ask_size_new,
             ),
-            f"Change ask size (#{i + 1})"
+            f"Change ask size (#{i + 1})",
         )
     dump_txns()
 
@@ -262,12 +255,12 @@ def start():
         U64_MAX,
         0,
         U64_MAX,
-        U64_MAX >> 32
+        U64_MAX >> 32,
     )
     exec_txn(
         EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
         calldata,
-        "Execute BID swap order for Account A"
+        "Execute BID swap order for Account A",
     )
     calldata = swap_between_coinstores_entry(
         ECONIA_ADDR,
@@ -280,12 +273,19 @@ def start():
         U64_MAX,
         0,
         U64_MAX,
-        0
+        0,
     )
     exec_txn(
         EconiaClient(NODE_URL, ECONIA_ADDR, account_A),
         calldata,
-        "Execute ASK swap order for Account A"
+        "Execute ASK swap order for Account A",
+    )
+    dump_txns()
+
+    input("\n\nPress enter to place limit orders with Account A (again).")
+    place_limit_order(Side.BID, account_A, market_id, buy_base_lots, buy_ticks_per_lot)
+    place_limit_order(
+        Side.ASK, account_A, market_id, sell_base_lots, sell_ticks_per_lot
     )
     dump_txns()
 
@@ -294,14 +294,10 @@ def start():
     print(f"Account B was setup: {account_B.account_address}")
     dump_txns()
 
-    input(
-        "\n\nPress enter to place market orders (buy and sell) with Account B."
-    )
+    input("\n\nPress enter to place market orders (buy and sell) with Account B.")
     place_market_order(Side.BID, account_B, market_id, 500)  # Buy 0.5 eAPT
     place_market_order(Side.ASK, account_B, market_id, 500)  # Sell 0.5 eAPT
-    fill_size = len(
-        get_fill_events(viewer, account_B.account_address, market_id, 0)
-    )
+    fill_size = len(get_fill_events(viewer, account_B.account_address, market_id, 0))
     print(f"Account B has finished placing 2 market orders.")
     print(f"  * This resulted in {fill_size} limit orders getting filled.")
     dump_txns()
@@ -371,10 +367,12 @@ def start():
 
     print("\n\nTHE END!")
 
+
 def get_order_ids(account_address: AccountAddress, market_id: int) -> Tuple[set, set]:
     viewer = EconiaViewer(NODE_URL, ECONIA_ADDR)
     market_account = get_market_account(viewer, account_address, market_id, 0)
     return (market_account["bids"], market_account["asks"])
+
 
 def place_market_order(
     direction: Side,
@@ -500,9 +498,7 @@ def setup_new_account(
     )
     exec_txn(client, calldata, f"Register a new account in market {market_id}")
 
-    mkt_account = get_market_account(
-        viewer, account.account_address, market_id, 0
-    )
+    mkt_account = get_market_account(viewer, account.account_address, market_id, 0)
     account_apt_pre = mkt_account["base_available"] // 10**8
     account_usdc_pre = mkt_account["quote_available"] // 10**6
 
@@ -621,15 +617,14 @@ def setup_market(faucet_client: FaucetClient, viewer: EconiaViewer) -> int:
 
     if ECONIA_ACCT is None:
         return market_id
-    
+
     fund_APT(ECONIA_ACCT, 1)
     exec_txn(
         EconiaClient(NODE_URL, ECONIA_ADDR, ECONIA_ACCT),
         set_recognized_market(ECONIA_ADDR, market_id),
-        f"Recognize the market (id {market_id}, min size {MIN_SIZE})"
+        f"Recognize the market (id {market_id}, min size {MIN_SIZE})",
     )
     return market_id
-    
 
 
 def get_best_prices(
@@ -707,7 +702,7 @@ def report_fill_events(fill_events: list[dict]):
     print("LAST ORDER EXECUTION BREAKDOWN: FillEvent(s)")
     if len(fill_events) != 0:
         last_events = find_all_fill_events_with_last_taker_order_id(fill_events)
-        last_events_maker_side = last_events[0]["data"]["maker_side"] # type: ignore
+        last_events_maker_side = last_events[0]["data"]["maker_side"]  # type: ignore
         n_last_events = len(last_events)
         if last_events_maker_side == Side.ASK:
             print(
@@ -736,7 +731,7 @@ def report_fill_events(fill_events: list[dict]):
 
 
 def report_order_for_last_fill(fill_events: list[dict], open_orders: list[dict]):
-    order_id = fill_events[-1]["data"]["taker_order_id"] # type: ignore
+    order_id = fill_events[-1]["data"]["taker_order_id"]  # type: ignore
     open_order = list(filter(lambda ev: ev["order_id"] == order_id, open_orders))
     if len(open_order) == 1:
         print("  * The order WAS NOT fully satisfied by initial execution")
@@ -752,8 +747,8 @@ def find_all_fill_events_with_last_taker_order_id(
     index = len(events) - 1
     returns = []
     while index > 0:
-        last_fill_order_id = events[-1]["data"]["taker_order_id"] # type: ignore
-        ev = events[index] # type: ignore
+        last_fill_order_id = events[-1]["data"]["taker_order_id"]  # type: ignore
+        ev = events[index]  # type: ignore
         if ev["data"]["taker_order_id"] == last_fill_order_id:
             returns.append(ev)
         index = index - 1


### PR DESCRIPTION
Among other events, we (and our developer friends) need the `trade.py` script to emit a `RecognizedMarketEvent` so that we can see its structure and verify our code around it. I've made it so that the user can optionally enter a private key for the Econia exchange which, if entered, will be used to generate the `Account` to recognize the market with. I've also added an argument for the minimum order size of the market so that multiple recognized/unrecognized markets can be created which should help front-end developers test their UI's and connectivity.

The idea is that this script can be used repeatedly to manually end-to-end test a UI for most of its features surrounding exchange activity.