### PR TITLE
[ECO-622] Cleanup recognized market PR

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -133,4 +133,4 @@ To see what transaction the DSS processor has synced through, do not run in deta
 
 Great job!
 You have successfully deployed Econia's DSS.
-You can now query port 3001 to access the REST API and port 3000 to access the WebSocket server.
+You can now query port 3000 to access the REST API and port 3001 to access the WebSocket server.

--- a/doc/doc-site/docs/off-chain/dss/websocket.md
+++ b/doc/doc-site/docs/off-chain/dss/websocket.md
@@ -109,13 +109,6 @@ cd src/python/sdk
 poetry run trade
 ```
 
-The script will have a few prompts, respond to each of them as follows:
-
-| Prompt         | Value                                                                |
-| -------------- | -------------------------------------------------------------------- |
-| Econia address | `0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40` |
-| Faucet address | `0xffff094ef8ccfa9137adcb13a2fae2587e83c348b32c63f811cc19fcc9fc5878` |
-| Node URL       | http://0.0.0.0:8080/v1                                               |
-| Faucet URL     | http://0.0.0.0:8081                                                  |
+Enter nothing for all of the prompts to use the default local configuration.
 
 As you run through the assorted sections in the trading script, you should see fill events coming in over the WebSockets channel.

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -157,7 +157,7 @@ Install the Aptos CLI & run your local node/faucet:
 ```bash
 brew install aptos # only if necessary
 mkdir aptos && cd aptos
-aptos node run-local-testnet --with-faucet
+aptos node run-local-testnet --with-faucet --test-dir data
 ```
 
 In another terminal, run the following:
@@ -173,8 +173,16 @@ It's time to deploy our own Econia Faucet to the local chain:
 ```bash
 git clone https://github.com/econia-labs/econia.git # only if necessary
 cd ./econia/src/move/faucet
-aptos init --profile econia_faucet_deploy # enter "local" for the chain
-export FAUCET_ADDR=<ACCOUNT-FROM-ABOVE> # make sure to put 0x at the start
+# enter "local" for the chain
+aptos init --profile econia_faucet_deploy
+```
+
+```sh
+# make sure to put 0x at the start
+export FAUCET_ADDR=<ACCOUNT-FROM-ABOVE>
+```
+
+```sh
 # deploy the faucet (all one command)
 aptos move publish \
         --named-addresses econia_faucet=$FAUCET_ADDR \
@@ -185,9 +193,17 @@ aptos move publish \
 You also need to deploy Econia:
 
 ```bash
-cd ./econia/src/move/econia
-aptos init --profile econia_exchange_deploy # enter "local" for the chain
-export ECONIA_ADDR=<ACCOUNT-FROM-ABOVE> # make sure to put 0x at the start
+cd ../econia/
+# enter "local" for the chain
+aptos init --profile econia_exchange_deploy
+```
+
+```sh
+# make sure to put 0x at the start
+export ECONIA_ADDR=<ACCOUNT-FROM-ABOVE>
+```
+
+```sh
 # deploy the exchange (all one command)
 aptos move publish \
         --override-size-check \
@@ -203,11 +219,13 @@ In order to run, install Poetry then install dependencies and run the script:
 
 ```bash
 brew install poetry # only if necessary
-cd ./econia/src/python/sdk && poetry install # only if necessary
+cd ../../python/sdk/
+poetry install # only if necessary
 poetry run trade # we're off to the races!
 ```
 
 There will be a few more prompts; enter nothing for them until you reach this printout:
+
 ```
 Press enter to initialize (or obtain) the market.
 ```
@@ -294,6 +312,7 @@ When a market order comes along and pays the price of a limit order, this is cal
 We're about to witness such a fill event in the coming steps.
 
 #### Step #4: Change order sizes (as Account A)
+
 ```
 Press enter to change Account A's order sizes.
 TRANSACTIONS EXECUTED (first-to-last):
@@ -304,11 +323,12 @@ TRANSACTIONS EXECUTED (first-to-last):
 Limit orders can be size-changed by their owner, including size increases.
 **If the size increases, the order is sent to the back of the time priority queue at its price!**
 This ensures price-time priority is preserved within the exchange.
-Here, the script has increase the size of the one bid order created above.
+Here, the script has increased the size of the one bid order created above.
 It's also decreased the size of the one ask order created above.
-Both of these transactions emit `ChangeOrderSizeEvent`.
+Both of these transactions emit a `ChangeOrderSizeEvent`.
 
 #### Step #5: Self-trade with swap orders (as Account A)
+
 ```
 Press enter to swap with Account A.
 TRANSACTIONS EXECUTED (first-to-last):
@@ -316,7 +336,7 @@ TRANSACTIONS EXECUTED (first-to-last):
   * Execute ASK swap order for Account A: 0x3ae0c79f9dca26552d42b700b4de319d0dda65f12acc8d2328d0c9f057792c4e
 ```
 
-It's possible for an account to trade against itself, such as with the swap orders above.
+It's possible for an account to match (but not fill) against itself, such as with the swap orders above.
 Swaps are trades performed without a market account involved.
 Since the limit orders have the `CancelMaker` self-match behavior, the above swaps do not emit fill events.
 However, the swaps do result in `PlaceSwapOrderEvent` emissions even though the trade doesn't fill anything.

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -64,7 +64,7 @@ poetry install
 poetry run trade
 ```
 
-The script will have a few prompts, respond to each of them with nothing for all of them.
+Enter nothing for all of the prompts to use the default local configuration.
 
 Next, the script will step through various operations such as order creation, cancellation and fulfillment; press `ENTER` to advance each step.
 The script should execute to completion (it says `THE END!`) if everything is working.
@@ -77,7 +77,7 @@ Verify that the database is accessible by navigating to `http://0.0.0.0:3000`, a
 - `http://0.0.0.0:3000/change_order_size_events`
 - `http://0.0.0.0:3000/place_market_order_events`
 - `http://0.0.0.0:3000/place_swap_order_events`
-- `http://0.0.0.0:3000/registered_market_evnets`
+- `http://0.0.0.0:3000/recognized_market_events`
 
 If each of these tables is visible and containing data then that means the processor, database and PostgREST are all working together!
 

--- a/src/docker/compose.dss-global.yaml
+++ b/src/docker/compose.dss-global.yaml
@@ -45,4 +45,4 @@ services:
       - PGWS_CHECK_LISTENER_INTERVAL=1000
       - PGWS_LISTEN_CHANNEL=econiaws
     ports:
-      - 3001:3000
+      - "3001:3000"

--- a/src/docker/compose.dss-local.yaml
+++ b/src/docker/compose.dss-local.yaml
@@ -56,4 +56,4 @@ services:
       - PGWS_CHECK_LISTENER_INTERVAL=1000
       - PGWS_LISTEN_CHANNEL=econiaws
     ports:
-      - 3001:3000
+      - "3001:3000"

--- a/src/rust/dbv2/migrations/2023-09-04-113144_postgrest/up.sql
+++ b/src/rust/dbv2/migrations/2023-09-04-113144_postgrest/up.sql
@@ -1,4 +1,5 @@
 -- Your SQL goes here
+DROP ROLE IF EXISTS web_anon;
 CREATE ROLE web_anon nologin;
 
 

--- a/src/rust/dbv2/src/schema.rs
+++ b/src/rust/dbv2/src/schema.rs
@@ -1,4 +1,21 @@
+// @generated automatically by Diesel CLI.
 
+diesel::table! {
+    balance_updates_by_handle (txn_version, handle, market_id, custodian_id) {
+        txn_version -> Numeric,
+        #[max_length = 70]
+        handle -> Varchar,
+        market_id -> Numeric,
+        custodian_id -> Numeric,
+        time -> Timestamptz,
+        base_total -> Numeric,
+        base_available -> Numeric,
+        base_ceiling -> Numeric,
+        quote_total -> Numeric,
+        quote_available -> Numeric,
+        quote_ceiling -> Numeric,
+    }
+}
 
 diesel::table! {
     cancel_order_events (txn_version, event_idx) {
@@ -60,24 +77,12 @@ diesel::table! {
 }
 
 diesel::table! {
-    recognized_market_events (txn_version, event_idx) {
-        txn_version -> Numeric,
-        event_idx -> Numeric,
-        time -> Timestamptz,
+    market_account_handles (user) {
         #[max_length = 70]
-        base_account_address -> Nullable<Varchar>,
-        base_module_name -> Nullable<Text>,
-        base_struct_name -> Nullable<Text>,
-        base_name_generic -> Nullable<Text>,
+        user -> Varchar,
         #[max_length = 70]
-        quote_account_address -> Varchar,
-        quote_module_name -> Text,
-        quote_struct_name -> Text,
-        market_id -> Nullable<Numeric>,
-        lot_size -> Nullable<Numeric>,
-        tick_size -> Nullable<Numeric>,
-        min_size -> Nullable<Numeric>,
-        underwriter_id -> Nullable<Numeric>,
+        handle -> Varchar,
+        creation_time -> Timestamptz,
     }
 }
 
@@ -172,29 +177,24 @@ diesel::table! {
 }
 
 diesel::table! {
-    market_account_handles (user) {
-        #[max_length = 70]
-        user -> Varchar,
-        #[max_length = 70]
-        handle -> Varchar,
-        creation_time -> Timestamptz,
-    }
-}
-
-diesel::table! {
-    balance_updates_by_handle (txn_version, handle, market_id, custodian_id) {
+    recognized_market_events (txn_version, event_idx) {
         txn_version -> Numeric,
-        #[max_length = 70]
-        handle -> Varchar,
-        market_id -> Numeric,
-        custodian_id -> Numeric,
+        event_idx -> Numeric,
         time -> Timestamptz,
-        base_total -> Numeric,
-        base_available -> Numeric,
-        base_ceiling -> Numeric,
-        quote_total -> Numeric,
-        quote_available -> Numeric,
-        quote_ceiling -> Numeric,
+        #[max_length = 70]
+        base_account_address -> Nullable<Varchar>,
+        base_module_name -> Nullable<Text>,
+        base_struct_name -> Nullable<Text>,
+        base_name_generic -> Nullable<Text>,
+        #[max_length = 70]
+        quote_account_address -> Varchar,
+        quote_module_name -> Text,
+        quote_struct_name -> Text,
+        market_id -> Nullable<Numeric>,
+        lot_size -> Nullable<Numeric>,
+        tick_size -> Nullable<Numeric>,
+        min_size -> Nullable<Numeric>,
+        underwriter_id -> Nullable<Numeric>,
     }
 }
 
@@ -210,4 +210,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     place_market_order_events,
     place_swap_order_events,
     processor_status,
+    recognized_market_events,
 );


### PR DESCRIPTION
This cleans up #524

* Add assorted fixes in instructions found while running tutorials
* Update processor submodule to head of `econia` branch (since https://github.com/econia-labs/aptos-indexer-processors/pull/11 has now merged)
* Update port mapping for WebSockets to be enclosed in double quotes per Docker compose file spec: https://docs.docker.com/compose/compose-file/compose-file-v3/#ports
* Add missing `web_anon` drop statement to migrations in order to run `diesel database reset`, which auto-updates `schema.rs`