### PR TITLE
[ECO-658] Enable manual dispatch for docs build

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - doc/doc-site/**
       - .github/workflows/deploy-doc-site.yml
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Enable manual dispatch for docs build due to recent build failing authentication with CloudFlare

If a glitch comes up during CI we need to be able to manually trigger the build