### PR TITLE
[ECO-625] Create new views with enum buy/sell

### DIFF
--- a/src/rust/dbv2/migrations/2023-10-09-223433_add_enumishes/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-09-223433_add_enumishes/down.sql
@@ -1,0 +1,8 @@
+DROP VIEW api.place_market_order_events;
+DROP VIEW api.place_swap_order_events;
+
+CREATE VIEW api.place_market_order_events AS SELECT * FROM place_market_order_events;
+GRANT SELECT ON api.place_market_order_events TO web_anon;
+
+CREATE VIEW api.place_swap_order_events AS SELECT * FROM place_swap_order_events;
+GRANT SELECT ON api.place_swap_order_events TO web_anon;

--- a/src/rust/dbv2/migrations/2023-10-09-223433_add_enumishes/up.sql
+++ b/src/rust/dbv2/migrations/2023-10-09-223433_add_enumishes/up.sql
@@ -1,0 +1,43 @@
+-- Your SQL goes here
+DROP VIEW api.place_market_order_events;
+DROP VIEW api.place_swap_order_events;
+
+CREATE VIEW api.place_market_order_events AS
+SELECT
+  txn_version,
+  event_idx,
+  market_id,
+  "time",
+  order_id,
+  "user",
+  custodian_id,
+  integrator,
+  CASE
+    WHEN direction = true THEN 'sell'
+    ELSE 'buy'
+  END AS direction,
+  "size",
+  self_match_behavior
+FROM place_market_order_events;
+GRANT SELECT ON api.place_market_order_events TO web_anon;
+
+CREATE VIEW api.place_swap_order_events AS
+SELECT
+  txn_version,
+  event_idx,
+  market_id,
+  "time",
+  order_id,
+  signing_account,
+  integrator,
+  CASE
+    WHEN direction = true THEN 'sell'
+    ELSE 'buy'
+  END AS direction,
+  min_base,
+  max_base,
+  min_quote,
+  max_quote,
+  limit_price
+FROM place_swap_order_events;
+GRANT SELECT ON api.place_swap_order_events TO web_anon;


### PR DESCRIPTION
Right now for `api.limit_orders` we say `"bid"` or `"ask"` for the side. For consistency let's also convert the binary `direction` of `api.place_swap_order_events` and `api.place_market_order_events` to `"buy"` or `"sell"`.

Verified by visiting http://localhost:3000/place_swap_order_events and http://localhost:3000/place_market_order_events after running the Python script.