### PR TITLE
[ECO-661] Add logging to aggregator

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -74,6 +74,8 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/rust/aggregator/Cargo.toml
+++ b/src/rust/aggregator/Cargo.toml
@@ -16,3 +16,5 @@ serde_json.workspace = true
 sqlx = { workspace = true, features = ["postgres", "chrono", "bigdecimal"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/src/rust/aggregator/src/data.rs
+++ b/src/rust/aggregator/src/data.rs
@@ -23,9 +23,9 @@ pub trait Data {
     /// [`DataProcessingError::NotReady`] is returned.
     async fn process_and_save(&mut self) -> DataAggregationResult {
         if self.ready() {
-            tracing::info!("[Aggregator] Starting processing & saving ({})", self.model_name());
+            tracing::info!("[Aggregator] Starting process & saving ({})", self.model_name());
             let res = self.process_and_save_internal().await;
-            tracing::info!("[Aggregator] Finished processing & saving ({})", self.model_name());
+            tracing::info!("[Aggregator] Finished process & saving ({})", self.model_name());
             res
         } else {
             Err(DataAggregationError::NotReady)

--- a/src/rust/aggregator/src/data.rs
+++ b/src/rust/aggregator/src/data.rs
@@ -23,9 +23,9 @@ pub trait Data {
     /// [`DataProcessingError::NotReady`] is returned.
     async fn process_and_save(&mut self) -> DataAggregationResult {
         if self.ready() {
-            tracing::info!("[Aggregator] Start processing & saving ({})", self.model_name());
+            tracing::info!("[Aggregator] Starting processing & saving ({})", self.model_name());
             let res = self.process_and_save_internal().await;
-            tracing::info!("[Aggregator] Finish processing & saving ({})", self.model_name());
+            tracing::info!("[Aggregator] Finished processing & saving ({})", self.model_name());
             res
         } else {
             Err(DataAggregationError::NotReady)

--- a/src/rust/aggregator/src/data.rs
+++ b/src/rust/aggregator/src/data.rs
@@ -9,9 +9,13 @@ type DataAggregationResult = Result<(), DataAggregationError>;
 /// This trait represents a data output.
 #[async_trait::async_trait]
 pub trait Data {
+
     /// Returns `true` if the data is ready to be processed (if the process function should be
     /// called now).
     fn ready(&self) -> bool;
+
+    // Used for visibility/logging, returns a static string e.g. "ModelName"
+    fn model_name(&self) -> &'static str;
 
     /// Processes the data and saves the result.
     ///
@@ -19,7 +23,10 @@ pub trait Data {
     /// [`DataProcessingError::NotReady`] is returned.
     async fn process_and_save(&mut self) -> DataAggregationResult {
         if self.ready() {
-            self.process_and_save_internal().await
+            tracing::info!("[Aggregator] Start processing & saving ({})", self.model_name());
+            let res = self.process_and_save_internal().await;
+            tracing::info!("[Aggregator] Finish processing & saving ({})", self.model_name());
+            res
         } else {
             Err(DataAggregationError::NotReady)
         }

--- a/src/rust/aggregator/src/data/markets.rs
+++ b/src/rust/aggregator/src/data/markets.rs
@@ -20,6 +20,11 @@ impl MarketsRegisteredPerDay {
 
 #[async_trait::async_trait]
 impl Data for MarketsRegisteredPerDay {
+
+    fn model_name(&self) -> &'static str {
+        "MarketsRegisteredPerDay"
+    }
+
     fn ready(&self) -> bool {
         self.last_indexed_timestamp.is_none()
             || self.last_indexed_timestamp.unwrap() + Duration::days(1) < Utc::now()

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -40,9 +40,9 @@ async fn main() -> Result<()> {
         handles.spawn(async move {
             let mut data = data.lock().await;
 
-            tracing::info!("[Aggregator] Starting process & save (historical).");
+            tracing::info!("[Aggregator] Starting process & save (historical, {}).", data.model_name());
             data.process_and_save_historical_data().await?;
-            tracing::info!("[Aggregator] Finished process & save (historical).");
+            tracing::info!("[Aggregator] Finished process & save (historical, {}).", data.model_name());
 
             loop {
                 let interval = data.poll_interval().unwrap_or(default_interval);

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -13,10 +13,9 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .init();
-    tracing::info!("[Aggregator] Starting up.");
+    tracing::info!("[Aggregator] Started up.");
     dotenvy::dotenv().ok();
 
-    tracing::info!("[Aggregator] Connecting to DB.");
     let pool = PgPool::connect(
         std::env::var("DATABASE_URL")
             .expect("DATABASE_URL should be set")
@@ -51,9 +50,7 @@ async fn main() -> Result<()> {
                 tokio::time::sleep(interval).await;
 
                 if data.ready() {
-                    tracing::info!("[Aggregator] Starting process & save.");
                     data.process_and_save().await?;
-                    tracing::info!("[Aggregator] Finished process & save.");
                 } else {
                     tracing::info!("[Aggregator] Data is not ready.");
                 }


### PR DESCRIPTION
This PR adds some logging to the aggregator to help diagnose crashing issues. It uses the `tracing` library which is used by the processor to do the same. I've primarily added logging to `UserHistory` but could add logging to the daily markets registered, although I thought that might be pointless spam.

---

Validated by observing these logs periodically in the docker output:
```
docker-aggregator-1  | 2023-10-10T20:25:22.468137Z  INFO aggregator: [Aggregator] Started up.
docker-aggregator-1  | 2023-10-10T20:25:22.481954Z  INFO aggregator: [Aggregator] Connected to DB.
docker-aggregator-1  | 2023-10-10T20:25:22.482049Z  INFO aggregator: [Aggregator] Starting process & save (historical, MarketsRegisteredPerDay).
docker-aggregator-1  | 2023-10-10T20:25:22.482217Z  INFO aggregator: [Aggregator] Starting process & save (historical, UserHistory).
docker-aggregator-1  | 2023-10-10T20:25:22.488307Z  INFO aggregator: [Aggregator] Finished process & save (historical, MarketsRegisteredPerDay).
docker-aggregator-1  | 2023-10-10T20:25:22.495964Z  INFO aggregator: [Aggregator] Finished process & save (historical, UserHistory).
docker-aggregator-1  | 2023-10-10T20:25:27.497253Z  INFO aggregator::data: [Aggregator] Start processing & saving (UserHistory)
docker-aggregator-1  | 2023-10-10T20:25:27.511502Z  INFO aggregator::data: [Aggregator] Finish processing & saving (UserHistory)
```