### PR TITLE
[ECO-660] Remove update swap/market order triggers

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/websocket.md
+++ b/doc/doc-site/docs/off-chain/dss/websocket.md
@@ -35,17 +35,14 @@ Channels include:
 - `new_limit_order`
 - `updated_limit_order`
 - `new_market_order`
-- `updated_market_order`
 - `new_swap_order`
-- `updated_swap_order`
-- `updated_order`
 
 For each channel, the payload format is identical to the corresponding event format returned by the [DSS REST API](./rest-api.md).
 For example, the payload of an event from the `fill_event` channel is identical to the event format returned by a REST API query for `localhost:3000/fill_events` (note that channel names have no `s` at the end but REST API endpoints do), except that WebSocket events are received one by one instead of in an array.
 
-Note that `new_{limit,market,swap}_order` and `updated_{limit,market,swap}_order` correspond to `{limit,market,swap}_orders`.
+Note that `new_{limit,market,swap}_order` and `updated_limit_order` correspond to `{limit,market,swap}_orders`.
 `new_*` channels will send a message each time an order is placed.
-`updated_*` channels will send a message each time an order is updated (size changed, filled, etc).
+The `updated_limit_order` channel will send a message each time an order is updated (size changed, filled, etc).
 
 Hence the format of an event payload from the `fill_event` channel:
 

--- a/src/rust/dbv2/migrations/2023-10-03-070930_add_order_queue/up.sql
+++ b/src/rust/dbv2/migrations/2023-10-03-070930_add_order_queue/up.sql
@@ -90,7 +90,7 @@ CREATE TRIGGER updated_limit_order_trigger
 AFTER UPDATE ON aggregator.user_history_limit FOR EACH ROW
 EXECUTE PROCEDURE notify_updated_limit_order ();
 
-
+/* Dropped in a later migration */
 CREATE FUNCTION notify_updated_market_order () RETURNS TRIGGER AS $$
    DECLARE x api.market_orders%ROWTYPE;
 BEGIN
@@ -100,12 +100,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-
+/* Dropped in a later migration */
 CREATE TRIGGER updated_market_order_trigger
 AFTER UPDATE ON aggregator.user_history_market FOR EACH ROW
 EXECUTE PROCEDURE notify_updated_market_order ();
 
-
+/* Dropped in a later migration */
 CREATE FUNCTION notify_updated_swap_order () RETURNS TRIGGER AS $$
    DECLARE x api.swap_orders%ROWTYPE;
 BEGIN
@@ -115,12 +115,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-
+/* Dropped in a later migration */
 CREATE TRIGGER updated_swap_order_trigger
 AFTER UPDATE ON aggregator.user_history_swap FOR EACH ROW
 EXECUTE PROCEDURE notify_updated_swap_order ();
 
-
+/* This was created improperly and is dropped/updated in a later migration */
 CREATE FUNCTION notify_updated_order () RETURNS TRIGGER AS $$
    DECLARE
       x api.limit_orders%ROWTYPE;

--- a/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/down.sql
@@ -1,1 +1,57 @@
--- This file should undo anything in `up.sql`
+CREATE FUNCTION notify_updated_market_order () RETURNS TRIGGER AS $$
+   DECLARE x api.market_orders%ROWTYPE;
+BEGIN
+   SELECT * INTO x FROM api.market_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+   PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_market_order', 'payload', x)::text);
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER updated_market_order_trigger
+AFTER UPDATE ON aggregator.user_history_market FOR EACH ROW
+EXECUTE PROCEDURE notify_updated_market_order ();
+
+
+CREATE FUNCTION notify_updated_swap_order () RETURNS TRIGGER AS $$
+   DECLARE x api.swap_orders%ROWTYPE;
+BEGIN
+   SELECT * INTO x FROM api.swap_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+   PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_swap_order', 'payload', x)::text);
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER updated_swap_order_trigger
+AFTER UPDATE ON aggregator.user_history_swap FOR EACH ROW
+EXECUTE PROCEDURE notify_updated_swap_order ();
+
+
+DROP TRIGGER updated_order_trigger ON aggregator.user_history;
+DROP FUNCTION notify_updated_order;
+
+CREATE FUNCTION notify_updated_order () RETURNS TRIGGER AS $$
+   DECLARE
+      x api.limit_orders%ROWTYPE;
+      y api.market_orders%ROWTYPE;
+      z api.swap_orders%ROWTYPE;
+BEGIN
+   IF NEW.order_type = 'limit' THEN
+      SELECT * INTO x FROM api.limit_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+      PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_limit_order', 'payload', x)::text);
+   END IF;
+   IF NEW.order_type = 'market' THEN
+      SELECT * INTO x FROM api.market_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+      PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_market_order', 'payload', x)::text);
+   END IF;
+   IF NEW.order_type = 'swap' THEN
+      SELECT * INTO x FROM api.swap_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+      PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_swap_order', 'payload', x)::text);
+   END IF;
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER updated_order_trigger
+AFTER UPDATE ON aggregator.user_history FOR EACH ROW
+EXECUTE PROCEDURE notify_updated_order ();

--- a/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/up.sql
+++ b/src/rust/dbv2/migrations/2023-10-10-171102_drop_update_orders_triggers/up.sql
@@ -1,0 +1,24 @@
+DROP TRIGGER updated_order_trigger ON aggregator.user_history;
+DROP FUNCTION notify_updated_order;
+
+DROP TRIGGER updated_market_order_trigger ON aggregator.user_history_market;
+DROP FUNCTION notify_updated_market_order;
+DROP TRIGGER updated_swap_order_trigger ON aggregator.user_history_swap;
+DROP FUNCTION notify_updated_swap_order;
+
+CREATE FUNCTION notify_updated_order () RETURNS TRIGGER AS $$
+   DECLARE
+      x api.limit_orders%ROWTYPE;
+BEGIN
+   IF NEW.order_type = 'limit' THEN
+      SELECT * INTO x FROM api.limit_orders AS lo WHERE lo.market_id = NEW.market_id AND lo.order_id = NEW.order_id;
+      PERFORM pg_notify('econiaws', json_build_object('channel', 'updated_limit_order', 'payload', x)::text);
+   END IF;
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER updated_order_trigger
+AFTER UPDATE ON aggregator.user_history FOR EACH ROW
+EXECUTE PROCEDURE notify_updated_order ();


### PR DESCRIPTION
This PR removes the triggers that send notifications on updates to swaps and market orders since semantically these orders do not get updates so this was confusing.

Verified using `trade.py`:

```
(econia-sdk-py3.11) (base) egd@Elliotts-MacBook-Pro sdk % poetry run trade
Enter the minimum order size to (re-)use for the market (enter nothing to default to 500==0.5 APT)

Enter the 0x-prefixed address of an Econia deployment (enter nothing to default to local OR re-run with ECONIA_ADDR environment variable)

Enter the 0x-prefixed private key of the Econia deployment (enter "." to use local OR enter nothing to skip recognizing the market)

Enter the 0x-prefixed address of an Econia faucet deployment (enter nothing to default to local OR re-run with FAUCET_ADDR environment variable)

Enter the URL of an Aptos node (enter nothing to default to local OR re-run with APTOS_NODE_URL environment variable)

Please enter the URL of an Aptos faucet (enter nothing to default to local OR re-run with APTOS_FAUCET_URL environment variable)


Press enter to initialize (or obtain) the market.
Market does not exist yet, creating one...
EVENT SUMMARY: MarketRegistrationEvent
  * Base Type (unit of lots): 0x...::example_apt::ExampleAPT
  * Quote Type (unit of ticks): 0x...::example_usdc::ExampleUSDC
Market ID: 1
TRANSACTIONS EXECUTED (first-to-last):
  * Create a new market: 0x8211dd7dd55430356aab721fa2a66e0782fc79866478e029bf5857e3db0f2379
There are no open orders on this market right now.


Press enter to setup an Account A with funds.
New market account after deposit:
  * eAPT: 0 -> 10.0
  * eUSDC: 0 -> 10000.0
Account A was setup: 0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2
TRANSACTIONS EXECUTED (first-to-last):
  * Mint 20.0 eAPT (yet to be deposited): 0x411e8b5a6916d594952facae5449bedcf567c1375b241f7b6cb1f5ea07fc57a0
  * Mint 20000.0 eUSDC (yet to be deposited): 0x7a001b24a1fbd6241eb2ef70fd66da0da3f8236a8914cccd712e748160853f7c
  * Register a new account in market 1: 0x6d203e70ea9eb3de08af2d0e088cfaf62da8dc46c0e0b173357f349a13f3f5d4
  * Deposit 10.0 eAPT to market account: 0x981d4cdf4b2f7dee9272773be5ebaf086dc85c25fefae209d59b666dd7ec14f7
  * Deposit 10000.0 eUSDC to market account: 0x76c84018def0117daa1e0cf50cda4658d2fd1045b1b242d7f2c47c23062f2e87


Press enter to place limit orders with Account A.
EVENT SUMMARY: PlaceLimitOrderEvent
  * User address: 0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2
  * Order ID: 18446884819787842536
  * Side: BID (Buying)
  * Price: 1000 eUSDC ticks per eAPT lot
  * Size: 1000 available eAPT lots / 1000
EVENT SUMMARY: PlaceLimitOrderEvent
  * User address: 0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2
  * Order ID: 36893628897792362448
  * Side: ASK (Selling)
  * Price: 2000 eUSDC ticks per eAPT lot
  * Size: 1000 available eAPT lots / 1000
Account A has finished placing limit orders.
  * There were no limit orders filled by any orders placed.
TRANSACTIONS EXECUTED (first-to-last):
  * Place limit BID/BUY order (1000 lots) (1000 ticks/lot): 0x8fd9cafcb55004d7c3a3d3a9dfc72a26005621a4cef27d508250a673964c1f48
  * Place limit ASK/SELL order (1000 lots) (2000 ticks/lot): 0x6627d51a6fd64ec092aa0b522bee56d9ba7c45826eb63154e747bde21c528964
CURRENT BEST PRICE LEVELS:
  * Highest BID/BUY @ 1000 ticks/lot, 1000 lots
  * Lowest ASK/SELL @ 2000 ticks/lot, 1000 lots


Press enter to change Account A's order sizes.
TRANSACTIONS EXECUTED (first-to-last):
  * Increase bid order size (#1): 0x606df908f38c381989167d5faed257d2191e79a780d26c26059d1bc5444ab1df
  * Decrease ask order size (#1): 0x793308b171c9c7ca642bbd940babb6bfddb0c32b1589d0f83cd160abd01d9065
  ```
  
  ```
  (econia-sdk-py3.11) (base) egd@Elliotts-MacBook-Pro sdk % poetry run event
Enter the URL of the REST host (enter nothing to default to local OR re-run with REST_URL environment variable)

Enter the channel to listen to (enter nothing to default to `fill_event` OR re-run with WS_CHANNEL environment variable)
updated_limit_order
Enter the URL of the WebSocket host (enter nothing to default to local OR re-run with WS_URL environment variable)

Opened connection
{"channel" : "updated_limit_order", "payload" : {"market_id":1,"order_id":18446884819787842536,"user":"0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2","custodian_id":0,"self_matching_behavior":2,"restriction":0,"created_at":"2023-10-10T18:38:49.77392+00:00","last_updated_at":null,"integrator":"0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40","total_filled":0,"remaining_size":1000,"order_status":"open","order_type":"limit","price":1000,"last_increase_stamp":9721434126844933701632,"side":"bid"}}
{"channel" : "updated_limit_order", "payload" : {"market_id":1,"order_id":18446884819787842536,"user":"0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2","custodian_id":0,"self_matching_behavior":2,"restriction":0,"created_at":"2023-10-10T18:38:49.77392+00:00","last_updated_at":"2023-10-10T18:38:52.997303+00:00","integrator":"0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40","total_filled":0,"remaining_size":2000,"order_status":"open","order_type":"limit","price":1000,"last_increase_stamp":9721434126844933701632,"side":"bid"}}
{"channel" : "updated_limit_order", "payload" : {"market_id":1,"order_id":36893628897792362448,"user":"0xf5c6b24914b002bbcd43f3416206f0970a388ea220d27b94de32963f88bb65f2","custodian_id":0,"self_matching_behavior":2,"restriction":0,"created_at":"2023-10-10T18:38:49.999829+00:00","last_updated_at":"2023-10-10T18:38:53.895516+00:00","integrator":"0xeeee0dd966cd4fc739f76006591239b32527edbb7c303c431f8c691bda150b40","total_filled":0,"remaining_size":500,"order_status":"open","order_type":"limit","price":2000,"last_increase_stamp":9555413430181547737088,"side":"ask"}}
  ```

Verified migrations by starting `compose.dss-local.yaml` and running:

```
export DATABASE_URL=postgres://econia:econia@localhost:5432/econia
diesel migration run
diesel migration revert --all
diesel migration run
```