### PR TITLE
[ECO-683] Remove daily markets aggregation

### DIFF
--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -22,10 +22,6 @@ async fn main() -> Result<()> {
 
     let mut data: Vec<Arc<Mutex<dyn Data + Send + Sync>>> = vec![];
 
-    data.push(Arc::new(Mutex::new(MarketsRegisteredPerDay::new(
-        pool.clone(),
-    ))));
-
     data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
 
     let mut handles = JoinSet::new();


### PR DESCRIPTION

* Take out market registration event aggregation, which was a proof of concept, is not necessary at present, and was causing panics