### PR TITLE
[ECO-662] Add PostgREST max rows config step

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/gcp.md
+++ b/doc/doc-site/docs/off-chain/dss/gcp.md
@@ -428,6 +428,16 @@ ZONE=a-zone
    echo $DB_URL_PRIVATE
    ```
 
+1. Determine a [max number of rows](https://postgrest.org/en/stable/references/configuration.html#db-max-rows) per PostgREST query:
+
+   ```sh
+   PGRST_DB_MAX_ROWS=<MAX_ROWS_FOR_FETCH>
+   ```
+
+   ```
+   echo $PGRST_DB_MAX_ROWS
+   ```
+
 1. Deploy [PostgREST](https://postgrest.org/en/stable/) on [GCP Cloud Run](https://cloud.google.com/run/docs/overview/what-is-cloud-run) with [public access](https://cloud.google.com/run/docs/authenticating/public):
 
    ```sh
@@ -439,7 +449,8 @@ ZONE=a-zone
        --set-env-vars "$(printf '%s' \
            PGRST_DB_ANON_ROLE=web_anon,\
            PGRST_DB_SCHEMA=api,\
-           PGRST_DB_URI=$DB_URL_PRIVATE\
+           PGRST_DB_URI=$DB_URL_PRIVATE,\
+           PGRST_DB_MAX_ROWS=$PGRST_DB_MAX_ROWS\
        )" \
        --vpc-connector postgrest
    ```
@@ -821,7 +832,15 @@ Whenever you redeploy, restart all instances and services, and reset the databas
    gcloud compute instances start aggregator
    ```
 
-1. Redeploy `postgrest` using the `gcloud run deploy` command [from initial deployment](#deploy-rest-api).
+1. Redeploy `postgrest` using the `gcloud run deploy` command [from initial deployment](#deploy-rest-api), after setting a max number of rows:
+
+   ```sh
+   PGRST_DB_MAX_ROWS=<MAX_ROWS_FOR_FETCH>
+   ```
+
+   ```
+   echo $PGRST_DB_MAX_ROWS
+   ```
 
 1. Redeploy `websockets` using the `gcloud run deploy` command [from initial deployment](#deploy-websockets-api), after reconstructing the WebSockets connection string:
 


### PR DESCRIPTION
Add to GCP instructions for limiting the max number of rows allowed in a PostgREST query

# Validation

1. Checked out #540

1. Updated `compose.dss-core.yaml` environment variables for postgres:

```yaml
    environment:
      PGRST_DB_URI: "postgres://econia:econia@postgres:5432/econia"
      PGRST_DB_ANON_ROLE: web_anon
      PGRST_DB_SCHEMA: api
      PGRST_DB_MAX_ROWS: 3
```

2. Ran in Econia root:

```
docker ps -aq | xargs docker stop | xargs docker rm
docker volume prune -af
docker image remove postgrest/postgrest
docker compose --file src/docker/compose.dss-global.yaml up
```

4. Ran in `src/rust/dbv2`:

```sh
export DATABASE_URL=postgres://econia:econia@localhost:5432/econia
cp competition-metadata-template.json competition-metadata.json
cargo build --release --bin init-competition
./../target/release/init-competition
./../target/release/init-competition
./../target/release/init-competition
./../target/release/init-competition
./../target/release/init-competition
./../target/release/init-competition
```

5. Visited http://localhost:3000/competition_metadata:
<img width="518" alt="Screenshot 2023-10-11 at 13 08 31" src="https://github.com/econia-labs/econia/assets/43892045/95c027c2-5f04-4811-a749-2974201f5ec7">
