### PR TITLE
[ECO-708] Refactor migrations/schema, update README

### DIFF
--- a/src/rust/dbv2/README.md
+++ b/src/rust/dbv2/README.md
@@ -19,6 +19,13 @@ This crates provides the models for every table in the database.
 
 We also use `diesel` to run migrations. In our docker compose configuration, we have a dedicated docker container that runs `diesel migration run`.
 
+To generate schemas:
+
+```sh
+diesel database reset
+diesel print-schema -s aggregator > src/schema/aggregator.rs
+```
+
 ## Notifications
 
 We use [Postgres notifications](https://www.postgresql.org/docs/14/sql-notify.html) to create a real time notification feed for Econia's events.

--- a/src/rust/dbv2/diesel.toml
+++ b/src/rust/dbv2/diesel.toml
@@ -1,5 +1,9 @@
 # For documentation on how to configure this file,
 # see https://diesel.rs/guides/configuring-diesel-cli
+#
+# The db has multiple schemas that need to be tracked here, pending:
+# https://github.com/diesel-rs/diesel/pull/3796
+# https://github.com/diesel-rs/diesel/issues/1728
 
 [print_schema]
 file = "src/schema/public.rs"

--- a/src/rust/dbv2/migrations/2023-10-06-164142_leaderboards/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-06-164142_leaderboards/down.sql
@@ -17,12 +17,6 @@ DROP VIEW aggregator.homogenous_places;
 DROP VIEW aggregator.homogenous_fills;
 
 
-DROP VIEW api.competition_exclusion_list;
-
-
-DROP TABLE aggregator.competition_exclusion_metadata;
-
-
 DROP VIEW api.competition_leaderboard_users;
 
 
@@ -30,6 +24,12 @@ DROP TABLE aggregator.competition_leaderboard_users;
 
 
 DROP TABLE aggregator.competition_indexed_events;
+
+
+DROP VIEW api.competition_exclusion_list;
+
+
+DROP TABLE aggregator.competition_exclusion_list;
 
 
 DROP VIEW api.competition_metadata;

--- a/src/rust/dbv2/src/bin/add-exclusions.rs
+++ b/src/rust/dbv2/src/bin/add-exclusions.rs
@@ -1,4 +1,6 @@
-use dbv2::{models::CompetitionExclusion, schema::competition_exclusion_list};
+use dbv2::{
+    models::CompetitionExclusion, schema::aggregator::aggregator::competition_exclusion_list,
+};
 use diesel::{self, pg::PgConnection, prelude::*};
 use std::env;
 use std::fs;

--- a/src/rust/dbv2/src/bin/add-inclusions.rs
+++ b/src/rust/dbv2/src/bin/add-inclusions.rs
@@ -1,4 +1,4 @@
-use dbv2::schema::competition_exclusion_list;
+use dbv2::schema::aggregator::aggregator::competition_exclusion_list;
 use diesel::{self, pg::PgConnection, prelude::*};
 use serde::Deserialize;
 use std::env;

--- a/src/rust/dbv2/src/bin/get-competitions.rs
+++ b/src/rust/dbv2/src/bin/get-competitions.rs
@@ -1,4 +1,6 @@
-use dbv2::{models::CompetitionMetadata, schema::competition_metadata::dsl::*};
+use dbv2::{
+    models::CompetitionMetadata, schema::aggregator::aggregator::competition_metadata::dsl::*,
+};
 use diesel::{self, pg::PgConnection, prelude::*};
 use std::env;
 

--- a/src/rust/dbv2/src/bin/get-exclusions.rs
+++ b/src/rust/dbv2/src/bin/get-exclusions.rs
@@ -1,4 +1,6 @@
-use dbv2::{models::CompetitionExclusion, schema::competition_exclusion_list};
+use dbv2::{
+    models::CompetitionExclusion, schema::aggregator::aggregator::competition_exclusion_list,
+};
 use diesel::{self, pg::PgConnection, prelude::*};
 use std::env;
 

--- a/src/rust/dbv2/src/bin/init-competition.rs
+++ b/src/rust/dbv2/src/bin/init-competition.rs
@@ -1,6 +1,6 @@
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
-use dbv2::{models::CompetitionMetadata, schema::competition_metadata};
+use dbv2::{models::CompetitionMetadata, schema::aggregator::aggregator::competition_metadata};
 use diesel::{self, pg::PgConnection, prelude::*};
 use serde::Deserialize;
 use std::env;

--- a/src/rust/dbv2/src/models.rs
+++ b/src/rust/dbv2/src/models.rs
@@ -169,7 +169,7 @@ pub struct BalanceUpdate {
 }
 
 #[derive(Clone, Debug, Queryable, Selectable, Insertable)]
-#[diesel(table_name = crate::schema::aggregator::competition_metadata)]
+#[diesel(table_name = crate::schema::aggregator::aggregator::competition_metadata)]
 pub struct CompetitionMetadata {
     pub id: i32,
     pub start: DateTime<Utc>,
@@ -180,7 +180,7 @@ pub struct CompetitionMetadata {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Queryable, Selectable, Insertable)]
-#[diesel(table_name = crate::schema::aggregator::competition_exclusion_list)]
+#[diesel(table_name = crate::schema::aggregator::aggregator::competition_exclusion_list)]
 pub struct CompetitionExclusion {
     pub user: String,
     pub reason: Option<String>,

--- a/src/rust/dbv2/src/schema/aggregator.rs
+++ b/src/rust/dbv2/src/schema/aggregator.rs
@@ -1,136 +1,139 @@
 // @generated automatically by Diesel CLI.
-pub mod sql_types {
-    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
-    #[diesel(postgres_type(name = "order_status"))]
-    pub struct OrderStatus;
 
-    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
-    #[diesel(postgres_type(name = "order_type"))]
-    pub struct OrderType;
-}
+pub mod aggregator {
+    pub mod sql_types {
+        #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
+        #[diesel(postgres_type(name = "order_status"))]
+        pub struct OrderStatus;
 
-diesel::table! {
-    aggregator.aggregated_events (txn_version, event_idx) {
-        txn_version -> Numeric,
-        event_idx -> Numeric,
+        #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
+        #[diesel(postgres_type(name = "order_type"))]
+        pub struct OrderType;
     }
-}
 
-diesel::table! {
-    aggregator.competition_exclusion_metadata (user, competition_id) {
-        user -> Text,
-        reason -> Nullable<Text>,
-        competition_id -> Int4,
+    diesel::table! {
+        aggregator.aggregated_events (txn_version, event_idx) {
+            txn_version -> Numeric,
+            event_idx -> Numeric,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.competition_indexed_events (txn_version, event_idx, competition_id) {
-        txn_version -> Numeric,
-        event_idx -> Numeric,
-        competition_id -> Int4,
+    diesel::table! {
+        aggregator.competition_exclusion_list (user, competition_id) {
+            user -> Text,
+            reason -> Nullable<Text>,
+            competition_id -> Int4,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.competition_leaderboard_users (user, competition_id) {
-        user -> Text,
-        volume -> Numeric,
-        integrators_used -> Array<Nullable<Text>>,
-        n_trades -> Int4,
-        points -> Nullable<Numeric>,
-        competition_id -> Int4,
+    diesel::table! {
+        aggregator.competition_indexed_events (txn_version, event_idx, competition_id) {
+            txn_version -> Numeric,
+            event_idx -> Numeric,
+            competition_id -> Int4,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.competition_metadata (id) {
-        id -> Int4,
-        start -> Timestamptz,
-        end -> Timestamptz,
-        prize -> Int4,
-        market_id -> Numeric,
-        integrators_required -> Array<Nullable<Text>>,
+    diesel::table! {
+        aggregator.competition_leaderboard_users (user, competition_id) {
+            user -> Text,
+            volume -> Numeric,
+            integrators_used -> Array<Nullable<Text>>,
+            n_trades -> Int4,
+            points -> Nullable<Numeric>,
+            competition_id -> Int4,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.markets_registered_per_day (date) {
-        date -> Date,
-        markets -> Int8,
+    diesel::table! {
+        aggregator.competition_metadata (id) {
+            id -> Int4,
+            start -> Timestamptz,
+            end -> Timestamptz,
+            prize -> Int4,
+            market_id -> Numeric,
+            integrators_required -> Array<Nullable<Text>>,
+        }
     }
-}
 
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::OrderStatus;
-    use super::sql_types::OrderType;
-
-    aggregator.user_history (market_id, order_id) {
-        market_id -> Numeric,
-        order_id -> Numeric,
-        created_at -> Timestamptz,
-        last_updated_at -> Nullable<Timestamptz>,
-        integrator -> Text,
-        total_filled -> Numeric,
-        remaining_size -> Numeric,
-        order_status -> OrderStatus,
-        order_type -> OrderType,
+    diesel::table! {
+        aggregator.markets_registered_per_day (date) {
+            date -> Date,
+            markets -> Int8,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.user_history_limit (market_id, order_id) {
-        market_id -> Numeric,
-        order_id -> Numeric,
-        user -> Text,
-        custodian_id -> Numeric,
-        side -> Bool,
-        self_matching_behavior -> Int2,
-        restriction -> Int2,
-        price -> Numeric,
-        last_increase_stamp -> Numeric,
+    diesel::table! {
+        use diesel::sql_types::*;
+        use super::sql_types::OrderStatus;
+        use super::sql_types::OrderType;
+
+        aggregator.user_history (market_id, order_id) {
+            market_id -> Numeric,
+            order_id -> Numeric,
+            created_at -> Timestamptz,
+            last_updated_at -> Nullable<Timestamptz>,
+            integrator -> Text,
+            total_filled -> Numeric,
+            remaining_size -> Numeric,
+            order_status -> OrderStatus,
+            order_type -> OrderType,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.user_history_market (market_id, order_id) {
-        market_id -> Numeric,
-        order_id -> Numeric,
-        user -> Text,
-        custodian_id -> Numeric,
-        direction -> Bool,
-        self_matching_behavior -> Int2,
+    diesel::table! {
+        aggregator.user_history_limit (market_id, order_id) {
+            market_id -> Numeric,
+            order_id -> Numeric,
+            user -> Text,
+            custodian_id -> Numeric,
+            side -> Bool,
+            self_matching_behavior -> Int2,
+            restriction -> Int2,
+            price -> Numeric,
+            last_increase_stamp -> Numeric,
+        }
     }
-}
 
-diesel::table! {
-    aggregator.user_history_swap (market_id, order_id) {
-        market_id -> Numeric,
-        order_id -> Numeric,
-        direction -> Bool,
-        limit_price -> Numeric,
-        signing_account -> Text,
-        min_base -> Numeric,
-        max_base -> Numeric,
-        min_quote -> Numeric,
-        max_quote -> Numeric,
+    diesel::table! {
+        aggregator.user_history_market (market_id, order_id) {
+            market_id -> Numeric,
+            order_id -> Numeric,
+            user -> Text,
+            custodian_id -> Numeric,
+            direction -> Bool,
+            self_matching_behavior -> Int2,
+        }
     }
+
+    diesel::table! {
+        aggregator.user_history_swap (market_id, order_id) {
+            market_id -> Numeric,
+            order_id -> Numeric,
+            direction -> Bool,
+            limit_price -> Numeric,
+            signing_account -> Text,
+            min_base -> Numeric,
+            max_base -> Numeric,
+            min_quote -> Numeric,
+            max_quote -> Numeric,
+        }
+    }
+
+    diesel::joinable!(competition_exclusion_list -> competition_metadata (competition_id));
+    diesel::joinable!(competition_indexed_events -> competition_metadata (competition_id));
+    diesel::joinable!(competition_leaderboard_users -> competition_metadata (competition_id));
+
+    diesel::allow_tables_to_appear_in_same_query!(
+        aggregated_events,
+        competition_exclusion_list,
+        competition_indexed_events,
+        competition_leaderboard_users,
+        competition_metadata,
+        markets_registered_per_day,
+        user_history,
+        user_history_limit,
+        user_history_market,
+        user_history_swap,
+    );
 }
-
-diesel::joinable!(competition_exclusion_metadata -> competition_metadata (competition_id));
-diesel::joinable!(competition_indexed_events -> competition_metadata (competition_id));
-diesel::joinable!(competition_leaderboard_users -> competition_metadata (competition_id));
-
-diesel::allow_tables_to_appear_in_same_query!(
-    aggregated_events,
-    competition_exclusion_metadata,
-    competition_indexed_events,
-    competition_leaderboard_users,
-    competition_metadata,
-    markets_registered_per_day,
-    user_history,
-    user_history_limit,
-    user_history_market,
-    user_history_swap,
-);


### PR DESCRIPTION
* Refactor migrations that would not run due to dependencies broken at current head of https://github.com/econia-labs/econia/pull/531
* Rename `exclusion_metadata` to `exclusion_list`
* Add instructions for generating schemas
  * Only store in `aggregator.rs` the autogenerated output of diesel, which wraps in`pub mod` 
* Update processor submodule to commit that fixes broken schema dependencies: https://github.com/econia-labs/aptos-indexer-processors/pull/13