### PR TITLE
[ECO-726] Add CLI args

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
+ "clap 4.4.6",
  "dotenvy",
  "env_logger",
  "log",

--- a/src/rust/aggregator/Cargo.toml
+++ b/src/rust/aggregator/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.75"
 async-trait = "0.1.73"
 bigdecimal.workspace = true
 chrono.workspace = true
+clap = { workspace = true, features = ["derive", "string"] }
 dotenvy.workspace = true
 env_logger = "0.10.0"
 log = "0.4.20"

--- a/src/rust/aggregator/src/data/leaderboards.rs
+++ b/src/rust/aggregator/src/data/leaderboards.rs
@@ -3,7 +3,7 @@ use bigdecimal::{BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{PgConnection, PgPool, Postgres, Transaction};
 
-use super::{Processor, ProcessorAggregationResult, ProcessorError};
+use super::{Pipeline, PipelineAggregationResult, PipelineError};
 
 pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -31,7 +31,7 @@ struct Competition {
 }
 
 #[async_trait::async_trait]
-impl Processor for Leaderboards {
+impl Pipeline for Leaderboards {
     fn model_name(&self) -> &'static str {
         "Leaderboard"
     }
@@ -42,7 +42,7 @@ impl Processor for Leaderboards {
                 < Utc::now()
     }
 
-    async fn process_and_save_historical_data(&mut self) -> ProcessorAggregationResult {
+    async fn process_and_save_historical_data(&mut self) -> PipelineAggregationResult {
         self.process_and_save_internal().await
     }
 
@@ -50,12 +50,12 @@ impl Processor for Leaderboards {
         Some(TIMEOUT)
     }
 
-    async fn process_and_save_internal(&mut self) -> ProcessorAggregationResult {
+    async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {
         let mut transaction = self
             .pool
             .begin()
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         // Get all competitions having created markets
         let competitions = sqlx::query_as!(
             Competition,
@@ -70,14 +70,14 @@ impl Processor for Leaderboards {
         )
         .fetch_all(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         for comp in competitions {
             aggregate_data_for_competition(&mut transaction, comp).await?;
         }
         transaction
             .commit()
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         Ok(())
     }
 }
@@ -85,7 +85,7 @@ impl Processor for Leaderboards {
 async fn aggregate_data_for_competition<'a>(
     transaction: &mut Transaction<'a, Postgres>,
     comp: Competition,
-) -> ProcessorAggregationResult {
+) -> PipelineAggregationResult {
     // Insert new users
     sqlx::query!(
         r#"
@@ -125,7 +125,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .execute(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
 
     sqlx::query!(
         r#"
@@ -141,7 +141,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .execute(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
 
     sqlx::query!(
         r#"
@@ -156,7 +156,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .execute(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
 
     sqlx::query!(
         r#"
@@ -176,7 +176,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .execute(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
 
     // Set last aggregated transaction version
     let max_txnv_fills = sqlx::query!(
@@ -187,7 +187,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .fetch_one(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?
     .max;
 
     let max_txnv_places = sqlx::query!(
@@ -198,7 +198,7 @@ async fn aggregate_data_for_competition<'a>(
     )
     .fetch_one(transaction as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?
     .max;
 
     let max = BigDecimal::max(
@@ -218,7 +218,7 @@ async fn aggregate_data_for_competition<'a>(
         )
         .execute(transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     }
     Ok(())
 }

--- a/src/rust/aggregator/src/data/user_history.rs
+++ b/src/rust/aggregator/src/data/user_history.rs
@@ -3,7 +3,7 @@ use bigdecimal::{num_bigint::ToBigInt, BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{Executor, PgConnection, PgPool, Postgres, Transaction};
 
-use super::{Processor, ProcessorAggregationResult, ProcessorError};
+use super::{Pipeline, PipelineAggregationResult, PipelineError};
 
 /// Number of bits to shift when encoding transaction version.
 const SHIFT_TXN_VERSION: u8 = 64;
@@ -39,7 +39,7 @@ impl UserHistory {
 }
 
 #[async_trait::async_trait]
-impl Processor for UserHistory {
+impl Pipeline for UserHistory {
     fn model_name(&self) -> &'static str {
         "UserHistory"
     }
@@ -49,7 +49,7 @@ impl Processor for UserHistory {
             || self.last_indexed_timestamp.unwrap() + Duration::seconds(5) < Utc::now()
     }
 
-    async fn process_and_save_historical_data(&mut self) -> ProcessorAggregationResult {
+    async fn process_and_save_historical_data(&mut self) -> PipelineAggregationResult {
         self.process_and_save_internal().await
     }
 
@@ -57,19 +57,19 @@ impl Processor for UserHistory {
         Some(std::time::Duration::from_secs(5))
     }
 
-    /// All database interactions are handled in a single atomic transaction. Processor insertions
+    /// All database interactions are handled in a single atomic transaction. Pipeline insertions
     /// are also handled in a single atomic transaction for each batch of transactions, such that
     /// user history aggregation logic is effectively serialized across historical chain state.
-    async fn process_and_save_internal(&mut self) -> ProcessorAggregationResult {
+    async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {
         let mut transaction = self
             .pool
             .begin()
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         transaction
             .execute("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;")
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         struct TxnVersion {
             txn_version: BigDecimal,
         }
@@ -79,7 +79,7 @@ impl Processor for UserHistory {
         )
         .fetch_optional(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         let txnv_exists = max_txn_version.is_some();
         let max_txn_version = max_txn_version
             .unwrap_or(TxnVersion {
@@ -92,56 +92,56 @@ impl Processor for UserHistory {
         )
         .fetch_all(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         let change_events = sqlx::query_file!(
             "sqlx_queries/user_history/get_change_order_size_events.sql",
             max_txn_version
         )
         .fetch_all(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_limit.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_limit.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_market.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_market.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_swap.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_swap.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         // Step through fill and change events in total order.
         let mut fill_index = 0;
         let mut change_index = 0;
@@ -200,12 +200,12 @@ impl Processor for UserHistory {
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         update_max_txn_version(&mut transaction, txnv_exists).await?;
         transaction
             .commit()
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
         Ok(())
     }
 }
@@ -217,7 +217,7 @@ async fn aggregate_fill_for_maker_and_taker<'a>(
     taker_order_id: &BigDecimal,
     market_id: &BigDecimal,
     time: &DateTime<Utc>,
-) -> ProcessorAggregationResult {
+) -> PipelineAggregationResult {
     aggregate_fill(tx, size, maker_order_id, market_id, time).await?;
     aggregate_fill(tx, size, taker_order_id, market_id, time).await?;
     Ok(())
@@ -229,7 +229,7 @@ async fn aggregate_fill<'a>(
     order_id: &BigDecimal,
     market_id: &BigDecimal,
     time: &DateTime<Utc>,
-) -> ProcessorAggregationResult {
+) -> PipelineAggregationResult {
     // Only limit orders can remain open after a transaction during which they are filled against,
     // so flag market orders and swaps as closed by default: if they end up being cancelled instead
     // of closed, the cancel event emitted during the same transaction (aggregated after fills) will
@@ -243,7 +243,7 @@ async fn aggregate_fill<'a>(
     )
     .execute(tx as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     Ok(())
 }
 
@@ -255,7 +255,7 @@ async fn aggregate_change<'a>(
     time: &DateTime<Utc>,
     txn_version: &BigDecimal,
     event_idx: &BigDecimal,
-) -> ProcessorAggregationResult {
+) -> PipelineAggregationResult {
     // Get some info
     let record = sqlx::query_file!(
         "sqlx_queries/user_history/get_order_type_with_remaining_size.sql",
@@ -264,20 +264,20 @@ async fn aggregate_change<'a>(
     )
     .fetch_one(tx as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     let (order_type, original_size): (OrderType, BigDecimal) =
         (record.order_type, record.remaining_size);
     // If it's a limit order and needs reordering
     if matches!(order_type, OrderType::Limit) && &original_size < new_size {
         let txn = txn_version
             .to_bigint()
-            .ok_or(ProcessorError::ProcessingError(anyhow!(
+            .ok_or(PipelineError::ProcessingError(anyhow!(
                 "txn_version not integer"
             )))?
             << SHIFT_TXN_VERSION;
         let event = event_idx
             .to_bigint()
-            .ok_or(ProcessorError::ProcessingError(anyhow!(
+            .ok_or(PipelineError::ProcessingError(anyhow!(
                 "event_idx not integer"
             )))?;
         let txn_event: BigDecimal = BigDecimal::from(txn | event);
@@ -289,7 +289,7 @@ async fn aggregate_change<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     }
     sqlx::query_file!(
         "sqlx_queries/user_history/aggregate_size_change.sql",
@@ -300,19 +300,19 @@ async fn aggregate_change<'a>(
     )
     .execute(tx as &mut PgConnection)
     .await
-    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     Ok(())
 }
 
 async fn update_max_txn_version<'a>(
     tx: &mut Transaction<'a, Postgres>,
     already_exists: bool,
-) -> ProcessorAggregationResult {
+) -> PipelineAggregationResult {
     let new_max_txn_version =
         sqlx::query_file!("sqlx_queries/user_history/get_new_last_indexed_txn_version.sql",)
             .fetch_one(tx as &mut PgConnection)
             .await
-            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?
+            .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?
             .max
             .unwrap_or(BigDecimal::zero());
     if already_exists {
@@ -322,7 +322,7 @@ async fn update_max_txn_version<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     } else {
         sqlx::query_file!(
             "sqlx_queries/user_history/init_last_indexed_txn_version.sql",
@@ -330,7 +330,7 @@ async fn update_max_txn_version<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
     }
     Ok(())
 }

--- a/src/rust/aggregator/src/data/user_history.rs
+++ b/src/rust/aggregator/src/data/user_history.rs
@@ -57,7 +57,7 @@ impl Pipeline for UserHistory {
         Some(std::time::Duration::from_secs(5))
     }
 
-    /// All database interactions are handled in a single atomic transaction. Pipeline insertions
+    /// All database interactions are handled in a single atomic transaction. Processor insertions
     /// are also handled in a single atomic transaction for each batch of transactions, such that
     /// user history aggregation logic is effectively serialized across historical chain state.
     async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {

--- a/src/rust/aggregator/src/data/user_history.rs
+++ b/src/rust/aggregator/src/data/user_history.rs
@@ -3,7 +3,7 @@ use bigdecimal::{num_bigint::ToBigInt, BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{Executor, PgConnection, PgPool, Postgres, Transaction};
 
-use super::{Data, DataAggregationError, DataAggregationResult};
+use super::{Processor, ProcessorAggregationResult, ProcessorError};
 
 /// Number of bits to shift when encoding transaction version.
 const SHIFT_TXN_VERSION: u8 = 64;
@@ -39,7 +39,7 @@ impl UserHistory {
 }
 
 #[async_trait::async_trait]
-impl Data for UserHistory {
+impl Processor for UserHistory {
     fn model_name(&self) -> &'static str {
         "UserHistory"
     }
@@ -49,7 +49,7 @@ impl Data for UserHistory {
             || self.last_indexed_timestamp.unwrap() + Duration::seconds(5) < Utc::now()
     }
 
-    async fn process_and_save_historical_data(&mut self) -> DataAggregationResult {
+    async fn process_and_save_historical_data(&mut self) -> ProcessorAggregationResult {
         self.process_and_save_internal().await
     }
 
@@ -60,16 +60,16 @@ impl Data for UserHistory {
     /// All database interactions are handled in a single atomic transaction. Processor insertions
     /// are also handled in a single atomic transaction for each batch of transactions, such that
     /// user history aggregation logic is effectively serialized across historical chain state.
-    async fn process_and_save_internal(&mut self) -> DataAggregationResult {
+    async fn process_and_save_internal(&mut self) -> ProcessorAggregationResult {
         let mut transaction = self
             .pool
             .begin()
             .await
-            .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         transaction
             .execute("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;")
             .await
-            .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         struct TxnVersion {
             txn_version: BigDecimal,
         }
@@ -79,7 +79,7 @@ impl Data for UserHistory {
         )
         .fetch_optional(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         let txnv_exists = max_txn_version.is_some();
         let max_txn_version = max_txn_version
             .unwrap_or(TxnVersion {
@@ -92,56 +92,56 @@ impl Data for UserHistory {
         )
         .fetch_all(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         let change_events = sqlx::query_file!(
             "sqlx_queries/user_history/get_change_order_size_events.sql",
             max_txn_version
         )
         .fetch_all(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_limit.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_limit.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_market.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_market.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/parse_order_events_swap.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         sqlx::query_file!(
             "sqlx_queries/user_history/insert_user_history_swap.sql",
             max_txn_version,
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         // Step through fill and change events in total order.
         let mut fill_index = 0;
         let mut change_index = 0;
@@ -200,12 +200,12 @@ impl Data for UserHistory {
         )
         .execute(&mut transaction as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         update_max_txn_version(&mut transaction, txnv_exists).await?;
         transaction
             .commit()
             .await
-            .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
         Ok(())
     }
 }
@@ -217,7 +217,7 @@ async fn aggregate_fill_for_maker_and_taker<'a>(
     taker_order_id: &BigDecimal,
     market_id: &BigDecimal,
     time: &DateTime<Utc>,
-) -> DataAggregationResult {
+) -> ProcessorAggregationResult {
     aggregate_fill(tx, size, maker_order_id, market_id, time).await?;
     aggregate_fill(tx, size, taker_order_id, market_id, time).await?;
     Ok(())
@@ -229,7 +229,7 @@ async fn aggregate_fill<'a>(
     order_id: &BigDecimal,
     market_id: &BigDecimal,
     time: &DateTime<Utc>,
-) -> DataAggregationResult {
+) -> ProcessorAggregationResult {
     // Only limit orders can remain open after a transaction during which they are filled against,
     // so flag market orders and swaps as closed by default: if they end up being cancelled instead
     // of closed, the cancel event emitted during the same transaction (aggregated after fills) will
@@ -243,7 +243,7 @@ async fn aggregate_fill<'a>(
     )
     .execute(tx as &mut PgConnection)
     .await
-    .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     Ok(())
 }
 
@@ -255,7 +255,7 @@ async fn aggregate_change<'a>(
     time: &DateTime<Utc>,
     txn_version: &BigDecimal,
     event_idx: &BigDecimal,
-) -> DataAggregationResult {
+) -> ProcessorAggregationResult {
     // Get some info
     let record = sqlx::query_file!(
         "sqlx_queries/user_history/get_order_type_with_remaining_size.sql",
@@ -264,20 +264,20 @@ async fn aggregate_change<'a>(
     )
     .fetch_one(tx as &mut PgConnection)
     .await
-    .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     let (order_type, original_size): (OrderType, BigDecimal) =
         (record.order_type, record.remaining_size);
     // If it's a limit order and needs reordering
     if matches!(order_type, OrderType::Limit) && &original_size < new_size {
         let txn = txn_version
             .to_bigint()
-            .ok_or(DataAggregationError::ProcessingError(anyhow!(
+            .ok_or(ProcessorError::ProcessingError(anyhow!(
                 "txn_version not integer"
             )))?
             << SHIFT_TXN_VERSION;
         let event = event_idx
             .to_bigint()
-            .ok_or(DataAggregationError::ProcessingError(anyhow!(
+            .ok_or(ProcessorError::ProcessingError(anyhow!(
                 "event_idx not integer"
             )))?;
         let txn_event: BigDecimal = BigDecimal::from(txn | event);
@@ -289,7 +289,7 @@ async fn aggregate_change<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     }
     sqlx::query_file!(
         "sqlx_queries/user_history/aggregate_size_change.sql",
@@ -300,19 +300,19 @@ async fn aggregate_change<'a>(
     )
     .execute(tx as &mut PgConnection)
     .await
-    .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+    .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     Ok(())
 }
 
 async fn update_max_txn_version<'a>(
     tx: &mut Transaction<'a, Postgres>,
     already_exists: bool,
-) -> DataAggregationResult {
+) -> ProcessorAggregationResult {
     let new_max_txn_version =
         sqlx::query_file!("sqlx_queries/user_history/get_new_last_indexed_txn_version.sql",)
             .fetch_one(tx as &mut PgConnection)
             .await
-            .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?
+            .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?
             .max
             .unwrap_or(BigDecimal::zero());
     if already_exists {
@@ -322,7 +322,7 @@ async fn update_max_txn_version<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     } else {
         sqlx::query_file!(
             "sqlx_queries/user_history/init_last_indexed_txn_version.sql",
@@ -330,7 +330,7 @@ async fn update_max_txn_version<'a>(
         )
         .execute(tx as &mut PgConnection)
         .await
-        .map_err(|e| DataAggregationError::ProcessingError(anyhow!(e)))?;
+        .map_err(|e| ProcessorError::ProcessingError(anyhow!(e)))?;
     }
     Ok(())
 }

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
             .ok_or(anyhow!("No data is included and --no-default is set."))?)
         .clone()
     } else {
-        let mut x = vec![Pipelines::UserHistory];
+        let mut x = vec![Pipelines::UserHistory, Pipelines::Leaderboards];
         x.append(&mut args.include.unwrap_or(vec![]));
         x.dedup();
         x

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -86,8 +86,8 @@ async fn main() -> Result<()> {
         .clone()
     } else {
         let mut x = vec![Pipelines::UserHistory, Pipelines::Leaderboards];
-        x.append(&mut args.include.unwrap_or(vec![]));
-        x.dedup();
+        let exclude = args.exclude.unwrap_or(vec![]);
+        x = x.into_iter().filter(|a| !exclude.contains(a)).collect();
         x
     };
 

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -1,13 +1,57 @@
 use std::{
+    fmt::Display,
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
-use anyhow::Result;
-use data::{leaderboards::Leaderboards, user_history::UserHistory, Data};
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use data::{leaderboards::Leaderboards, user_history::UserHistory, Processor};
 use sqlx::PgPool;
 use tokio::{sync::Mutex, task::JoinSet};
 use tracing_subscriber;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// If set, no processor will be included by default.
+    #[arg(short, long)]
+    no_default: bool,
+
+    /// Exclusion list. Processors specified here will not be executed. Ignored if --no-default passed.
+    #[arg(short, long)]
+    exclude: Option<Vec<Processors>>,
+
+    /// Inclusion list. Processors specified here will be executed. Ignored if --no-default is not passed.
+    #[arg(short, long, value_enum)]
+    include: Option<Vec<Processors>>,
+
+    /// Database URL.
+    #[arg(short, long)]
+    database_url: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Processors {
+    UserHistory,
+    Leaderboards,
+}
+
+impl ValueEnum for Processors {
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        Some(clap::builder::PossibleValue::new(self.to_string()))
+    }
+
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::UserHistory, Self::Leaderboards]
+    }
+}
+
+impl Display for Processors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
 
 mod data;
 
@@ -18,22 +62,45 @@ async fn main() -> Result<()> {
         .init();
     tracing::info!("Started up.");
     dotenvy::dotenv().ok();
+    let args: Args = Args::parse();
 
-    let pool = PgPool::connect(
-        std::env::var("DATABASE_URL")
-            .expect("DATABASE_URL should be set")
-            .as_str(),
-    )
-    .await?;
+    let database_url = std::env::var("DATABASE_URL")
+        .or_else(|_| -> Result<String> {
+            args.database_url
+                .ok_or(anyhow!("No database URL was provided."))
+        })
+        .expect("DATABASE_URL should be set");
+
+    let pool = PgPool::connect(&database_url).await?;
+
     tracing::info!("Connected to DB.");
 
     let default_interval = Duration::from_secs(5);
 
-    let mut data: Vec<Arc<Mutex<dyn Data + Send + Sync>>> = vec![];
+    let mut data: Vec<Arc<Mutex<dyn Processor + Send + Sync>>> = vec![];
 
-    data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
+    let processors = if args.no_default {
+        (args
+            .include
+            .ok_or(anyhow!("No data is included and --no-default is set."))?)
+        .clone()
+    } else {
+        let mut x = vec![Processors::UserHistory];
+        x.append(&mut args.include.unwrap_or(vec![]));
+        x.dedup();
+        x
+    };
 
-    data.push(Arc::new(Mutex::new(Leaderboards::new(pool.clone()))));
+    for processor in processors {
+        match processor {
+            Processors::UserHistory => {
+                data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
+            }
+            Processors::Leaderboards => {
+                data.push(Arc::new(Mutex::new(Leaderboards::new(pool.clone()))));
+            }
+        }
+    }
 
     let mut handles = JoinSet::new();
 


### PR DESCRIPTION
- renamed `Data` to `Pipeline`
- can now pass db url as cli arg
- can now pass an exclusion list or an inclusion list to run processors

The purpose of this PR is so that people can run the aggregator to get data without having to process leaderboards.

I also renamed `Data` to `Pipeline` because it's more accurate, and it was hard to name things with `Data`.