### PR TITLE
[ECO-785] Remove market account deposit throttling

### DIFF
--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -1188,13 +1188,6 @@ module econia::user {
                                          type_info::type_of<GenericAsset>();
         // Assert coin type is not generic asset.
         assert!(!coin_type_is_generic_asset, E_COIN_TYPE_IS_GENERIC_ASSET);
-        // Throttle the deposit.
-        throttler::throttle::throttle_transfer(
-            market_id,
-            user_address,
-            false,
-            coin::decimals<CoinType>() == 8,
-            coin::value(&coins));
         deposit_asset<CoinType>( // Deposit asset.
             user_address,
             market_id,
@@ -1973,13 +1966,8 @@ module econia::user {
         deposit_asset<BaseType>( // Deposit base asset.
             user_address, market_id, custodian_id, base_amount,
             optional_base_coins, underwriter_id);
-        deposit_asset<QuoteType>( // Deposit quote coins.
-            user_address,
-            market_id,
-            custodian_id,
-            coin::value(&quote_coins),
-            option::some(quote_coins),
-            NO_UNDERWRITER);
+        deposit_coins<QuoteType>( // Deposit quote coins.
+            user_address, market_id, custodian_id, quote_coins);
     }
 
     /// Emit limit order events to a user's market event handles.
@@ -4016,7 +4004,6 @@ module econia::user {
         Collateral,
         MarketAccounts
     {
-        econia::assets::init_coin_types_test();
         // Attempt invalid invocation.
         deposit_coins<BC>(@user, 0, 0, coin::zero());
     }

--- a/src/move/testnet-competition-throttler/README.md
+++ b/src/move/testnet-competition-throttler/README.md
@@ -20,7 +20,7 @@ The `SCREAMING_SNAKE_CASE` constants referenced below are defined at the top of 
 - A user may only mint up to `MAX_TRANSFER_APT` at each `eAPT` mint.
 - A user may only mint up to `MAX_TRANSFER_USDC` at each `eUSDC` mint.
 
-## Depositing
+## Depositing (optional)
 
 - A user must wait `WAIT_TIME_IN_SECONDS` between each `eAPT` deposit into their Econia market account.
 - A user must wait `WAIT_TIME_IN_SECONDS` between each `eUSDC` deposit into their Econia market account.


### PR DESCRIPTION
Revert `user.move` modifications that implemented market account deposit throttling, update throttler README