### PR TITLE
[ECO-745] JWT support update

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -18,8 +18,7 @@ The REST API also provides all the events emitted by the Econia Move package., a
 It can be addressed at `http://0.0.0.0:3000` in the default local configuration of docker compose.
 
 In order to access the WebSocket server, connect to the following URL: `ws://your-host/[JWT]` where `[JWT]` is a JSON Web Token (JWT).
-You must generate the JWT yourself, see `/src/python/sdk/examples/event.py` for an example of how to do so.
-Remember to change the secret to something only you and your team know (global search and replace for it).
+You must generate the JWT yourself, see `src/python/sdk/examples/event.py` for an example of how to do so.
 To get a list of the different channels, please see the [WebSocket server documentation](./websocket.md).
 
 The REST API is actually a PostgREST instance.

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -22,17 +22,6 @@ You must generate the JWT yourself, see `/src/python/sdk/examples/event.py` for 
 Remember to change the secret to something only you and your team know (global search and replace for it).
 To get a list of the different channels, please see the [WebSocket server documentation](./websocket.md).
 
-:::note
-In preparation for the testnet trading competition during 2023-10-25T00:00/2023-11-01T00:00Z, JWT support has been removed from the REST API because the required extension is unavailable on Google Cloud Platform, such that database migrations had to be refactored in a way that prevented JWT generation through the `PostgREST` service.
-You can still manually generate a JWT yourself, though, noting the following plaintext environment variable for the `postgrest-websockets` service:
-
-```yaml
-- PGWS_JWT_SECRET=econia_0000000000000000000000000
-```
-
-Stand by for a resolution, including explicit instructions on JWT generation.
-:::
-
 The REST API is actually a PostgREST instance.
 You can find the REST API documentation [here](./rest-api.md).
 You can learn more about how to query a PostgREST instance on their [official documentation](https://postgrest.org/en/stable/).

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -18,8 +18,8 @@ The REST API also provides all the events emitted by the Econia Move package., a
 It can be addressed at `http://0.0.0.0:3000` in the default local configuration of docker compose.
 
 In order to access the WebSocket server, connect to the following URL: `ws://your-host/[JWT]` where `[JWT]` is a JSON Web Token (JWT).
-To get a JWT, query the REST API at `http://your-host/rpc/jwt` with the HTTP method `POST` and `{"channels": […]}` as a payload, where `[…]` is a list of the names of the channels you want to receive notifications for.
-Alternatively, you can generate the JWT by yourself (you can find the secret in the Docker compose file under `src/docker`).
+You must generate the JWT yourself, see `/src/python/sdk/examples/event.py` for an example of how to do so.
+Remember to change the secret to something only you and your team know (global search and replace for it).
 To get a list of the different channels, please see the [WebSocket server documentation](./websocket.md).
 
 :::note

--- a/doc/doc-site/docs/off-chain/dss/websocket.md
+++ b/doc/doc-site/docs/off-chain/dss/websocket.md
@@ -108,18 +108,9 @@ poetry install
 poetry run event
 ```
 
-:::note
-In preparation for the testnet trading competition during 2023-10-25T00:00/2023-11-01T00:00Z, JWT support has been removed from the REST API because the required extension is unavailable on Google Cloud Platform, such that database migrations had to be refactored in a way that prevented JWT generation through the `PostgREST` service.
-You can still manually generate a JWT yourself, though, noting the following plaintext environment variable for the `postgrest-websockets` service:
-
-```yaml
-- PGWS_JWT_SECRET=econia_0000000000000000000000000
-```
-
-Stand by for a resolution, including explicit instructions on JWT generation.
-:::
-
 Enter nothing for all of the prompts to use the default local configuration.
+The JWT will be generated for you using Econia's compromised secret.
+See the `event.py` code for an example of how to generate the JWT yourself.
 
 Now you can perform actions on the locally-deployed exchange to trigger events, or run the `trade.py` script:
 

--- a/doc/doc-site/docs/off-chain/dss/websocket.md
+++ b/doc/doc-site/docs/off-chain/dss/websocket.md
@@ -109,7 +109,7 @@ poetry run event
 ```
 
 Enter nothing for all of the prompts to use the default local configuration.
-The JWT will be generated for you using Econia's compromised secret.
+The JWT will be generated for you using the compromised `PGWS_JWT_SECRET` environment variable included as an example in the DSS configuration.
 See the `event.py` code for an example of how to generate the JWT yourself.
 
 Now you can perform actions on the locally-deployed exchange to trigger events, or run the `trade.py` script:

--- a/src/python/sdk/examples/event.py
+++ b/src/python/sdk/examples/event.py
@@ -5,7 +5,7 @@ import rel
 import websocket
 import jwt
 
-REST_URL_LOCAL_DEFAULT = "http://0.0.0.0:3000"
+JWT_SECRET_DEFAULT = "econia_0000000000000000000000000"
 WS_URL_LOCAL_DEFAULT = "ws://0.0.0.0:3001"
 WS_CHANNEL_DEFAULT = "fill_event"
 
@@ -24,20 +24,6 @@ def on_close(ws, close_status_code, close_msg):
 
 def on_open(ws):
     print("Opened connection")
-
-
-def get_rest_host() -> str:
-    url = environ.get("REST_URL")
-    if url == None:
-        url_in = input(
-            "Enter the URL of the REST host (enter nothing to default to local OR re-run with REST_URL environment variable)\n"
-        ).strip()
-        if url_in == "":
-            return REST_URL_LOCAL_DEFAULT
-        else:
-            return url_in
-    else:
-        return url
 
 
 def get_ws_host() -> str:
@@ -66,12 +52,25 @@ def get_channel() -> str:
             return url_in
     else:
         return url
+    
+def get_jwt_secret() -> str:
+    jwt_sec = environ.get("JWT_SECRET")
+    if jwt_sec == None:
+        jwt_sec = input(
+            "Enter the JWT secret (enter nothing to used default compromised key OR re-run with JWT_SECRET environment variable)\n"
+        ).strip()
+        if jwt_sec == "":
+            return JWT_SECRET_DEFAULT
+        else:
+            return jwt_sec
+    else:
+        return jwt_sec
 
 
 def start():
     token = jwt.encode(
         {'mode': 'r', 'channels': [get_channel()]},
-        'econia_0000000000000000000000000',
+        get_jwt_secret(),
         algorithm='HS256'
     ).decode('utf-8')
     host_ws = get_ws_host()

--- a/src/python/sdk/examples/event.py
+++ b/src/python/sdk/examples/event.py
@@ -3,6 +3,7 @@ from os import environ
 import httpx
 import rel
 import websocket
+import jwt
 
 REST_URL_LOCAL_DEFAULT = "http://0.0.0.0:3000"
 WS_URL_LOCAL_DEFAULT = "ws://0.0.0.0:3001"
@@ -68,13 +69,14 @@ def get_channel() -> str:
 
 
 def start():
-    host_rest = get_rest_host()
-    channel = get_channel()
-    response = httpx.post(f"{host_rest}/rpc/jwt", json={"channels": [channel]})
-
+    token = jwt.encode(
+        {'mode': 'r', 'channels': [get_channel()]},
+        'econia_0000000000000000000000000',
+        algorithm='HS256'
+    ).decode('utf-8')
     host_ws = get_ws_host()
     ws = websocket.WebSocketApp(
-        f"{host_ws}/{response.text[1:-1]}",
+        f"{host_ws}/{token}",
         on_open=on_open,
         on_message=on_message,
         on_error=on_error,

--- a/src/python/sdk/poetry.lock
+++ b/src/python/sdk/poetry.lock
@@ -681,6 +681,22 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "pyjwt"
+version = "1.7.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
+    {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=1.4)"]
+flake8 = ["flake8", "flake8-import-order", "pep8-naming"]
+test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner (>=4.2,<5.0.0)"]
+
+[[package]]
 name = "pynacl"
 version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
@@ -847,4 +863,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "134f977c6afe31f69f5cc1d646834424ded51e80d48d989bc2ee7b5873585238"
+content-hash = "e35e5e3c7d5ba3f6ffadd47a57a3e3412416c363cb033de3aa5061ae033b6cee"

--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -15,6 +15,7 @@ python = "^3.8"
 websocket-client = "^1.6.3"
 httpx = "0.23.0"
 rel = "^0.4.9"
+pyjwt = "1.7.1"
 
 [tool.poetry.group.dev.dependencies]
 autoflake = "^2.2.0"


### PR DESCRIPTION
We lost JWT generation support due to compatibility issues. So in the WebSockets example, instead of using the now-gone endpoint for the JWT, let's generate the JWT and have that be an example for others.

Validated by running `event` and `trade` scripts against local deployment.