### PR TITLE
[ECO-558] Bumps docs for audit

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -55,5 +55,5 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#504]: https://github.com/econia-labs/econia/pull/504
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
-[v4.1.0]: https://github.com/econia-labs/econia/releases/tag/v4.1.0-audited
-[v4.1.1]: https://github.com/econia-labs/econia/releases/tag/v4.1.1-audited
+[v4.1.0]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...v4.1.0-audited
+[v4.1.1]: https://github.com/econia-labs/econia/compare/v4.1.0-audited...v4.1.1-audited

--- a/doc/doc-site/docs/security.md
+++ b/doc/doc-site/docs/security.md
@@ -1,7 +1,7 @@
 # Security
 
 Econia has been independently audited by three firms, and all [audit reports] are public:
-Move source code is audited through commit [`48e701e`] (tag [`v4.1.0-audited`]), via three initial audits and two followup audits.
+Move source code is audited through commit [`8220489`] (tag [`v4.1.1-audited`]), via three initial audits and three followup audits.
 
 Moreover, Econia is deployed on Aptos mainnet under a community-governed multisig account in accordance with the [Econia signatory guide].
 
@@ -13,5 +13,5 @@ Anyone who uses the Econia protocol agrees to hold harmless all signatories to t
 
 [audit reports]: https://econia-labs.notion.site/Econia-Audit-Reports-27634e9c7d1249228e2cbc3e705a59c9
 [econia signatory guide]: https://econia-labs.notion.site/Aptos-Multisig-v2-and-Econia-v4-A-Signatory-s-Guide-to-On-Chain-Governance-96da99732f744044af6a3eca88a21fac?pvs=4
-[`48e701e`]: https://github.com/econia-labs/econia/commit/48e701e36775ae987ddcca880dcb6068bbe3b758
-[`v4.1.0-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.1.0-audited
+[`8220489`]: https://github.com/econia-labs/econia/commit/8220489650600cf9b236ef634a00dec6049a46c2
+[`v4.1.1-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.1.1-audited


### PR DESCRIPTION
* Update Move changelog and security docs pages per recent audit/mainnet governance upgrade