### PR TITLE
[ECO-770] Guard against negative volume

### DIFF
--- a/src/rust/dbv2/migrations/2023-10-24-110811_guard_against_negative_volume/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-24-110811_guard_against_negative_volume/down.sql
@@ -1,0 +1,59 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE aggregator.competition_leaderboard_users
+DROP COLUMN points CASCADE;
+
+
+ALTER TABLE aggregator.competition_leaderboard_users
+ADD COLUMN "points" NUMERIC GENERATED ALWAYS AS (
+  CASE volume
+    WHEN 0 THEN 0
+    ELSE POWER(2, LOG10(volume)) * COALESCE(ARRAY_LENGTH(integrators_used, 1), 0)
+  END
+) STORED;
+
+
+CREATE VIEW
+  api.competition_leaderboard_users AS
+SELECT
+  *,
+  RANK() OVER (
+    PARTITION BY
+      competition_id
+    ORDER BY
+      points DESC,
+      volume DESC,
+      n_trades DESC
+  ) AS RANK
+FROM
+  aggregator.competition_leaderboard_users AS users
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      aggregator.competition_exclusion_list AS ex
+    WHERE
+      users."user" = ex."user"
+      AND users.competition_id = ex.competition_id
+  )
+ORDER BY
+  points DESC,
+  volume DESC,
+  n_trades DESC;
+
+
+GRANT
+SELECT
+  ON api.competition_leaderboard_users TO web_anon;
+
+
+CREATE FUNCTION api.is_eligible (api.competition_leaderboard_users) RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN NOT EXISTS(
+        SELECT *
+        FROM api.competition_exclusion_list
+        WHERE api.competition_exclusion_list.competition_id = $1.competition_id
+        AND api.competition_exclusion_list."user" = $1."user"
+    );
+END;
+$$ LANGUAGE plpgsql;

--- a/src/rust/dbv2/migrations/2023-10-24-110811_guard_against_negative_volume/up.sql
+++ b/src/rust/dbv2/migrations/2023-10-24-110811_guard_against_negative_volume/up.sql
@@ -1,0 +1,59 @@
+-- Your SQL goes here
+ALTER TABLE aggregator.competition_leaderboard_users
+DROP COLUMN points CASCADE;
+
+
+ALTER TABLE aggregator.competition_leaderboard_users
+ADD COLUMN "points" NUMERIC GENERATED ALWAYS AS (
+  CASE
+    WHEN volume <= 0 THEN 0
+    ELSE POWER(2, LOG10(volume)) * COALESCE(ARRAY_LENGTH(integrators_used, 1), 0)
+  END
+) STORED;
+
+
+CREATE VIEW
+  api.competition_leaderboard_users AS
+SELECT
+  *,
+  RANK() OVER (
+    PARTITION BY
+      competition_id
+    ORDER BY
+      points DESC,
+      volume DESC,
+      n_trades DESC
+  ) AS RANK
+FROM
+  aggregator.competition_leaderboard_users AS users
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      aggregator.competition_exclusion_list AS ex
+    WHERE
+      users."user" = ex."user"
+      AND users.competition_id = ex.competition_id
+  )
+ORDER BY
+  points DESC,
+  volume DESC,
+  n_trades DESC;
+
+
+GRANT
+SELECT
+  ON api.competition_leaderboard_users TO web_anon;
+
+
+CREATE FUNCTION api.is_eligible (api.competition_leaderboard_users) RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN NOT EXISTS(
+        SELECT *
+        FROM api.competition_exclusion_list
+        WHERE api.competition_exclusion_list.competition_id = $1.competition_id
+        AND api.competition_exclusion_list."user" = $1."user"
+    );
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This change acts as a failsafe in case volume would become negative. This should never happen, but we never know, so it's better to do this than let the aggregator crash.