### PR TITLE
[ECO-804] Deploy competition DSS v1.0.0

### DIFF
--- a/src/terraform/leaderboard-backend/main.tf
+++ b/src/terraform/leaderboard-backend/main.tf
@@ -482,7 +482,7 @@ resource "google_compute_security_policy" "public_traffic" {
     rate_limit_options {
       ban_duration_sec = 60
       ban_threshold {
-        count        = 30
+        count        = 200
         interval_sec = 60
       }
       conform_action = "allow"
@@ -495,7 +495,7 @@ resource "google_compute_security_policy" "public_traffic" {
       }
       exceed_action = "deny(429)"
       rate_limit_threshold {
-        count        = 10
+        count        = 30
         interval_sec = 10
       }
     }


### PR DESCRIPTION
This is a draft PR stub to track the state of the repo for the competition leaderboard backend. It is a branch from the `competition-dss-v1.0.0` tag, with IP rate limit tuning.

`competition-metadata.json`:

```json
{
    "start": "2023-10-25T00:00:00Z",
    "end": "2023-11-01T00:00:00Z",
    "prize": 5000,
    "market_id": 3,
    "integrators_required": [
        "0x2e51979739db25dc987bd24e1a968e45cca0e0daea7cae9121f68af93e8884c9",
        "0xd718181a753f5b759518d9b896018dd7eb3d77d80bf90ba77fffaf678f781929",
        "0x69f76d32b0e6b08af826f5f75a7c58e6581d1c6c4ed1a935b121970f65d7436e"
    ]
}
```

`config.yaml`

```yaml
health_check_port: 8085
server_config:
  processor_config:
    type: econia_transaction_processor
    econia_address: 0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff
  postgres_connection_string: postgres://econia:econia@postgres:5432/econia
  indexer_grpc_data_service_address: https://grpc.testnet.aptoslabs.com:443
  indexer_grpc_http2_ping_interval_in_secs: 60
  indexer_grpc_http2_ping_timeout_in_secs: 10
  auth_token: <AUTH_TOKEN>
  starting_version: 649555969
```