### PR TITLE
[ECO-816] Throttle all limit orders

### DIFF
--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -3406,6 +3406,8 @@ module econia::market {
         assert!(quote <= (HI_64 as u128), E_SIZE_PRICE_QUOTE_OVERFLOW);
         // Max base to trade is amount calculated from size, lot size.
         let max_base = (base as u64);
+        // Throttle trade.
+        throttler::throttle::throttle_trade(market_id, user_address, max_base);
         // If a fill-or-abort order, must fill as a taker order with
         // a minimum trade amount equal to max base. Else no min.
         let min_base = if (restriction == FILL_OR_ABORT) max_base else 0;


### PR DESCRIPTION
Limit orders that post do not get throttled because presently the throttler only checks matches.

Throttle limit orders that post too, by simpling throttling all limit orders.