### PR TITLE
[ECO-818] Lower eviction threshold

### DIFF
--- a/src/move/econia/sources/avl_queue.move
+++ b/src/move/econia/sources/avl_queue.move
@@ -858,6 +858,11 @@ module econia::avl_queue {
     /// $2^{14} - 1$, the maximum number of nodes that can be allocated
     /// for either node type.
     const N_NODES_MAX: u64 = 16383;
+    /// The maximum number of allocated list nodes before eviction. This
+    /// is a constraint imposed by the Aptos view function paradigm,
+    /// namely that attempting to query all open orders leads to a view
+    /// function execution error.
+    const N_NODES_MAX_EVICT: u64 = 500;
     /// Flag for inorder predecessor traversal.
     const PREDECESSOR: bool = true;
     /// Flag for right direction.
@@ -1386,7 +1391,7 @@ module econia::avl_queue {
         // Get number of allocated list nodes.
         let n_list_nodes = table_with_length::length(&avlq_ref_mut.list_nodes);
         let max_list_nodes_active = // Check if max list nodes active.
-            (n_list_nodes == N_NODES_MAX) && (list_top == (NIL as u64));
+            (n_list_nodes == N_NODES_MAX_EVICT) && (list_top == (NIL as u64));
         // Declare tail access key and insertion value.
         let (tail_access_key, tail_value);
         // If above critical height or max list nodes active:


### PR DESCRIPTION
# Incident report

## Observations

* On 2023-10-26, during the testnet trading competition, the `market::get_open_orders_all()` view function began to fail with `EXECUTION_LIMIT_REACHED`:

```
~ % aptos move view --function-id $econia_addr::market::get_open_orders_all --args u64:3 --url "https://fullnode.testnet.aptoslabs.com" 
{
  "Error": "API error: API error Error(InvalidInput): Failed to execute function: VMError { major_status: EXECUTION_LIMIT_REACHED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: c0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff, name: Identifier(\"avl_queue\") }), indices: [], offsets: [(FunctionDefinitionIndex(45), 29)] }"
}
```

* Quries for just the best bid, and for the best bid and ask still worked:

```
(base) ~ % aptos move view --function-id $econia_addr::market::get_open_orders --args u64:3 u64:0 u64:1 --url "https://fullnode.testnet.aptoslabs.com"
{
  "Result": [
    {
      "asks": [],
      "bids": [
        {
          "custodian_id": "0",
          "market_id": "3",
          "order_id": "4634965971174311967332825",
          "price": "6617",
          "remaining_size": "5455405",
          "side": false,
          "user": "0x7676c6ad191680ee72a03f724aa750a66a9570ca90c7b6861c94a7c2c4ec5515"
        }
      ]
    }
  ]
}
(base) ~ % aptos move view --function-id $econia_addr::market::get_open_orders --args u64:3 u64:1 u64:1 --url "https://fullnode.testnet.aptoslabs.com"
{
  "Result": [
    {
      "asks": [
        {
          "custodian_id": "0",
          "market_id": "3",
          "order_id": "4634763053455614956018149",
          "price": "6629",
          "remaining_size": "10629968",
          "side": true,
          "user": "0x7676c6ad191680ee72a03f724aa750a66a9570ca90c7b6861c94a7c2c4ec5515"
        }
      ],
      "bids": [
        {
          "custodian_id": "0",
          "market_id": "3",
          "order_id": "4634965971174311967332825",
          "price": "6617",
          "remaining_size": "3455405",
          "side": false,
          "user": "0x7676c6ad191680ee72a03f724aa750a66a9570ca90c7b6861c94a7c2c4ec5515"
        }
      ]
    }
  ]
}

```

* And the view function also functioned properly when passing `n_asks_max = 1000` and `n_bids_max = 1000`

* At the time, the DSS reported 2221 open orders via a `psql` query.

* The view function `user::get_market_account` functioned as expected.

* The `market::place_market_order_user_entry` functioned as expected.

## Conclusions

* The `market::get_open_orders_all()` function was simply consuming more gas than the VM gas limit allowed, due to the operation iterating over every open order via Move, rather than via a relational database, for example.
* The matching engine and runtime are not affected, nor is there any concern about core Move functionality.
* The issue can be quickly resolved by changing eviction logic to evict when there are more than 500 orders on either side of the book, thus enabling `get_open_orders_all()` to index the book to completion without hitting execution gas limits.

# Code changes

* Change the AVL queue to evict the order with the lowest price-time priority when there are more than 500 orders on that side of the book.

# Further discussion

* It is proposed that Aptos relax constraints on max gas consumption during view functions, since these do not affect core runtime functionality.
* As for the Econia Move package, the current quick fix can be kept, but this will lead to a smaller possible total order book.
* Alternatively, the quick fix could be reverted, and additional view functions with pagination could be added so as to avoid the execution limit error.
