### PR TITLE
[ECO-847] Clean up internal Terraform deployment

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/terraform.md
+++ b/doc/doc-site/docs/off-chain/dss/terraform.md
@@ -76,14 +76,19 @@ class rest-service yellow;
 1. [Configure a billable GCP project](gcp#configure-project):
 
    ```sh
+   PROJECT_NAME=leaderboard-backend
+   ```
+
+   ```sh
    echo $PROJECT_ID
+   echo $PROJECT_NAME
    echo $ORGANIZATION_ID
    echo $BILLING_ACCOUNT_ID
    ```
 
    ```sh
    gcloud projects create $PROJECT_ID \
-       --name leaderboard-backend \
+       --name $PROJECT_NAME \
        --organization $ORGANIZATION_ID
    gcloud alpha billing projects link $PROJECT_ID \
        --billing-account $BILLING_ACCOUNT_ID

--- a/src/terraform/internal-dss/README.md
+++ b/src/terraform/internal-dss/README.md
@@ -1,3 +1,4 @@
 This Terraform project is designed to support an internal deployment of the Econia Data Service Stack (DSS).
-It uses a compromised JWT secret, does not limit the number of rows in a PostgREST query, and sets up endpoint URLs that have no load balancing, IP rate limiting, etc.
-See the docs site for example deployment commands.
+If you wish to use it in production, note that it uses a compromised JWT secret, does not implement load balancing or IP rate limiting, etc., and you will probably want to tune it for your own deployment.
+
+See the docs site for example deployment commands, denial-of-service (DoS) mitigation strategies, etc.

--- a/src/terraform/internal-dss/variables.tf
+++ b/src/terraform/internal-dss/variables.tf
@@ -8,6 +8,10 @@ variable "credentials_file" {
   default = "gcp-key.json"
 }
 
+variable "postgrest_max_rows" {
+  default = 500
+}
+
 variable "ws_jwt_secret" {
   default = "econia_0000000000000000000000000"
 }


### PR DESCRIPTION
* Set PostgREST max rows to 500
* Update internal DSS README
* Add destroy-time provisioner to get rid of peering, effectively automating the manual process currently described as a "tip" on the Terraform page of the docs site
* Update docs site project creation instructions to make project naming simpler for assorted projects