### PR TITLE
[ECO-842] Add execution price field

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/down.sql
@@ -1,1 +1,8 @@
 -- This file should undo anything in `up.sql`
+DROP INDEX fill_events_maker_order_id;
+
+
+DROP INDEX fill_events_taker_order_id;
+
+
+DROP FUNCTION api.execution_price;

--- a/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/up.sql
@@ -1,0 +1,23 @@
+-- Your SQL goes here
+CREATE INDEX fill_events_maker_order_id ON fill_events (maker_order_id);
+
+
+CREATE INDEX fill_events_taker_order_id ON fill_events (taker_order_id);
+
+
+CREATE FUNCTION api.execution_price(api.orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = 3
+    AND (
+            fill_events.maker_order_id = 44689488021338381355057152
+        OR
+            fill_events.taker_order_id = 44689488021338381355057152
+    )
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-02-210244_execution-price-function/up.sql
@@ -14,10 +14,10 @@ RETURNS numeric AS $$
     WHERE
         maker_address = emit_address
     AND
-        fill_events.market_id = 3
+        fill_events.market_id = $1.market_id
     AND (
-            fill_events.maker_order_id = 44689488021338381355057152
+            fill_events.maker_order_id = $1.order_id
         OR
-            fill_events.taker_order_id = 44689488021338381355057152
+            fill_events.taker_order_id = $1.order_id
     )
 $$ LANGUAGE SQL;


### PR DESCRIPTION
Add execution price as a [computed field](https://postgrest.org/en/stable/references/api/computed_fields.html) for orders.

The price is calculated as `SUM(size * price) / SUM(size)`.

Also add two indexes to speed up the function.