### PR TITLE
[ECO-852] Make price info query suggestions

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-02-131654_small-queries/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-02-131654_small-queries/up.sql
@@ -1,40 +1,64 @@
 -- Your SQL goes here
+CREATE INDEX timeprice ON fill_events("time", price);
 
-CREATE INDEX timeprice ON fill_events (time, price);
-
-CREATE FUNCTION api.price_info(market integer, seconds integer)
-RETURNS TABLE(last_price numeric, price_change numeric, high_price numeric, low_price numeric) AS $$
-    WITH market_data AS (
-        SELECT *
-        FROM market_registration_events
-        WHERE market_id = market
-    ),
-    fills AS (
-        SELECT *
-        FROM fill_events
-        WHERE market_id = market
-        AND time >= CURRENT_TIMESTAMP - '1 second'::interval * seconds
-        ORDER BY txn_version DESC, event_idx DESC
-    ),
-    last_fill AS (
-        SELECT *
-        FROM fills
-        LIMIT 1
-    ),
-    first_fill AS (
-        SELECT *
-        FROM fills
-        LIMIT 1
+CREATE FUNCTION api.price_info(market integer, "seconds" integer)
+    RETURNS TABLE(
+        last_price numeric,
+        price_change numeric,
+        high_price numeric,
+        low_price numeric
     )
+    AS $$
+    WITH market_data AS(
+        SELECT
+            *
+        FROM
+            market_registration_events
+        WHERE
+            market_id = market
+),
+fills AS(
     SELECT
-        last_fill.price * market_data.lot_size,
-        100::numeric - first_fill.price / last_fill.price * 100,
-        MIN(fills.price) * market_data.lot_size,
-        MAX(fills.price) * market_data.lot_size
+        *
     FROM
-        last_fill,
-        first_fill,
-        market_data,
+        fill_events
+    WHERE
+        market_id = market
+        AND "time" >= CURRENT_TIMESTAMP - '1 second'::interval * seconds
+),
+last_fill AS(
+    SELECT
+        *
+    FROM
         fills
-    GROUP BY last_fill.price, first_fill.price, market_data.lot_size
-$$ LANGUAGE SQL IMMUTABLE;
+    ORDER BY
+        txn_version DESC,
+        event_idx DESC
+    LIMIT 1
+),
+first_fill AS(
+    SELECT
+        *
+    FROM
+        fills
+    ORDER BY
+        txn_version ASC,
+        event_idx ASC
+    LIMIT 1
+)
+SELECT
+    last_fill.price,
+(last_fill.price - first_fill.price) / first_fill.price * 100,
+    MIN(fills.price),
+    MAX(fills.price)
+FROM
+    last_fill,
+    first_fill,
+    fills
+GROUP BY
+    last_fill.price,
+    first_fill.price
+$$
+LANGUAGE SQL
+IMMUTABLE;
+


### PR DESCRIPTION
* Address comments from https://github.com/econia-labs/econia/pull/582
  * Fix `last_fill` and `first_fill` logic
  * Remove lot size multipliers
  * Change percentage to be a relative amount
* Run through `pgformatter` via format on save