### PR TITLE
[ECO-826] Remove decimals from last_increase_timestamp

### DIFF
--- a/src/rust/dbv2/migrations/2023-10-03-070930_add_order_queue/down.sql
+++ b/src/rust/dbv2/migrations/2023-10-03-070930_add_order_queue/down.sql
@@ -22,3 +22,5 @@ ALTER TABLE aggregator.user_history_limit DROP COLUMN price;
 
 CREATE VIEW api.limit_orders AS
     SELECT * FROM aggregator.user_history_limit NATURAL JOIN aggregator.user_history;
+
+GRANT SELECT ON api.limit_orders TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-03-102931_lix_last_increase_timestamp/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-03-102931_lix_last_increase_timestamp/down.sql
@@ -1,0 +1,32 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.limit_orders ;
+
+
+ALTER TABLE aggregator.user_history_limit ALTER COLUMN last_increase_stamp TYPE numeric;
+
+
+CREATE VIEW api.limit_orders AS
+    SELECT
+        market_id,
+        order_id,
+        "user",
+        custodian_id,
+        self_matching_behavior,
+        restriction,
+        created_at,
+        last_updated_at,
+        integrator,
+        total_filled,
+        remaining_size,
+        order_status,
+        order_type,
+        price,
+        last_increase_stamp,
+        CASE
+            WHEN side = true THEN 'ask'
+            ELSE 'bid'
+        END AS side
+    FROM aggregator.user_history_limit NATURAL JOIN aggregator.user_history;
+
+
+GRANT SELECT ON api.limit_orders TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-03-102931_lix_last_increase_timestamp/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-03-102931_lix_last_increase_timestamp/up.sql
@@ -1,0 +1,32 @@
+-- Your SQL goes here
+DROP VIEW api.limit_orders ;
+
+
+ALTER TABLE aggregator.user_history_limit ALTER COLUMN last_increase_stamp TYPE numeric(39,0);
+
+
+CREATE VIEW api.limit_orders AS
+    SELECT
+        market_id,
+        order_id,
+        "user",
+        custodian_id,
+        self_matching_behavior,
+        restriction,
+        created_at,
+        last_updated_at,
+        integrator,
+        total_filled,
+        remaining_size,
+        order_status,
+        order_type,
+        price,
+        last_increase_stamp,
+        CASE
+            WHEN side = true THEN 'ask'
+            ELSE 'bid'
+        END AS side
+    FROM aggregator.user_history_limit NATURAL JOIN aggregator.user_history;
+
+
+GRANT SELECT ON api.limit_orders TO web_anon;


### PR DESCRIPTION
Remove decimals from the `last_increase_timestamp` field in `limit_orders`. Also fix an old related migration.