### PR TITLE
[ECO-857] Use buy/sell instead of boolean for orders endpoints

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-05-120656_direction_as_string/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-120656_direction_as_string/down.sql
@@ -1,0 +1,33 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.market_orders;
+
+
+DROP VIEW api.swap_orders;
+
+
+CREATE VIEW
+  api.market_orders AS
+SELECT
+  *
+FROM
+  aggregator.user_history_market
+  NATURAL JOIN aggregator.user_history;
+
+
+CREATE VIEW
+  api.swap_orders AS
+SELECT
+  *
+FROM
+  aggregator.user_history_swap
+  NATURAL JOIN aggregator.user_history;
+
+
+GRANT
+SELECT
+  ON api.market_orders TO web_anon;
+
+
+GRANT
+SELECT
+  ON api.swap_orders TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-05-120656_direction_as_string/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-120656_direction_as_string/up.sql
@@ -1,0 +1,66 @@
+-- Your SQL goes here
+DROP VIEW api.market_orders;
+
+
+DROP VIEW api.swap_orders;
+
+
+CREATE VIEW
+  api.market_orders AS
+SELECT
+  market_id,
+  order_id,
+  "user",
+  custodian_id,
+  CASE
+    WHEN direction = TRUE THEN 'sell'
+    ELSE 'buy'
+  END AS direction,
+  self_matching_behavior,
+  created_at,
+  last_updated_at,
+  integrator,
+  total_filled,
+  remaining_size,
+  order_status,
+  order_type
+FROM
+  aggregator.user_history_market
+  NATURAL JOIN aggregator.user_history;
+
+
+CREATE VIEW
+  api.swap_orders AS
+SELECT
+  market_id,
+  order_id,
+  CASE
+    WHEN direction = TRUE THEN 'sell'
+    ELSE 'buy'
+  END AS direction,
+  limit_price,
+  signing_account,
+  min_base,
+  max_base,
+  min_quote,
+  max_quote,
+  created_at,
+  last_updated_at,
+  integrator,
+  total_filled,
+  remaining_size,
+  order_status,
+  order_type
+FROM
+  aggregator.user_history_swap
+  NATURAL JOIN aggregator.user_history;
+
+
+GRANT
+SELECT
+  ON api.market_orders TO web_anon;
+
+
+GRANT
+SELECT
+  ON api.swap_orders TO web_anon;


### PR DESCRIPTION
This PR updates the `market_orders` and `swap_orders` endpoints to change the
previously boolean field `direction` to text.

---

## Example

**Previous response example**:

```json
[
  {
    "market_id": 3,
    "order_id": 387381625547900583936,
    "user": "0x6c509ada7a55a622d97e8f9725723460d3e08e02ebd32de1d9038bbc93530192",
    "custodian_id": 0,
    "direction": true,
    "self_matching_behavior": 2,
    "created_at": "2023-09-05T20:45:19.88794+00:00",
    "last_updated_at": "2023-09-05T20:45:19.88794+00:00",
    "integrator": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "total_filled": 500,
    "remaining_size": 0,
    "order_status": "closed",
    "order_type": "market"
  }
]
```

**Current response example**:

```json
[
  {
    "market_id": 3,
    "order_id": 387381625547900583936,
    "user": "0x6c509ada7a55a622d97e8f9725723460d3e08e02ebd32de1d9038bbc93530192",
    "custodian_id": 0,
    "direction": "sell",
    "self_matching_behavior": 2,
    "created_at": "2023-09-05T20:45:19.88794+00:00",
    "last_updated_at": "2023-09-05T20:45:19.88794+00:00",
    "integrator": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "total_filled": 500,
    "remaining_size": 0,
    "order_status": "closed",
    "order_type": "market"
  }
]
```
