### PR TITLE
[ECO-858] create `markets` and `recognized_markets` endpoints

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.markets;
+
+
+DROP VIEW api.recognized_markets;

--- a/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/down.sql
@@ -3,3 +3,6 @@ DROP VIEW api.markets;
 
 
 DROP VIEW api.recognized_markets;
+
+
+DROP VIEW aggregator.recognized_markets;

--- a/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
@@ -1,0 +1,58 @@
+-- Your SQL goes here
+CREATE VIEW api.recognized_markets AS
+    SELECT
+    DISTINCT ON (
+        base_account_address,
+        base_module_name,
+        base_struct_name,
+        base_name_generic,
+        quote_account_address,
+        quote_module_name,
+        quote_struct_name
+    )
+        *
+    FROM
+        recognized_market_events
+    ORDER BY
+        base_account_address,
+        base_module_name,
+        base_struct_name,
+        base_name_generic,
+        quote_account_address,
+        quote_module_name,
+        quote_struct_name,
+        txn_version DESC,
+        event_idx DESC;
+
+
+GRANT SELECT ON api.recognized_markets TO web_anon;
+
+
+CREATE VIEW api.markets AS
+    SELECT
+        m.*,
+        CASE
+            WHEN r.market_id = m.market_id THEN true
+            ELSE false
+        END AS is_recognized
+    FROM
+        market_registration_events AS m
+    LEFT JOIN
+        api.recognized_markets AS r
+    ON
+        COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+    AND
+        COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+    AND
+        COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+    AND
+        COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+    AND
+        r.quote_account_address = m.quote_account_address
+    AND
+        r.quote_module_name = m.quote_module_name
+    AND
+        r.quote_struct_name = m.quote_struct_name;
+
+
+GRANT SELECT ON api.markets TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
@@ -10,7 +10,19 @@ CREATE VIEW aggregator.recognized_markets AS
         quote_module_name,
         quote_struct_name
     )
-        *
+        market_id,
+        "time",
+        "base_account_address",
+        "base_module_name",
+        "base_struct_name",
+        "base_name_generic",
+        "quote_account_address",
+        "quote_module_name",
+        "quote_struct_name",
+        "lot_size",
+        "tick_size",
+        "min_size",
+        "underwriter_id"
     FROM
         recognized_market_events
     ORDER BY

--- a/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-124149_recognized_market_endpoint/up.sql
@@ -1,5 +1,5 @@
 -- Your SQL goes here
-CREATE VIEW api.recognized_markets AS
+CREATE VIEW aggregator.recognized_markets AS
     SELECT
     DISTINCT ON (
         base_account_address,
@@ -25,6 +25,15 @@ CREATE VIEW api.recognized_markets AS
         event_idx DESC;
 
 
+CREATE VIEW api.recognized_markets AS
+    SELECT
+        *
+    FROM
+        aggregator.recognized_markets
+    WHERE
+        market_id IS NOT NULL;
+
+
 GRANT SELECT ON api.recognized_markets TO web_anon;
 
 
@@ -38,7 +47,7 @@ CREATE VIEW api.markets AS
     FROM
         market_registration_events AS m
     LEFT JOIN
-        api.recognized_markets AS r
+        aggregator.recognized_markets AS r
     ON
         COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
     AND


### PR DESCRIPTION
This PR adds the following endpoints:

- `/markets`
- `/recognized_markets`

You might ask why `/recognized_markets` exists, as you could query them only by
adding `?is_recognized=eq.true` to the first endpoint to get recognized
markets. The reason it that the second endpoint is more performant, as it is
not joining two tables, as would the query mentioned before do.

---

## Example

**Output of querying `/markets`**:

```json
[
  {
    "market_id": 2,
    "time": "2023-09-04T15:20:12.12123+00:00",
    "base_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "base_module_name": "example_apt",
    "base_struct_name": "ExampleAPT",
    "base_name_generic": null,
    "quote_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "quote_module_name": "example_usdc",
    "quote_struct_name": "ExampleUSDC",
    "lot_size": 100000,
    "tick_size": 1,
    "min_size": 1,
    "underwriter_id": 0,
    "is_recognized": false
  },
  {
    "market_id": 3,
    "time": "2023-09-04T17:09:37.423851+00:00",
    "base_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "base_module_name": "example_apt",
    "base_struct_name": "ExampleAPT",
    "base_name_generic": null,
    "quote_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "quote_module_name": "example_usdc",
    "quote_struct_name": "ExampleUSDC",
    "lot_size": 100000,
    "tick_size": 1,
    "min_size": 500,
    "underwriter_id": 0,
    "is_recognized": true
  }
]
```

**Output of querying `/recognized_markets`**:

```json
[
  {
    "time": "2023-10-03T18:27:47.224021+00:00",
    "base_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "base_module_name": "example_apt",
    "base_struct_name": "ExampleAPT",
    "base_name_generic": null,
    "quote_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "quote_module_name": "example_usdc",
    "quote_struct_name": "ExampleUSDC",
    "market_id": 3,
    "lot_size": 100000,
    "tick_size": 1,
    "min_size": 500,
    "underwriter_id": 0
  }
]
```
