### PR TITLE
[ECO-853] add function to get user market account balance

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-05-131409_user_market_account_balance/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-131409_user_market_account_balance/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION api.user_handle;
+
+
+DROP FUNCTION api.user_balance;
+
+
+DROP INDEX user_balance;

--- a/src/rust/dbv2/migrations/2023-11-05-131409_user_market_account_balance/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-05-131409_user_market_account_balance/up.sql
@@ -1,0 +1,45 @@
+-- Your SQL goes here
+CREATE FUNCTION api.user_handle (user_address TEXT) RETURNS TEXT AS $$
+    SELECT handle FROM market_account_handles WHERE "user" = user_address;
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.user_balance (
+  user_address TEXT,
+  market NUMERIC,
+  custodian NUMERIC
+) RETURNS TABLE (
+  base_total NUMERIC,
+  base_available NUMERIC,
+  base_ceiling NUMERIC,
+  quote_total NUMERIC,
+  quote_available NUMERIC,
+  quote_ceiling NUMERIC
+) AS $$
+DECLARE
+    v_handle text := '';
+BEGIN
+    SELECT api.user_handle(user_address) INTO v_handle;
+    RETURN QUERY SELECT
+        b."base_total",
+        b."base_available",
+        b."base_ceiling",
+        b."quote_total",
+        b."quote_available",
+        b."quote_ceiling"
+    FROM
+        balance_updates_by_handle AS b
+    WHERE
+        b.custodian_id = custodian
+    AND
+        b.market_id = market
+    AND
+        b.handle = v_handle
+    ORDER BY
+        b."txn_version" DESC
+    LIMIT 1;
+END;
+$$ LANGUAGE PLPGSQL;
+
+
+CREATE INDEX user_balance ON balance_updates_by_handle (custodian_id, market_id, handle, txn_version DESC);


### PR DESCRIPTION
This PR adds the `/rpc/user_balance` endpoint, which returns the user balance for a given user, market and custodian.

---

## Example

```http
GET /rpc/user_balance\?market=MARKET_ID\&custodian=CUSTODIAN_ID\&user_address=USER_ADDRESS
```

```json
[
  {
    "base_total": 201160061618600000,
    "base_available": 201159251459200000,
    "base_ceiling": 201161211569500000,
    "quote_total": 1933878511960591,
    "quote_available": 1933803458830544,
    "quote_ceiling": 1933931887592552
  }
]
```
