### PR TITLE
[ECO-875] rename `execution_price` to `average_execution_price`

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-06-214605_rename_execution_price/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-06-214605_rename_execution_price/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER FUNCTION
+    api.average_execution_price
+RENAME TO
+    execution_price;

--- a/src/rust/dbv2/migrations/2023-11-06-214605_rename_execution_price/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-06-214605_rename_execution_price/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER FUNCTION
+    api.execution_price
+RENAME TO
+    average_execution_price;


### PR DESCRIPTION
Change the name of the `execution_price` field to `average_execution_price`.
