### PR TITLE
[ECO-828] Bump audit references for pagination

### DIFF
--- a/doc/doc-site/docs/security.md
+++ b/doc/doc-site/docs/security.md
@@ -1,7 +1,7 @@
 # Security
 
 Econia has been independently audited by three firms, and all [audit reports] are public:
-Move source code is audited through commit [`8220489`] (tag [`v4.1.1-audited`]), via three initial audits and three followup audits.
+Move source code is audited through commit [`ea0f02b`] (tag [`v4.2.0-audited`]), via three initial audits and four followup audits.
 
 Moreover, Econia is deployed on Aptos mainnet under a community-governed multisig account in accordance with the [Econia signatory guide].
 
@@ -13,5 +13,5 @@ Anyone who uses the Econia protocol agrees to hold harmless all signatories to t
 
 [audit reports]: https://econia-labs.notion.site/Econia-Audit-Reports-27634e9c7d1249228e2cbc3e705a59c9
 [econia signatory guide]: https://econia-labs.notion.site/Aptos-Multisig-v2-and-Econia-v4-A-Signatory-s-Guide-to-On-Chain-Governance-96da99732f744044af6a3eca88a21fac?pvs=4
-[`8220489`]: https://github.com/econia-labs/econia/commit/8220489650600cf9b236ef634a00dec6049a46c2
-[`v4.1.1-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.1.1-audited
+[`ea0f02b`]: https://github.com/econia-labs/econia/commit/ea0f02b2e678449c348d3cc2eabdfa42532b6334
+[`v4.2.0-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.2.0-audited


### PR DESCRIPTION
Update security page with references to auxiliary pagination functions added during testnet competition