### PR TITLE
[ECO-889] add average execution price for all order endpoints

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-07-152818_average_execution_price_for_all_order_endpoints/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-07-152818_average_execution_price_for_all_order_endpoints/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION api.average_execution_price(api.limit_orders);
+
+
+DROP FUNCTION api.average_execution_price(api.market_orders);
+
+
+DROP FUNCTION api.average_execution_price(api.swap_orders);

--- a/src/rust/dbv2/migrations/2023-11-07-152818_average_execution_price_for_all_order_endpoints/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-07-152818_average_execution_price_for_all_order_endpoints/up.sql
@@ -1,0 +1,53 @@
+-- Your SQL goes here
+CREATE FUNCTION api.average_execution_price(api.limit_orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS average_execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = $1.market_id
+    AND (
+            fill_events.maker_order_id = $1.order_id
+        OR
+            fill_events.taker_order_id = $1.order_id
+    )
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.average_execution_price(api.market_orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS average_execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = $1.market_id
+    AND (
+            fill_events.maker_order_id = $1.order_id
+        OR
+            fill_events.taker_order_id = $1.order_id
+    )
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.average_execution_price(api.swap_orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS average_execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = $1.market_id
+    AND (
+            fill_events.maker_order_id = $1.order_id
+        OR
+            fill_events.taker_order_id = $1.order_id
+    )
+$$ LANGUAGE SQL;


### PR DESCRIPTION
Add the possibility to query the `average_execution_price` for `{limit,market,swap}_orders` endpoints just like for the `orders` endpoint.
