### PR TITLE
[ECO-845] unify all orders endpoints into one

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/down.sql
@@ -1,0 +1,33 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION api.average_execution_price;
+
+
+DROP VIEW api.orders;
+
+
+CREATE VIEW api.orders AS
+    SELECT
+        *
+    FROM
+        aggregator.user_history;
+
+
+GRANT SELECT ON api.orders TO web_anon;
+
+
+CREATE FUNCTION api.average_execution_price(api.orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS average_execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = $1.market_id
+    AND (
+            fill_events.maker_order_id = $1.order_id
+        OR
+            fill_events.taker_order_id = $1.order_id
+    )
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/up.sql
@@ -1,0 +1,98 @@
+-- Your SQL goes here
+DROP FUNCTION api.average_execution_price;
+
+
+DROP VIEW api.orders;
+
+
+CREATE VIEW api.orders AS
+    SELECT
+        -- Common to all
+        u.market_id,
+        u.order_id,
+        u.created_at,
+        u.last_updated_at,
+        u.integrator,
+        u.total_filled,
+        u.remaining_size,
+        u.order_status,
+        u.order_type,
+
+        -- Common to all but with different names
+        CASE
+            WHEN u.order_type = 'limit' THEN l."user"
+            WHEN u.order_type = 'market' THEN m."user"
+            WHEN u.order_type = 'swap' THEN s.signing_account
+        END AS "user",
+        CASE
+            WHEN u.order_type = 'limit' THEN
+                CASE
+                    WHEN l.side = true THEN 'ask'
+                    ELSE 'bid'
+                END
+            WHEN u.order_type = 'market' THEN
+                CASE
+                    WHEN m.direction = true THEN 'buy'
+                    ELSE 'sell'
+                END
+            WHEN u.order_type = 'swap' THEN
+                CASE
+                    WHEN s.direction = true THEN 'buy'
+                    ELSE 'sell'
+                END
+        END AS direction,
+
+        -- Common to some
+        CASE
+            WHEN u.order_type = 'limit' THEN l.price
+            WHEN u.order_type = 'market' THEN NULL
+            WHEN u.order_type = 'swap' THEN s.limit_price
+        END AS price,
+        CASE
+            WHEN u.order_type = 'limit' THEN l.custodian_id
+            WHEN u.order_type = 'market' THEN m.custodian_id
+            WHEN u.order_type = 'swap' THEN NULL
+        END AS custodian_id,
+        CASE
+            WHEN u.order_type = 'limit' THEN l.self_matching_behavior
+            WHEN u.order_type = 'market' THEN m.self_matching_behavior
+            WHEN u.order_type = 'swap' THEN NULL
+        END AS self_matching_behavior,
+
+        -- Particular to limit orders
+        l.restriction,
+
+        -- Particular to swap orders
+        s.min_base,
+        s.max_base,
+        s.min_quote,
+        s.max_quote
+    FROM
+        aggregator.user_history AS u
+    NATURAL LEFT JOIN
+        aggregator.user_history_limit AS l
+    NATURAL LEFT JOIN
+        aggregator.user_history_market AS m
+    NATURAL LEFT JOIN
+        aggregator.user_history_swap AS s;
+
+
+GRANT SELECT ON api.orders TO web_anon;
+
+
+CREATE FUNCTION api.average_execution_price(api.orders)
+RETURNS numeric AS $$
+    SELECT
+        SUM(size * price) / SUM(size) AS average_execution_price
+    FROM
+        fill_events
+    WHERE
+        maker_address = emit_address
+    AND
+        fill_events.market_id = $1.market_id
+    AND (
+            fill_events.maker_order_id = $1.order_id
+        OR
+            fill_events.taker_order_id = $1.order_id
+    )
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-07-154637_new_orders_endpoint/up.sql
@@ -32,13 +32,13 @@ CREATE VIEW api.orders AS
                 END
             WHEN u.order_type = 'market' THEN
                 CASE
-                    WHEN m.direction = true THEN 'buy'
-                    ELSE 'sell'
+                    WHEN m.direction = true THEN 'sell'
+                    ELSE 'buy'
                 END
             WHEN u.order_type = 'swap' THEN
                 CASE
-                    WHEN s.direction = true THEN 'buy'
-                    ELSE 'sell'
+                    WHEN s.direction = true THEN 'sell'
+                    ELSE 'buy'
                 END
         END AS direction,
 


### PR DESCRIPTION
Instead of having `{limit,market,swap}_orders` and `orders`, only have an `orders` endpoint.

This endpoint will return a list of elements which have the fields of all order types, but with the unused ones set to `null`.

---

## Example

```http
GET /orders
```

```json
[
  {
    "market_id": 3,
    "order_id": 67470442778538899702552972,
    "created_at": "2023-11-05T15:44:13.294947+00:00",
    "last_updated_at": null,
    "integrator": "0x2e51979739db25dc987bd24e1a968e45cca0e0daea7cae9121f68af93e8884c9",
    "total_filled": 0,
    "remaining_size": 200000,
    "order_status": "open",
    "order_type": "limit",
    "user": "0xf3ce7187f9a72e9b63146c28dbb00918623ee60aa2a86828d49cc0d4355554a9",
    "direction": "bid",
    "price": 6540,
    "custodian_id": 0,
    "self_matching_behavior": 3,
    "restriction": 0,
    "min_base": null,
    "max_base": null,
    "min_quote": null,
    "max_quote": null
  },
  {
    "market_id": 3,
    "order_id": 67470294615165992123236352,
    "created_at": "2023-11-05T13:26:45.244727+00:00",
    "last_updated_at": "2023-11-05T13:26:45.244727+00:00",
    "integrator": "0x69f76d32b0e6b08af826f5f75a7c58e6581d1c6c4ed1a935b121970f65d7436e",
    "total_filled": 30000,
    "remaining_size": 0,
    "order_status": "closed",
    "order_type": "market",
    "user": null,
    "direction": "sell",
    "price": null,
    "custodian_id": null,
    "self_matching_behavior": null,
    "restriction": null,
    "min_base": null,
    "max_base": null,
    "min_quote": null,
    "max_quote": null
  },
  {
    "market_id": 3,
    "order_id": 67470276168421918413684736,
    "created_at": "2023-11-05T11:01:56.37315+00:00",
    "last_updated_at": "2023-11-05T11:01:56.37315+00:00",
    "integrator": "0x69f76d32b0e6b08af826f5f75a7c58e6581d1c6c4ed1a935b121970f65d7436e",
    "total_filled": 50000,
    "remaining_size": 0,
    "order_status": "closed",
    "order_type": "swap",
    "user": null,
    "direction": "sell",
    "price": null,
    "custodian_id": null,
    "self_matching_behavior": null,
    "restriction": null,
    "min_base": null,
    "max_base": null,
    "min_quote": null,
    "max_quote": null
  }
]
```
