### PR TITLE
[ECO-891] update markets enpoint with more data

### DIFF
--- a/src/docker/compose.database.yaml
+++ b/src/docker/compose.database.yaml
@@ -23,8 +23,6 @@ services:
     ports:
       - "5432:5432"
     restart: always
-    volumes:
-      - "db:/var/lib/postgresql/data"
 
 volumes:
   db:

--- a/src/docker/compose.database.yaml
+++ b/src/docker/compose.database.yaml
@@ -23,6 +23,8 @@ services:
     ports:
       - "5432:5432"
     restart: always
+    volumes:
+      - "db:/var/lib/postgresql/data"
 
 volumes:
   db:

--- a/src/rust/dbv2/migrations/2023-11-08-091936_markets_overview/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-08-091936_markets_overview/down.sql
@@ -1,0 +1,32 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.markets;
+
+
+CREATE VIEW api.markets AS
+    SELECT
+        m.*,
+        CASE
+            WHEN r.market_id = m.market_id THEN true
+            ELSE false
+        END AS is_recognized
+    FROM
+        market_registration_events AS m
+    LEFT JOIN
+        aggregator.recognized_markets AS r
+    ON
+        COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+    AND
+        COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+    AND
+        COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+    AND
+        COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+    AND
+        r.quote_account_address = m.quote_account_address
+    AND
+        r.quote_module_name = m.quote_module_name
+    AND
+        r.quote_struct_name = m.quote_struct_name;
+
+
+GRANT SELECT ON api.markets TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-08-091936_markets_overview/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-08-091936_markets_overview/up.sql
@@ -30,13 +30,25 @@ CREATE VIEW api.markets AS
             event_idx ASC
     )
     SELECT
-        m.*,
+        m.market_id,
+        m.time AS registration_time,
+        m.base_account_address,
+        m.base_module_name,
+        m.base_struct_name,
+        m.base_name_generic,
+        m.quote_account_address,
+        m.quote_module_name,
+        m.quote_struct_name,
+        m.lot_size,
+        m.tick_size,
+        m.min_size,
+        m.underwriter_id,
         CASE
             WHEN r.market_id = m.market_id THEN true
             ELSE false
         END AS is_recognized,
-        l.price,
-        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS change
+        l.price AS last_fill_price_24hr,
+        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS percent_change_24h
     FROM
         market_registration_events AS m
     LEFT JOIN


### PR DESCRIPTION
Add `price` and `change` fields to the `/markets` endpoint.

---

## Example

```http
GET /markets?market_id=eq.3
```

```json
[
  {
    "market_id": 3,
    "registration_time": "2023-09-04T17:09:37.423851+00:00",
    "base_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "base_module_name": "example_apt",
    "base_struct_name": "ExampleAPT",
    "base_name_generic": null,
    "quote_account_address": "0xc0de11113b427d35ece1d8991865a941c0578b0f349acabbe9753863c24109ff",
    "quote_module_name": "example_usdc",
    "quote_struct_name": "ExampleUSDC",
    "lot_size": 100000,
    "tick_size": 1,
    "min_size": 500,
    "underwriter_id": 0,
    "is_recognized": true,
    "last_fill_price_24hr": 7329,
    "percent_change_24h": -0.06817562039814562300
  }
]
```
