### PR TITLE
[ECO-897] fix min and max price in `market_aggregated_info` endpoint

### DIFF
--- a/src/rust/dbv2/migrations/2023-11-09-112633_fix_min_max_market_aggregated_info/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-09-112633_fix_min_max_market_aggregated_info/down.sql
@@ -1,0 +1,63 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION api.market_aggregated_info;
+
+
+CREATE FUNCTION api.market_aggregated_info(market integer, "seconds" integer)
+RETURNS TABLE(
+    last_price numeric,
+    price_change_percentage numeric,
+    price_change_nominal numeric,
+    high_price numeric,
+    low_price numeric,
+    base_volume numeric,
+    quote_volume numeric
+)
+AS $$
+WITH fills AS(
+    SELECT
+        *
+    FROM
+        fill_events
+    WHERE
+        market_id = market
+        AND "time" >= CURRENT_TIMESTAMP - '1 second'::interval * seconds
+        AND emit_address = maker_address
+),
+last_fill AS(
+    SELECT
+        *
+    FROM
+        fills
+    ORDER BY
+        txn_version DESC,
+        event_idx DESC
+    LIMIT 1
+),
+first_fill AS(
+    SELECT
+        *
+    FROM
+        fills
+    ORDER BY
+        txn_version ASC,
+        event_idx ASC
+    LIMIT 1
+)
+SELECT
+    last_fill.price,
+    (last_fill.price - first_fill.price) / first_fill.price * 100,
+    last_fill.price - first_fill.price,
+    MIN(fills.price),
+    MAX(fills.price),
+    SUM(fills.size),
+    SUM(fills.size * fills.price)
+FROM
+    last_fill,
+    first_fill,
+    fills
+GROUP BY
+    last_fill.price,
+    first_fill.price
+$$
+LANGUAGE SQL
+IMMUTABLE;

--- a/src/rust/dbv2/migrations/2023-11-09-112633_fix_min_max_market_aggregated_info/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-09-112633_fix_min_max_market_aggregated_info/up.sql
@@ -1,0 +1,63 @@
+-- Your SQL goes here
+DROP FUNCTION api.market_aggregated_info;
+
+
+CREATE FUNCTION api.market_aggregated_info(market integer, "seconds" integer)
+RETURNS TABLE(
+    last_price numeric,
+    price_change_percentage numeric,
+    price_change_nominal numeric,
+    high_price numeric,
+    low_price numeric,
+    base_volume numeric,
+    quote_volume numeric
+)
+AS $$
+WITH fills AS(
+    SELECT
+        *
+    FROM
+        fill_events
+    WHERE
+        market_id = market
+        AND "time" >= CURRENT_TIMESTAMP - '1 second'::interval * seconds
+        AND emit_address = maker_address
+),
+last_fill AS(
+    SELECT
+        *
+    FROM
+        fills
+    ORDER BY
+        txn_version DESC,
+        event_idx DESC
+    LIMIT 1
+),
+first_fill AS(
+    SELECT
+        *
+    FROM
+        fills
+    ORDER BY
+        txn_version ASC,
+        event_idx ASC
+    LIMIT 1
+)
+SELECT
+    last_fill.price,
+    (last_fill.price - first_fill.price) / first_fill.price * 100,
+    last_fill.price - first_fill.price,
+    MAX(fills.price),
+    MIN(fills.price),
+    SUM(fills.size),
+    SUM(fills.size * fills.price)
+FROM
+    last_fill,
+    first_fill,
+    fills
+GROUP BY
+    last_fill.price,
+    first_fill.price
+$$
+LANGUAGE SQL
+IMMUTABLE;


### PR DESCRIPTION
Fix fields that were in the wrong order and resulted into min and max price being swapped.
