### PR TITLE
[ECO-829] Include pagination in view function helpers

### DIFF
--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "econia-sdk"
-version = "1.0.6"
+version = "1.0.7"
 description = ""
 authors = ["Econia Labs <developers@econialabs.com>"]
 readme = "README.md"


### PR DESCRIPTION
We've added pagination to "get open orders" and "get price levels" so we need to include these functions in the SDK view helpers. I've also included a helper to get a fixed number of orders/price levels that uses the pagination feature. This is a step away from what we've been doing which is to only provide wrappers for the functions and nothing else. However, it's tricky to do the pagination right (have to use the transaction version) so I figured we should just include it as nobody gets hurt.

Validated by calling each paginator in the middle of `trade.py`