### PR TITLE
[ECO-905] Enforce 1 concurrent processor task

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -56,6 +56,7 @@ In the same folder as the template, create a copy of the file named `config.yaml
     See [the Aptos official documentation](https://aptos.dev/indexer/txn-stream/labs-hosted) for other networks.
   - indexer_grpc_http2_ping_interval_in_secs: `60`.
   - indexer_grpc_http2_ping_timeout_in_secs: `10`.
+  - number_concurrent_processing_tasks: `1`.
   - auth_token: the key you got earlier.
   - starting_version: where to start indexing.
     For this walkthrough, use the first transaction of the [Econia testnet account](../../welcome.md#account-addresses) (`649555969`), which is a prudent starting point that slightly precedes the publication of the Econia Move package on testnet.

--- a/src/docker/processor/config-template-global.yaml
+++ b/src/docker/processor/config-template-global.yaml
@@ -7,5 +7,6 @@ server_config:
   indexer_grpc_data_service_address: https://grpc.mainnet.aptoslabs.com:443
   indexer_grpc_http2_ping_interval_in_secs: 60
   indexer_grpc_http2_ping_timeout_in_secs: 10
+  number_concurrent_processing_tasks: 1
   auth_token: aptoslabs_grpc_token_or_token_for_another_grpc_endpoint
   starting_version: 0

--- a/src/docker/processor/config-template-local.yaml
+++ b/src/docker/processor/config-template-local.yaml
@@ -7,5 +7,6 @@ server_config:
   indexer_grpc_data_service_address: http://streamer:50051
   indexer_grpc_http2_ping_interval_in_secs: 60
   indexer_grpc_http2_ping_timeout_in_secs: 10
+  number_concurrent_processing_tasks: 1
   auth_token: dummy_token
   starting_version: 0


### PR DESCRIPTION
Per https://github.com/aptos-labs/aptos-indexer-processors/pull/187, enforce 1 concurrent processor task to uphold total order invariant for Econia events/writesets inserted into db via processor