### PR TITLE
[ECO-915] Allow public Cloud SQL connections

### DIFF
--- a/src/terraform/internal-dss/main.tf
+++ b/src/terraform/internal-dss/main.tf
@@ -114,7 +114,7 @@ resource "google_sql_database_instance" "postgres" {
     }
     ip_configuration {
       authorized_networks {
-        value = var.db_admin_public_ip
+        value = "0.0.0.0/0"
       }
       ipv4_enabled    = true
       private_network = google_compute_network.sql_network.id


### PR DESCRIPTION
Allow public Cloud SQL connections such that for internal development anyone with the Cloud SQL IP address and password can connect