### PR TITLE
[ECO-914] update `/markets` endpoint to include volume, min, and max

### DIFF
--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use aggregator::Pipeline;
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
-use pipelines::{Candlesticks, Leaderboards, UserHistory};
+use pipelines::{Candlesticks, Leaderboards, UpdateMaterializedView, UserHistory};
 use sqlx::Executor;
 use sqlx_postgres::PgPoolOptions;
 use tokio::{sync::Mutex, task::JoinSet};
@@ -36,6 +36,7 @@ struct Args {
 pub enum Pipelines {
     Candlesticks,
     Leaderboards,
+    Market24hData,
     UserHistory,
 }
 
@@ -45,7 +46,12 @@ impl ValueEnum for Pipelines {
     }
 
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Candlesticks, Self::Leaderboards, Self::UserHistory]
+        &[
+            Self::Candlesticks,
+            Self::Leaderboards,
+            Self::Market24hData,
+            Self::UserHistory,
+        ]
     }
 }
 
@@ -96,7 +102,11 @@ async fn main() -> Result<()> {
             .ok_or(anyhow!("No data is included and --no-default is set."))?)
         .clone()
     } else {
-        let mut x = vec![Pipelines::Candlesticks, Pipelines::UserHistory];
+        let mut x = vec![
+            Pipelines::Candlesticks,
+            Pipelines::Market24hData,
+            Pipelines::UserHistory,
+        ];
         let exclude = args.exclude.unwrap_or(vec![]);
         x = x.into_iter().filter(|a| !exclude.contains(a)).collect();
         x.append(&mut args.include.unwrap_or(vec![]));
@@ -138,6 +148,13 @@ async fn main() -> Result<()> {
             }
             Pipelines::Leaderboards => {
                 data.push(Arc::new(Mutex::new(Leaderboards::new(pool.clone()))));
+            }
+            Pipelines::Market24hData => {
+                data.push(Arc::new(Mutex::new(UpdateMaterializedView::new(
+                    pool.clone(),
+                    "aggregator.markets_24h_data",
+                    Duration::from_secs(5 * 60),
+                ))))
             }
             Pipelines::UserHistory => {
                 data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use aggregator::Pipeline;
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
-use pipelines::{Candlesticks, Leaderboards, UpdateMaterializedView, UserHistory};
+use pipelines::{Candlesticks, Leaderboards, RefreshMaterializedView, UserHistory};
 use sqlx::Executor;
 use sqlx_postgres::PgPoolOptions;
 use tokio::{sync::Mutex, task::JoinSet};
@@ -150,7 +150,7 @@ async fn main() -> Result<()> {
                 data.push(Arc::new(Mutex::new(Leaderboards::new(pool.clone()))));
             }
             Pipelines::Market24hData => {
-                data.push(Arc::new(Mutex::new(UpdateMaterializedView::new(
+                data.push(Arc::new(Mutex::new(RefreshMaterializedView::new(
                     pool.clone(),
                     "aggregator.markets_24h_data",
                     Duration::from_secs(5 * 60),

--- a/src/rust/aggregator/src/pipelines.rs
+++ b/src/rust/aggregator/src/pipelines.rs
@@ -1,9 +1,11 @@
 pub mod candlesticks;
 pub mod leaderboards;
 pub mod markets;
+pub mod update_materialized_view;
 pub mod user_history;
 
 pub use candlesticks::Candlesticks;
 pub use leaderboards::Leaderboards;
 pub use markets::MarketsRegisteredPerDay;
+pub use update_materialized_view::UpdateMaterializedView;
 pub use user_history::UserHistory;

--- a/src/rust/aggregator/src/pipelines.rs
+++ b/src/rust/aggregator/src/pipelines.rs
@@ -1,11 +1,11 @@
 pub mod candlesticks;
 pub mod leaderboards;
 pub mod markets;
-pub mod update_materialized_view;
+pub mod refresh_materialized_view;
 pub mod user_history;
 
 pub use candlesticks::Candlesticks;
 pub use leaderboards::Leaderboards;
 pub use markets::MarketsRegisteredPerDay;
-pub use update_materialized_view::UpdateMaterializedView;
+pub use refresh_materialized_view::RefreshMaterializedView;
 pub use user_history::UserHistory;

--- a/src/rust/aggregator/src/pipelines/refresh_materialized_view.rs
+++ b/src/rust/aggregator/src/pipelines/refresh_materialized_view.rs
@@ -29,7 +29,7 @@ impl RefreshMaterializedView {
 #[async_trait::async_trait]
 impl Pipeline for RefreshMaterializedView {
     fn model_name(&self) -> String {
-        String::from("UpdateMaterializedView")
+        String::from("RefreshMaterializedView")
     }
 
     fn ready(&self) -> bool {

--- a/src/rust/aggregator/src/pipelines/update_materialized_view.rs
+++ b/src/rust/aggregator/src/pipelines/update_materialized_view.rs
@@ -1,0 +1,66 @@
+use anyhow::anyhow;
+use chrono::{DateTime, Duration, Utc};
+use sqlx::PgPool;
+
+use aggregator::{Pipeline, PipelineAggregationResult, PipelineError};
+
+pub struct UpdateMaterializedView {
+    pool: PgPool,
+    view_name: String,
+    update_interval: std::time::Duration,
+    last_indexed_timestamp: Option<DateTime<Utc>>,
+}
+
+#[allow(dead_code)]
+impl UpdateMaterializedView {
+    pub fn new(
+        pool: PgPool,
+        view_name: impl Into<String>,
+        update_interval: std::time::Duration,
+    ) -> Self {
+        Self {
+            pool,
+            view_name: view_name.into(),
+            update_interval,
+            last_indexed_timestamp: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Pipeline for UpdateMaterializedView {
+    fn model_name(&self) -> String {
+        String::from("UpdateMaterializedView")
+    }
+
+    fn ready(&self) -> bool {
+        self.last_indexed_timestamp.is_none()
+            || self.last_indexed_timestamp.unwrap()
+                + Duration::from_std(self.update_interval).unwrap()
+                < Utc::now()
+    }
+
+    async fn process_and_save_historical_data(&mut self) -> PipelineAggregationResult {
+        self.process_and_save_internal().await
+    }
+
+    fn poll_interval(&self) -> Option<std::time::Duration> {
+        Some(self.update_interval)
+    }
+
+    async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {
+        sqlx::query(
+            format!(
+                r#"
+                REFRESH MATERIALIZED VIEW {};
+            "#,
+                self.view_name
+            )
+            .as_str(),
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| PipelineError::ProcessingError(anyhow!(e)))?;
+        Ok(())
+    }
+}

--- a/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/down.sql
+++ b/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/down.sql
@@ -1,0 +1,83 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.markets;
+
+
+DROP MATERIALIZED VIEW aggregator.markets_24h_data;
+
+
+CREATE VIEW api.markets AS
+    WITH last_fills AS(
+        SELECT
+        DISTINCT ON (market_id)
+            *
+        FROM
+            fill_events
+        WHERE
+            "time" >= CURRENT_TIMESTAMP - '1 day'::interval
+        ORDER BY
+            market_id,
+            txn_version DESC,
+            event_idx DESC
+    ),
+    first_fills AS(
+        SELECT
+        DISTINCT ON (market_id)
+            *
+        FROM
+            fill_events
+        WHERE
+            "time" >= CURRENT_TIMESTAMP - '1 day'::interval
+        ORDER BY
+            market_id,
+            txn_version ASC,
+            event_idx ASC
+    )
+    SELECT
+        m.market_id,
+        m.time AS registration_time,
+        m.base_account_address,
+        m.base_module_name,
+        m.base_struct_name,
+        m.base_name_generic,
+        m.quote_account_address,
+        m.quote_module_name,
+        m.quote_struct_name,
+        m.lot_size,
+        m.tick_size,
+        m.min_size,
+        m.underwriter_id,
+        CASE
+            WHEN r.market_id = m.market_id THEN true
+            ELSE false
+        END AS is_recognized,
+        l.price AS last_fill_price_24hr,
+        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS percent_change_24h
+    FROM
+        market_registration_events AS m
+    LEFT JOIN
+        aggregator.recognized_markets AS r
+    ON
+        COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+    AND
+        COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+    AND
+        COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+    AND
+        COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+    AND
+        r.quote_account_address = m.quote_account_address
+    AND
+        r.quote_module_name = m.quote_module_name
+    AND
+        r.quote_struct_name = m.quote_struct_name
+    LEFT JOIN
+        first_fills AS f
+    ON
+        f.market_id = m.market_id
+    LEFT JOIN
+        last_fills AS l
+    ON
+        l.market_id = m.market_id;
+
+
+GRANT SELECT ON api.markets TO web_anon;

--- a/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/up.sql
@@ -70,8 +70,8 @@ CREATE VIEW api.markets AS
             ELSE false
         END AS is_recognized,
         l.price AS last_fill_price_24hr,
-        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS percent_change_24h,
-        l.price - f.price AS nominal_change_24h,
+        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS price_change_as_percent_24hr,
+        l.price - f.price AS price_change_24hr,
         v.min_price_24h,
         v.max_price_24h,
         v.base_volume_24h,

--- a/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/up.sql
+++ b/src/rust/dbv2/migrations/2023-11-16-103707_market_volume/up.sql
@@ -1,0 +1,111 @@
+-- Your SQL goes here
+CREATE MATERIALIZED VIEW aggregator.markets_24h_data AS
+    WITH fills AS(
+        SELECT
+            *
+        FROM
+            fill_events
+        WHERE
+            "time" >= CURRENT_TIMESTAMP - '1 day'::interval
+            AND emit_address = maker_address
+    )
+    SELECT
+        market_id,
+        MIN(fills.price) AS min_price_24h,
+        MAX(fills.price) AS max_price_24h,
+        SUM(fills.size) AS base_volume_24h,
+        SUM(fills.size * fills.price) AS quote_volume_24h
+    FROM
+        fills
+    GROUP BY
+        market_id;
+
+
+DROP VIEW api.markets;
+
+
+CREATE VIEW api.markets AS
+    WITH last_fills AS(
+        SELECT
+        DISTINCT ON (market_id)
+            *
+        FROM
+            fill_events
+        WHERE
+            "time" >= CURRENT_TIMESTAMP - '1 day'::interval
+        ORDER BY
+            market_id,
+            txn_version DESC,
+            event_idx DESC
+    ),
+    first_fills AS(
+        SELECT
+        DISTINCT ON (market_id)
+            *
+        FROM
+            fill_events
+        WHERE
+            "time" >= CURRENT_TIMESTAMP - '1 day'::interval
+        ORDER BY
+            market_id,
+            txn_version ASC,
+            event_idx ASC
+    )
+    SELECT
+        m.market_id,
+        m.time AS registration_time,
+        m.base_account_address,
+        m.base_module_name,
+        m.base_struct_name,
+        m.base_name_generic,
+        m.quote_account_address,
+        m.quote_module_name,
+        m.quote_struct_name,
+        m.lot_size,
+        m.tick_size,
+        m.min_size,
+        m.underwriter_id,
+        CASE
+            WHEN r.market_id = m.market_id THEN true
+            ELSE false
+        END AS is_recognized,
+        l.price AS last_fill_price_24hr,
+        (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS percent_change_24h,
+        l.price - f.price AS nominal_change_24h,
+        v.min_price_24h,
+        v.max_price_24h,
+        v.base_volume_24h,
+        v.quote_volume_24h
+    FROM
+        market_registration_events AS m
+    LEFT JOIN
+        aggregator.recognized_markets AS r
+    ON
+        COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+    AND
+        COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+    AND
+        COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+    AND
+        COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+    AND
+        r.quote_account_address = m.quote_account_address
+    AND
+        r.quote_module_name = m.quote_module_name
+    AND
+        r.quote_struct_name = m.quote_struct_name
+    LEFT JOIN
+        first_fills AS f
+    ON
+        f.market_id = m.market_id
+    LEFT JOIN
+        last_fills AS l
+    ON
+        l.market_id = m.market_id
+    LEFT JOIN
+        aggregator.markets_24h_data AS v
+    ON
+        v.market_id = m.market_id;
+
+
+GRANT SELECT ON api.markets TO web_anon;


### PR DESCRIPTION
Added a new aggregator pipeline that is named `UpdateMaterializedView`. This updates the given materialized view every given duration. This will allow easly creating views that can be updated at a set interval with minimal aggregator code.

This PR also adds a materialized view for market volume, min fill, and max fill in the last 24 hours.
