### PR TITLE
Revert #621

### DIFF
--- a/src/terraform/internal-dss/main.tf
+++ b/src/terraform/internal-dss/main.tf
@@ -114,7 +114,7 @@ resource "google_sql_database_instance" "postgres" {
     }
     ip_configuration {
       authorized_networks {
-        value = "0.0.0.0/0"
+        value = var.db_admin_public_ip
       }
       ipv4_enabled    = true
       private_network = google_compute_network.sql_network.id


### PR DESCRIPTION
DO NOT expose a database to the public. This is very poor security practice.

Instead, use the Cloud SQL Auth Proxy if you need to connect to a Cloud SQL instance for development.

@alnoki please read the Cloud SQL documentation before proceeding further.
<https://cloud.google.com/sql/docs/postgres/connect-instance-auth-proxy>