### PR TITLE
[ECO-937] Patch max quote traded event case for complete cross-spread limit order taking

### DIFF
--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -2,6 +2,12 @@
 
 Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] standards.
 
+## [v4.2.1]
+
+### Fixed
+
+- Cancel event emission logic for max quote traded case ([#629]).
+
 ## [v4.2.0]
 
 ### Added
@@ -61,8 +67,10 @@ Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] 
 [#504]: https://github.com/econia-labs/econia/pull/504
 [#577]: https://github.com/econia-labs/econia/pull/577
 [#597]: https://github.com/econia-labs/econia/pull/597
+[#629]: https://github.com/econia-labs/econia/pull/629
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [v4.1.0]: https://github.com/econia-labs/econia/compare/v4.0.2-audited...v4.1.0-audited
 [v4.1.1]: https://github.com/econia-labs/econia/compare/v4.1.0-audited...v4.1.1-audited
 [v4.2.0]: https://github.com/econia-labs/econia/compare/v4.1.1-audited...v4.2.0-audited
+[v4.2.1]: https://github.com/econia-labs/econia/compare/v4.2.0-audited...v4.2.1-audited

--- a/doc/doc-site/docs/security.md
+++ b/doc/doc-site/docs/security.md
@@ -1,7 +1,7 @@
 # Security
 
 Econia has been independently audited by three firms, and all [audit reports] are public:
-Move source code is audited through commit [`ea0f02b`] (tag [`v4.2.0-audited`]), via three initial audits and four followup audits.
+Move source code is audited through commit [`bfaf890`] (tag [`v4.2.1-audited`]), via three initial audits and five followup audits.
 
 Moreover, Econia is deployed on Aptos mainnet under a community-governed multisig account in accordance with the [Econia signatory guide].
 
@@ -13,5 +13,5 @@ Anyone who uses the Econia protocol agrees to hold harmless all signatories to t
 
 [audit reports]: https://econia-labs.notion.site/Econia-Audit-Reports-27634e9c7d1249228e2cbc3e705a59c9
 [econia signatory guide]: https://econia-labs.notion.site/Aptos-Multisig-v2-and-Econia-v4-A-Signatory-s-Guide-to-On-Chain-Governance-96da99732f744044af6a3eca88a21fac?pvs=4
-[`ea0f02b`]: https://github.com/econia-labs/econia/commit/ea0f02b2e678449c348d3cc2eabdfa42532b6334
-[`v4.2.0-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.2.0-audited
+[`bfaf890`]: https://github.com/econia-labs/econia/commit/bfaf890011a03b5ff68839bcac98a1d7ada0c6e3
+[`v4.2.1-audited`]: https://github.com/econia-labs/econia/releases/tag/v4.2.1-audited

--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Econia"
-version = "4.2.0"
+version = "4.2.1"
 upgrade_policy = "compatible"
 authors = ["Econia Labs (developers@econialabs.com)"]
 

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2917,7 +2917,7 @@ module econia::market {
     ///
     /// * `Option<u8>`: An optional cancel reason, if the order needs
     ///   to be cancelled.
-    /*inline*/ fun get_cancel_reason_option_for_market_order_or_swap(
+    inline fun get_cancel_reason_option_for_market_order_or_swap(
         self_match_taker_cancel: bool,
         base_traded: u64,
         max_base: u64,

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -3627,9 +3627,11 @@ module econia::market {
     /// * `test_place_limit_order_crosses_ask_exact()`
     /// * `test_place_limit_order_crosses_ask_partial()`
     /// * `test_place_limit_order_crosses_ask_partial_cancel()`
+    /// * `test_place_limit_order_crosses_ask_partial_maker()`
     /// * `test_place_limit_order_crosses_ask_self_match_cancel()`
     /// * `test_place_limit_order_crosses_bid_exact()`
     /// * `test_place_limit_order_crosses_bid_partial()`
+    /// * `test_place_limit_order_crosses_bid_partial_maker()`
     /// * `test_place_limit_order_crosses_bid_partial_post_under_min()`
     /// * `test_place_limit_order_evict()`
     /// * `test_place_limit_order_no_cross_ask_user()`
@@ -3812,15 +3814,6 @@ module econia::market {
             user::deposit_assets_internal<BaseType, QuoteType>(
                 user_address, market_id, custodian_id, base_deposit,
                 optional_base_coins, quote_coins, underwriter_id);
-            // Order still crosses spread if an ask and would trail
-            // behind bids AVL queue head, or if a bid and would trail
-            // behind asks AVL queue head: can happen if an ask (taker
-            // sell) and quote ceiling reached, or if a bid (taker buy)
-            // and all available quote spent.
-            let still_crosses_spread = if (side == ASK)
-                !avl_queue::would_update_head(&order_book_ref_mut.bids, price)
-                else
-                !avl_queue::would_update_head(&order_book_ref_mut.asks, price);
             // Remaining size is amount not traded during matching.
             remaining_size =
                 size - (base_traded / order_book_ref_mut.lot_size);
@@ -3828,13 +3821,27 @@ module econia::market {
             if (self_match_cancel) {
                 option::fill(&mut cancel_reason_option,
                              CANCEL_REASON_SELF_MATCH_TAKER);
-            } else if ((remaining_size > 0) &&
-                       (restriction == IMMEDIATE_OR_CANCEL)) {
-                option::fill(&mut cancel_reason_option,
-                             CANCEL_REASON_IMMEDIATE_OR_CANCEL);
-            } else if (still_crosses_spread) {
-                option::fill(&mut cancel_reason_option,
-                             CANCEL_REASON_MAX_QUOTE_TRADED);
+            } else if (remaining_size > 0) {
+                if (restriction == IMMEDIATE_OR_CANCEL) {
+                    option::fill(&mut cancel_reason_option,
+                                 CANCEL_REASON_IMMEDIATE_OR_CANCEL);
+                } else {
+                    // Order still crosses spread if an ask and would
+                    // trail behind bids AVL queue head, or if a bid and
+                    // would trail behind asks AVL queue head: can
+                    // happen if an ask (taker sell) and quote ceiling
+                    // reached, or if a bid (taker buy) and all
+                    // available quote spent.
+                    let still_crosses_spread = if (side == ASK)
+                        !avl_queue::would_update_head(
+                            &order_book_ref_mut.bids, price) else
+                        !avl_queue::would_update_head(
+                            &order_book_ref_mut.asks, price);
+                    if (still_crosses_spread) {
+                        option::fill(&mut cancel_reason_option,
+                                     CANCEL_REASON_MAX_QUOTE_TRADED);
+                    }
+                }
             };
         } else { // If spread not crossed (matching engine not called):
             // Order book counter needs to be updated for new order ID.
@@ -10424,6 +10431,185 @@ module econia::market {
     }
 
     #[test]
+    /// Verify state updates, returns, for placing taker ask that fills
+    /// completely across the spread with a partial maker match, under
+    /// authority of signing user. Based on
+    /// `test_place_limit_order_crosses_ask_exact()`.
+    fun test_place_limit_order_crosses_ask_partial_maker()
+    acquires OrderBooks {
+        // Initialize markets, users, and an integrator.
+        let (user_0, user_1) = init_markets_users_integrator_test();
+        // Get fee divisors.
+        let (taker_divisor, integrator_divisor) =
+            (incentives::get_taker_fee_divisor(),
+             incentives::get_fee_share_divisor(INTEGRATOR_TIER));
+        // Declare order parameters from taker's perspective, with
+        // price set to product of divisors to prevent truncation
+        // effects on estimates.
+        let side                = ASK; // Taker sell.
+        let size                = MIN_SIZE_COIN;
+        let size_maker          = size + 1;
+        let base                = size * LOT_SIZE_COIN;
+        let base_maker          = size_maker * LOT_SIZE_COIN;
+        let price               = integrator_divisor * taker_divisor;
+        let quote               = size * price * TICK_SIZE_COIN;
+        let quote_maker         = size_maker * price * TICK_SIZE_COIN;
+        let integrator_share    = quote / integrator_divisor;
+        let econia_share        = quote / taker_divisor - integrator_share;
+        let fee                 = integrator_share + econia_share;
+        let quote_trade         = quote - fee;
+        let restriction         = FILL_OR_ABORT;
+        let self_match_behavior = ABORT;
+        // Deposit to user's accounts asset amounts that fill them just
+        // up to max or down to min after the trade, for user 0 holding
+        // maker order.
+        user::deposit_coins<BC>(@user_0, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(HI_64 - base_maker));
+        user::deposit_coins<QC>(@user_0, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(quote_maker));
+        user::deposit_coins<BC>(@user_1, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(base));
+        user::deposit_coins<QC>(@user_1, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(HI_64 - quote_trade));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        // Place maker order.
+        let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
+            &user_0, MARKET_ID_COIN, @integrator, !side, size_maker, price,
+            POST_OR_ABORT, self_match_behavior);
+        // Get user-side order access key for later.
+        let (_, _, _, _, order_access_key_0) = get_order_fields_test(
+            MARKET_ID_COIN, !side, market_order_id_0);
+        assert!(is_list_node_order_active( // Assert order is active.
+            MARKET_ID_COIN, !side, market_order_id_0), 0);
+        // Place taker order.
+        let (market_order_id_1, base_trade_r, quote_trade_r, fee_r) =
+            place_limit_order_user<BC, QC>(
+                &user_1, MARKET_ID_COIN, @integrator, side, size, price,
+                restriction, self_match_behavior);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    !side,
+                    size_maker,
+                    price,
+                    POST_OR_ABORT,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_1,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side,
+                    size,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    0,
+                    market_order_id_1
+                )
+            ], 0);
+        let fill_event = user::create_fill_event_internal(
+            MARKET_ID_COIN,
+            size,
+            price,
+            !side,
+            @user_0,
+            NO_CUSTODIAN,
+            market_order_id_0,
+            @user_1,
+            NO_CUSTODIAN,
+            market_order_id_1,
+            fee_r,
+            0
+        );
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[fill_event], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[fill_event], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        // Assert returns.
+        assert!(market_order_id_1 == order_id_no_post(2), 0);
+        assert!(base_trade_r      == base, 0);
+        assert!(quote_trade_r     == quote_trade, 0);
+        assert!(fee_r             == fee, 0);
+        // Assert order is active on the order book.
+        assert!(is_list_node_order_active(
+            MARKET_ID_COIN, !side, market_order_id_0), 0);
+        // Assert user-side order fields for partially-filled maker
+        // order.
+        let (market_order_id_r, size_r) = user::get_order_fields_simple_test(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN, !side, order_access_key_0);
+        // No market order ID.
+        assert!(market_order_id_r == market_order_id_0, 0);
+        assert!(size_r == size_maker - size, 0);
+        // Assert maker's asset counts.
+        let (base_total , base_available , base_ceiling,
+             quote_total, quote_available, quote_ceiling) =
+            user::get_asset_counts_internal(
+                @user_0, MARKET_ID_COIN, NO_CUSTODIAN);
+        assert!(base_total      == HI_64 - base_maker + base, 0);
+        assert!(base_available  == HI_64 - base_maker + base, 0);
+        assert!(base_ceiling    == HI_64, 0);
+        assert!(quote_total     == quote_maker - quote, 0);
+        assert!(quote_available == 0, 0);
+        assert!(quote_ceiling   == quote_maker - quote, 0);
+        // Assert collateral amounts.
+        assert!(user::get_collateral_value_simple_test<BC>(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN) ==
+            HI_64 - base_maker + base, 0);
+        assert!(user::get_collateral_value_simple_test<QC>(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN) == quote_maker - quote, 0);
+        // Assert takers's asset counts.
+        let (base_total , base_available , base_ceiling,
+             quote_total, quote_available, quote_ceiling) =
+            user::get_asset_counts_internal(
+                @user_1, MARKET_ID_COIN, NO_CUSTODIAN);
+        assert!(base_total      == 0, 0);
+        assert!(base_available  == 0, 0);
+        assert!(base_ceiling    == 0, 0);
+        assert!(quote_total     == HI_64, 0);
+        assert!(quote_available == HI_64, 0);
+        assert!(quote_ceiling   == HI_64, 0);
+        // Assert collateral amounts.
+        assert!(user::get_collateral_value_simple_test<BC>(
+            @user_1, MARKET_ID_COIN, NO_CUSTODIAN) == 0, 0);
+        assert!(user::get_collateral_value_simple_test<QC>(
+            @user_1, MARKET_ID_COIN, NO_CUSTODIAN) == HI_64, 0);
+        // Assert integrator fee share.
+        assert!(incentives::get_integrator_fee_store_balance_test<QC>(
+            @integrator, MARKET_ID_COIN) == integrator_share, 0);
+        // Assert Econia fee share.
+        assert!(incentives::get_econia_fee_store_balance_test<QC>(
+            MARKET_ID_COIN) == econia_share, 0);
+    }
+
+    #[test]
     /// Verify state updates, returns for placing ask that self matches
     /// with taker cancellation. Based on
     /// `test_place_limit_order_crosses_ask_partial()`.
@@ -10900,6 +11086,185 @@ module econia::market {
             @user_1, MARKET_ID_COIN, NO_CUSTODIAN, side, order_access_key);
         assert!(market_order_id_r == market_order_id_1, 0);
         assert!(size_r == size_post, 0);
+    }
+
+    #[test]
+    /// Verify state updates, returns, for placing taker bid that fills
+    /// completely across the spread with a partial maker match, under
+    /// authority of signing user. Based on
+    /// `test_place_limit_order_crosses_bid_exact()`.
+    fun test_place_limit_order_crosses_bid_partial_maker()
+    acquires OrderBooks {
+        // Initialize markets, users, and an integrator.
+        let (user_0, user_1) = init_markets_users_integrator_test();
+        // Get fee divisors.
+        let (taker_divisor, integrator_divisor) =
+            (incentives::get_taker_fee_divisor(),
+             incentives::get_fee_share_divisor(INTEGRATOR_TIER));
+        // Declare order parameters from taker's perspective, with
+        // price set to product of divisors to prevent truncation
+        // effects on estimates.
+        let side                = BID; // Taker buy.
+        let size                = MIN_SIZE_COIN;
+        let size_maker          = size + 1;
+        let base                = size * LOT_SIZE_COIN;
+        let base_maker          = size_maker * LOT_SIZE_COIN;
+        let price               = integrator_divisor * taker_divisor;
+        let quote               = size * price * TICK_SIZE_COIN;
+        let quote_maker         = size_maker * price * TICK_SIZE_COIN;
+        let integrator_share    = quote / integrator_divisor;
+        let econia_share        = quote / taker_divisor - integrator_share;
+        let fee                 = integrator_share + econia_share;
+        let quote_trade         = quote + fee;
+        let restriction         = NO_RESTRICTION;
+        let self_match_behavior = ABORT;
+        // Deposit to user's accounts asset amounts that fill them just
+        // up to max or down to min after the trade, for user 0 holding
+        // maker order.
+        user::deposit_coins<BC>(@user_0, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(base_maker));
+        user::deposit_coins<QC>(@user_0, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(HI_64 - quote_maker));
+        user::deposit_coins<BC>(@user_1, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(HI_64 - base));
+        user::deposit_coins<QC>(@user_1, MARKET_ID_COIN, NO_CUSTODIAN,
+                                assets::mint_test(quote_trade));
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        // Place maker order.
+        let (market_order_id_0, _, _, _) = place_limit_order_user<BC, QC>(
+            &user_0, MARKET_ID_COIN, @integrator, !side, size_maker, price,
+            restriction, self_match_behavior);
+        // Get user-side order access key for later.
+        let (_, _, _, _, order_access_key_0) = get_order_fields_test(
+            MARKET_ID_COIN, !side, market_order_id_0);
+        assert!(is_list_node_order_active( // Assert order is active.
+            MARKET_ID_COIN, !side, market_order_id_0), 0);
+        // Place taker order.
+        let (market_order_id_1, base_trade_r, quote_trade_r, fee_r) =
+            place_limit_order_user<BC, QC>(
+                &user_1, MARKET_ID_COIN, @integrator, side, size, price,
+                restriction, self_match_behavior);
+        // Assert events.
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_0,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    !side,
+                    size_maker,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    size_maker,
+                    market_order_id_0
+                )
+            ], 0);
+        assert!(user::get_place_limit_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[
+                user::create_place_limit_order_event_test(
+                    MARKET_ID_COIN,
+                    @user_1,
+                    NO_CUSTODIAN,
+                    @integrator,
+                    side,
+                    size,
+                    price,
+                    restriction,
+                    self_match_behavior,
+                    0,
+                    market_order_id_1
+                )
+            ], 0);
+        let fill_event = user::create_fill_event_internal(
+            MARKET_ID_COIN,
+            size,
+            price,
+            !side,
+            @user_0,
+            NO_CUSTODIAN,
+            market_order_id_0,
+            @user_1,
+            NO_CUSTODIAN,
+            market_order_id_1,
+            fee_r,
+            0
+        );
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[fill_event], 0);
+        assert!(user::get_fill_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[fill_event], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_0, NO_CUSTODIAN) == vector[], 0);
+        assert!(user::get_cancel_order_events_test(
+            MARKET_ID_COIN, @user_1, NO_CUSTODIAN) == vector[], 0);
+        // Assert returns.
+        assert!(market_order_id_1 == order_id_no_post(2), 0);
+        assert!(base_trade_r      == base, 0);
+        assert!(quote_trade_r     == quote_trade, 0);
+        assert!(fee_r             == fee, 0);
+        // Assert order is active on the order book.
+        assert!(is_list_node_order_active(
+            MARKET_ID_COIN, !side, market_order_id_0), 0);
+        // Assert user-side order fields for partially-filled maker
+        // order.
+        let (market_order_id_r, size_r) = user::get_order_fields_simple_test(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN, !side, order_access_key_0);
+        // No market order ID.
+        assert!(market_order_id_r == market_order_id_0, 0);
+        assert!(size_r == size_maker - size, 0);
+        // Assert maker's asset counts.
+        let (base_total , base_available , base_ceiling,
+             quote_total, quote_available, quote_ceiling) =
+            user::get_asset_counts_internal(
+                @user_0, MARKET_ID_COIN, NO_CUSTODIAN);
+        assert!(base_total      == base_maker - base, 0);
+        assert!(base_available  == 0, 0);
+        assert!(base_ceiling    == base_maker - base, 0);
+        assert!(quote_total     == HI_64 - quote_maker + quote, 0);
+        assert!(quote_available == HI_64 - quote_maker + quote, 0);
+        assert!(quote_ceiling   == HI_64, 0);
+        // Assert collateral amounts.
+        assert!(user::get_collateral_value_simple_test<BC>(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN) == base_maker - base, 0);
+        assert!(user::get_collateral_value_simple_test<QC>(
+            @user_0, MARKET_ID_COIN, NO_CUSTODIAN) ==
+            HI_64 - quote_maker + quote, 0);
+        // Assert takers's asset counts.
+        let (base_total , base_available , base_ceiling,
+             quote_total, quote_available, quote_ceiling) =
+            user::get_asset_counts_internal(
+                @user_1, MARKET_ID_COIN, NO_CUSTODIAN);
+        assert!(base_total      == HI_64, 0);
+        assert!(base_available  == HI_64, 0);
+        assert!(base_ceiling    == HI_64, 0);
+        assert!(quote_total     == 0, 0);
+        assert!(quote_available == 0, 0);
+        assert!(quote_ceiling   == 0, 0);
+        // Assert collateral amounts.
+        assert!(user::get_collateral_value_simple_test<BC>(
+            @user_1, MARKET_ID_COIN, NO_CUSTODIAN) == HI_64, 0);
+        assert!(user::get_collateral_value_simple_test<QC>(
+            @user_1, MARKET_ID_COIN, NO_CUSTODIAN) == 0, 0);
+        // Assert integrator fee share.
+        assert!(incentives::get_integrator_fee_store_balance_test<QC>(
+            @integrator, MARKET_ID_COIN) == integrator_share, 0);
+        // Assert Econia fee share.
+        assert!(incentives::get_econia_fee_store_balance_test<QC>(
+            MARKET_ID_COIN) == econia_share, 0);
     }
 
     #[test]

--- a/src/move/econia/sources/market.move
+++ b/src/move/econia/sources/market.move
@@ -2917,7 +2917,7 @@ module econia::market {
     ///
     /// * `Option<u8>`: An optional cancel reason, if the order needs
     ///   to be cancelled.
-    inline fun get_cancel_reason_option_for_market_order_or_swap(
+    /*inline*/ fun get_cancel_reason_option_for_market_order_or_swap(
         self_match_taker_cancel: bool,
         base_traded: u64,
         max_base: u64,

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -2864,7 +2864,7 @@ module econia::user {
     /// Emit a `FillEvent` for the market account of the maker
     /// associated with a fill, if market event handles exist for the
     /// indicated market account.
-    /*inline*/ fun emit_maker_fill_event(
+    inline fun emit_maker_fill_event(
         event_ref: &FillEvent
     ) acquires MarketEventHandles {
         let maker = event_ref.maker;

--- a/src/move/econia/sources/user.move
+++ b/src/move/econia/sources/user.move
@@ -2864,7 +2864,7 @@ module econia::user {
     /// Emit a `FillEvent` for the market account of the maker
     /// associated with a fill, if market event handles exist for the
     /// indicated market account.
-    inline fun emit_maker_fill_event(
+    /*inline*/ fun emit_maker_fill_event(
         event_ref: &FillEvent
     ) acquires MarketEventHandles {
         let maker = event_ref.maker;


### PR DESCRIPTION
# Auxiliary functionality discussion

The changes in his PR only affect auxiliary event emission logic. They do not modify core settlement/accounting/etc. logic.

# Issue

Without this PR, if a limit order fills completely across the spread but there is still liquidity on the book after matching, a cancel event may be emitted with `CANCEL_REASON_MAX_QUOTE_TRADED`, since the check for `still_crosses_spread` is performed regardless of remaining size.

# Changes

* After optional cross-spread matching for a limit order, only check for `still_crosses_spread` if `remaining_size > 0`
* Add tests validating that no such cancel event is emitted for applicable cases on both sides 
* Bump changelog and `Move.toml` to `v4.2.1`
* Rebuild Move docs
* Update security docs page per new audit

# Testing

Tested to 100% coverage per 172bf51 and bfaf890