### PR TITLE
[ECO-954] do not error out if transaction fails with specific message

### DIFF
--- a/src/rust/aggregator/src/pipelines/user_history.rs
+++ b/src/rust/aggregator/src/pipelines/user_history.rs
@@ -192,7 +192,7 @@ impl Pipeline for UserHistory {
             .or_else(|e| match &e {
                 Error::Database(dbe) => {
                     if dbe.message() == "could not serialize access due to read/write dependencies among transactions" {
-                        warn!("transaction error, gracefully ignoring");
+                        warn!("transaction serialization error, gracefully ignoring, will retry next loop");
                         Ok(())
                     } else {
                         Err(PipelineError::ProcessingError(anyhow!(e)))

--- a/src/rust/aggregator/src/pipelines/user_history.rs
+++ b/src/rust/aggregator/src/pipelines/user_history.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 use sqlx::{Executor, PgConnection, PgPool, Postgres, Transaction, Error};
 
 use aggregator::{Pipeline, PipelineAggregationResult, PipelineError};
+use tracing::warn;
 
 /// Number of bits to shift when encoding transaction version.
 const SHIFT_TXN_VERSION: u8 = 64;
@@ -191,6 +192,7 @@ impl Pipeline for UserHistory {
             .or_else(|e| match &e {
                 Error::Database(dbe) => {
                     if dbe.message() == "could not serialize access due to read/write dependencies among transactions" {
+                        warn!("transaction error, gracefully ignoring");
                         Ok(())
                     } else {
                         Err(PipelineError::ProcessingError(anyhow!(e)))

--- a/src/rust/aggregator/src/pipelines/user_history.rs
+++ b/src/rust/aggregator/src/pipelines/user_history.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use bigdecimal::{num_bigint::ToBigInt, BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
-use sqlx::{Executor, PgConnection, PgPool, Postgres, Transaction, Error};
+use sqlx::{Error, Executor, PgConnection, PgPool, Postgres, Transaction};
 
 use aggregator::{Pipeline, PipelineAggregationResult, PipelineError};
 use tracing::warn;


### PR DESCRIPTION
An edge case could happen where a transaction would fail with a message that says that the transaction might succeed if it is tried again. This PR changes the code so that error is gracefully ignored, and the aggregator doesn't stop.
