### PR TITLE
[ECO-953] wait for diesel to finish before starting aggregator and processor

### DIFF
--- a/src/docker/aggregator/Dockerfile
+++ b/src/docker/aggregator/Dockerfile
@@ -41,5 +41,4 @@ COPY --from=builder $BIN_PATH $APP_DIR/
 ENV APTOS_NETWORK=$APTOS_NETWORK
 ENV DATABASE_URL=$DATABASE_URL
 
-# Delay start to avoid migrations race condition
 ENTRYPOINT /app/aggregator

--- a/src/docker/aggregator/Dockerfile
+++ b/src/docker/aggregator/Dockerfile
@@ -42,4 +42,4 @@ ENV APTOS_NETWORK=$APTOS_NETWORK
 ENV DATABASE_URL=$DATABASE_URL
 
 # Delay start to avoid migrations race condition
-ENTRYPOINT sleep 5 && /app/aggregator
+ENTRYPOINT /app/aggregator

--- a/src/docker/compose.dss-core.yaml
+++ b/src/docker/compose.dss-core.yaml
@@ -11,8 +11,10 @@ services:
       context: ../../
       dockerfile: src/docker/aggregator/Dockerfile
     depends_on:
-      - diesel
-      - postgres
+      diesel:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     environment:
       APTOS_NETWORK: ${APTOS_NETWORK}
       DATABASE_URL: "postgres://econia:econia@postgres:5432/econia"
@@ -36,8 +38,10 @@ services:
       args:
         - POSTGRES_WEBSOCKETS_VERSION=0.11.1.0
     depends_on:
-      - diesel
-      - postgres
+      diesel:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     environment:
       - PGWS_DB_URI=postgres://econia:econia@postgres/econia
       # This has to be at least 32 characters long.

--- a/src/docker/compose.dss-global.yaml
+++ b/src/docker/compose.dss-global.yaml
@@ -5,6 +5,9 @@ include:
 
 services:
     processsor:
+      depends_on:
+        diesel:
+          condition: service_completed_successfully
       environment:
         - HEALTHCHECK_BEFORE_START=false
       extends:

--- a/src/docker/compose.dss-local.yaml
+++ b/src/docker/compose.dss-local.yaml
@@ -16,7 +16,10 @@ services:
 
   processor:
     depends_on:
-      - streamer
+      streamer:
+        condition: service_started
+      diesel:
+        condition: service_completed_successfully
     environment:
       - HEALTHCHECK_BEFORE_START=true
     extends:


### PR DESCRIPTION
Update the docker dependencies so that the aggregator and processor do not start before diesel finishes executing.
