### PR TITLE
[ECO-1005] Add healthcheck endpoint

### DIFF
--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
@@ -1,1 +1,2 @@
 -- This file should undo anything in `up.sql`
+DROP FUNCTION api.healthcheck;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/down.sql
@@ -1,2 +1,14 @@
 -- This file should undo anything in `up.sql`
-DROP FUNCTION api.healthcheck;
+DROP FUNCTION api.data_is_consistent;
+
+
+DROP VIEW
+  api.user_history_last_indexed_txn;
+
+
+DROP VIEW
+  api.candlesticks_last_indexed_txn;
+
+
+DROP VIEW
+  api.data_status;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -65,7 +65,7 @@ RETURNS boolean AS $$
             AND maker_address = emit_address
             GROUP BY volume, last_candlesticks.market_id, resolution
         ) AS lool
-    ), true) AS is_data_coherent;
+    ), true) AS is_data_consistent;
 $$ LANGUAGE SQL;
 
 

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -32,12 +32,13 @@ RETURNS boolean AS $$
             SELECT SUM(total_filled)
             FROM api.orders
         ) = (
-            SELECT SUM(size)
+            SELECT SUM(size)*2
             FROM fill_events
             WHERE txn_version <= (
                 SELECT txn_version
                 FROM api.user_history_last_indexed_txn
             )
+            AND emit_address = maker_address
         ), true)
     ) AND COALESCE((
         WITH last_candlesticks AS (

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -74,7 +74,7 @@ SELECT
     CURRENT_TIMESTAMP AS current_time,
     processor_status.last_success_version AS processor_last_txn_version_processed,
     user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
-    array_agg((resolution, candlesticks_last_indexed_txn.txn_version)) AS aggregator_candlesticks_last_txn_version_processed
+    array_agg(ARRAY[resolution, candlesticks_last_indexed_txn.txn_version]) AS aggregator_candlesticks_last_txn_version_processed
 FROM
     processor_status,
     aggregator.user_history_last_indexed_txn,

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -2,7 +2,7 @@
 CREATE or replace FUNCTION api.healthcheck ()
 RETURNS boolean AS $$
     SELECT (
-        SELECT (
+        SELECT COALESCE((
             SELECT SUM(total_filled)
             FROM api.orders
         ) = (
@@ -12,8 +12,8 @@ RETURNS boolean AS $$
                 SELECT txn_version
                 FROM aggregator.user_history_last_indexed_txn
             )
-        )
-    ) AND (
+        ), true)
+    ) AND COALESCE((
         WITH last_candlesticks AS (
             SELECT DISTINCT ON (market_id, resolution)
                 volume,
@@ -38,5 +38,5 @@ RETURNS boolean AS $$
             AND "time" < start_time + '1 second'::interval * resolution
             GROUP BY volume, last_candlesticks.market_id, resolution
         ) AS lool
-    );
+    ), true);
 $$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -52,7 +52,7 @@ RETURNS boolean AS $$
         SELECT
             SUM(CASE WHEN ok THEN 0 ELSE 1 END) = 0
         FROM (
-            SELECT SUM(size*price)/2 = volume AS ok
+            SELECT SUM(size*price) = volume AS ok
             FROM fill_events, last_candlesticks
             WHERE txn_version <= (
                 SELECT txn_version
@@ -62,6 +62,7 @@ RETURNS boolean AS $$
             AND fill_events.market_id = last_candlesticks.market_id
             AND "time" >= start_time
             AND "time" < start_time + '1 second'::interval * resolution
+            AND maker_address = emit_address
             GROUP BY volume, last_candlesticks.market_id, resolution
         ) AS lool
     ), true) AS is_data_coherent;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -24,14 +24,6 @@ GRANT
 SELECT
   ON api.candlesticks_last_indexed_txn TO web_anon;
 
-CREATE VIEW api.data_status AS
-SELECT
-    CURRENT_TIMESTAMP AS current_time,
-    processor_status.last_success_version AS processor_last_txn_version_processed,
-    user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
-    array_agg((resolution, candlesticks_last_indexed_txn.txn_version)) AS aggregator_candlesticks_last_txn_version_processed,
-    api.data_is_consistent() AS aggregator_data_passes_simple_consistency_check
-FROM 
 
 CREATE FUNCTION api.data_is_consistent ()
 RETURNS boolean AS $$

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -24,7 +24,16 @@ GRANT
 SELECT
   ON api.candlesticks_last_indexed_txn TO web_anon;
 
-CREATE FUNCTION api.healthcheck ()
+CREATE VIEW api.data_status AS
+SELECT
+    CURRENT_TIMESTAMP AS current_time,
+    processor_status.last_success_version AS processor_last_txn_version_processed,
+    user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
+    array_agg((resolution, candlesticks_last_indexed_txn.txn_version)) AS aggregator_candlesticks_last_txn_version_processed,
+    api.data_is_consistent() AS aggregator_data_passes_simple_consistency_check
+FROM 
+
+CREATE FUNCTION api.data_is_consistent ()
 RETURNS boolean AS $$
     SELECT (
         SELECT COALESCE((
@@ -65,3 +74,25 @@ RETURNS boolean AS $$
         ) AS lool
     ), true) AS is_data_coherent;
 $$ LANGUAGE SQL;
+
+
+CREATE VIEW api.data_status AS
+SELECT
+    CURRENT_TIMESTAMP AS current_time,
+    processor_status.last_success_version AS processor_last_txn_version_processed,
+    user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
+    array_agg((resolution, candlesticks_last_indexed_txn.txn_version)) AS aggregator_candlesticks_last_txn_version_processed
+FROM
+    processor_status,
+    aggregator.user_history_last_indexed_txn,
+    aggregator.candlesticks_last_indexed_txn
+WHERE
+    processor_status.processor = 'econia_processor'
+GROUP BY
+    user_history_last_indexed_txn.txn_version,
+    processor_status.last_success_version;
+
+
+GRANT
+SELECT
+  ON api.data_status TO web_anon;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -1,0 +1,42 @@
+-- Your SQL goes here
+CREATE or replace FUNCTION api.healthcheck ()
+RETURNS boolean AS $$
+    SELECT (
+        SELECT (
+            SELECT SUM(total_filled)
+            FROM api.orders
+        ) = (
+            SELECT SUM(size)
+            FROM fill_events
+            WHERE txn_version <= (
+                SELECT txn_version
+                FROM aggregator.user_history_last_indexed_txn
+            )
+        )
+    ) AND (
+        WITH last_candlesticks AS (
+            SELECT DISTINCT ON (market_id, resolution)
+                volume,
+                start_time,
+                resolution,
+                market_id
+            FROM api.candlesticks
+            ORDER BY market_id, resolution, start_time DESC
+        )
+        SELECT
+            SUM(CASE WHEN ok THEN 0 ELSE 1 END) = 0
+        FROM (
+            SELECT SUM(size*price)/2 = volume AS ok
+            FROM fill_events, last_candlesticks
+            WHERE txn_version <= (
+                SELECT txn_version
+                FROM aggregator.candlesticks_last_indexed_txn AS i
+                WHERE i.resolution = last_candlesticks.resolution
+            )
+            AND fill_events.market_id = last_candlesticks.market_id
+            AND "time" >= start_time
+            AND "time" < start_time + '1 second'::interval * resolution
+            GROUP BY volume, last_candlesticks.market_id, resolution
+        ) AS lool
+    );
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -1,5 +1,5 @@
 -- Your SQL goes here
-CREATE or replace FUNCTION api.healthcheck ()
+CREATE FUNCTION api.healthcheck ()
 RETURNS boolean AS $$
     SELECT (
         SELECT COALESCE((

--- a/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-01-180017_healthcheck/up.sql
@@ -65,8 +65,8 @@ RETURNS boolean AS $$
             AND "time" < start_time + '1 second'::interval * resolution
             AND maker_address = emit_address
             GROUP BY volume, last_candlesticks.market_id, resolution
-        ) AS lool
-    ), true) AS is_data_consistent;
+        ) AS are_candlesticks_ok
+    ), true) AS data_is_consistent;
 $$ LANGUAGE SQL;
 
 


### PR DESCRIPTION
This PR adds the `/rpc/healthcheck` endpoint which helps check that the data in the database is coherent.

To do this, `aggregator.user_history_last_indexed_txn` had to be exposed, and for consistency, `aggregator.candlesticks_last_indexed_txn` was exposed as well. They can respectively be queried at /user_history_last_indexed_txn` and `/candlesticks_last_indexed_txn`.

## Example

```http
GET /rpc/data_is_consistent
```

```json
true
```

```http
GET /data_status
```

```json
[
  {
    "current_time": "2023-12-15T19:29:33.023216+00:00",
    "processor_last_txn_version_processed": 355183999,
    "aggregator_user_history_last_txn_version_processed": 355183938,
    "aggregator_candlesticks_last_txn_version_processed": [
      [
        60,
        355183192
      ],
      [
        900,
        355183192
      ],
      [
        1800,
        355183192
      ],
      [
        14400,
        355183192
      ],
      [
        86400,
        355183192
      ],
      [
        3600,
        355183192
      ],
      [
        43200,
        355183192
      ],
      [
        300,
        355183192
      ]
    ]
  }
]
```