### PR TITLE
[ECO-1084] add automatic schema reloading

### DIFF
--- a/src/rust/dbv2/migrations/2023-12-20-202439_automatic_schema_reloading/down.sql
+++ b/src/rust/dbv2/migrations/2023-12-20-202439_automatic_schema_reloading/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+DROP EVENT TRIGGER pgrst_ddl_watch;
+
+DROP EVENT TRIGGER pgrst_drop_watch;
+
+DROP FUNCTION pgrst_ddl_watch;
+
+DROP FUNCTION pgrst_drop_watch;

--- a/src/rust/dbv2/migrations/2023-12-20-202439_automatic_schema_reloading/up.sql
+++ b/src/rust/dbv2/migrations/2023-12-20-202439_automatic_schema_reloading/up.sql
@@ -1,0 +1,63 @@
+-- Your SQL goes here
+
+-- Copied over from https://postgrest.org/en/stable/references/schema_cache.html?highlight=schema%20cache#finer-grained-event-trigger
+
+-- watch CREATE and ALTER
+CREATE OR REPLACE FUNCTION pgrst_ddl_watch() RETURNS event_trigger AS $$
+DECLARE
+  cmd record;
+BEGIN
+  FOR cmd IN SELECT * FROM pg_event_trigger_ddl_commands()
+  LOOP
+    IF cmd.command_tag IN (
+      'CREATE SCHEMA', 'ALTER SCHEMA'
+    , 'CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO', 'ALTER TABLE'
+    , 'CREATE FOREIGN TABLE', 'ALTER FOREIGN TABLE'
+    , 'CREATE VIEW', 'ALTER VIEW'
+    , 'CREATE MATERIALIZED VIEW', 'ALTER MATERIALIZED VIEW'
+    , 'CREATE FUNCTION', 'ALTER FUNCTION'
+    , 'CREATE TRIGGER'
+    , 'CREATE TYPE', 'ALTER TYPE'
+    , 'CREATE RULE'
+    , 'COMMENT'
+    )
+    -- don't notify in case of CREATE TEMP table or other objects created on pg_temp
+    AND cmd.schema_name is distinct from 'pg_temp'
+    THEN
+      NOTIFY pgrst, 'reload schema';
+    END IF;
+  END LOOP;
+END; $$ LANGUAGE plpgsql;
+
+-- watch DROP
+CREATE OR REPLACE FUNCTION pgrst_drop_watch() RETURNS event_trigger AS $$
+DECLARE
+  obj record;
+BEGIN
+  FOR obj IN SELECT * FROM pg_event_trigger_dropped_objects()
+  LOOP
+    IF obj.object_type IN (
+      'schema'
+    , 'table'
+    , 'foreign table'
+    , 'view'
+    , 'materialized view'
+    , 'function'
+    , 'trigger'
+    , 'type'
+    , 'rule'
+    )
+    AND obj.is_temporary IS false -- no pg_temp objects
+    THEN
+      NOTIFY pgrst, 'reload schema';
+    END IF;
+  END LOOP;
+END; $$ LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER pgrst_ddl_watch
+  ON ddl_command_end
+  EXECUTE PROCEDURE pgrst_ddl_watch();
+
+CREATE EVENT TRIGGER pgrst_drop_watch
+  ON sql_drop
+  EXECUTE PROCEDURE pgrst_drop_watch();


### PR DESCRIPTION
This PRs adds two Postgres triggers that will make sure the PostgREST schema is reloaded every time the database layout is updated.
