### PR TITLE
[ECO-1086] add a script to init grafana

### DIFF
--- a/src/terraform/internal-dss/create_grafana_user.sh
+++ b/src/terraform/internal-dss/create_grafana_user.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Create a PostgreSQL data source
+curl "http://admin:$ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/datasources" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    --data "{\"name\":\"DSS Database\",\"type\":\"postgres\",\"url\":\"$DATABASE_HOST:$DATABASE_PORT\",\"access\":\"proxy\",\"user\":\"$DATABASE_USER\",\"password\":\"$DATABASE_PASSWORD\",\"jsonData\": {\"database\":\"$DATABASE_DB\",\"sslmode\":\"disable\",\"postgresVersion\":1500}}"
+
+# Create a public user
+curl "http://admin:$ADMIN_PASSWORD@$GRAFANA_HOST:$GRAFANA_PORT/api/admin/users" \
+    -X POST \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    --data "{\"name\":\"public\",\"email\":\"$PUBLIC_USER_EMAIL\",\"login\":\"public\",\"password\":\"$PUBLIC_USER_PASSWORD\",\"OrgId\":1}"


### PR DESCRIPTION
This PR adds a script that creates a PostgreSQL data source for Grafana, as well as a new public user.

It needs the following environment variables:

- ADMIN_PASSWORD (ex: 1234)
- GRAFANA_HOST (ex: grafana.econia.lol)
- GRAFANA_PORT (ex: 3000)
- DATABASE_HOST (ex: database.econia.lol)
- DATABASE_PORT (ex: 5432)
- DATABASE_USER (ex: grafana)
- DATABASE_PASSWORD (ex: *****)
- DATABASE_DB (ex: econia)
- PUBLIC_USER_EMAIL (ex: mister.potato1984@example.com)
- PUBLIC_USER_PASSWORD (ex: *****)
