### PR TITLE
hotfix the insert_daily_rolling_volume query

### DIFF
--- a/src/rust/aggregator/sqlx_queries/rolling_volume/insert_daily_rolling_volume.sql
+++ b/src/rust/aggregator/sqlx_queries/rolling_volume/insert_daily_rolling_volume.sql
@@ -6,7 +6,7 @@ WITH "times" AS (
     FROM
         generate_series((SELECT "time" FROM fill_events ORDER BY "time" LIMIT 1), (SELECT * FROM aggregator.order_history_latest_event_timestamp), '1 minute'::interval) dd
     WHERE
-        (SELECT * FROM aggregator.daily_rolling_volume_history_last_indexed_timestamp) IS NOT NULL
+        (SELECT * FROM aggregator.daily_rolling_volume_history_last_indexed_timestamp) IS NULL
     OR
         dd > (SELECT * FROM aggregator.daily_rolling_volume_history_last_indexed_timestamp)
 )


### PR DESCRIPTION
Somehow, this happened.

`NOT NULL` instead of `NULL`...

This PR fixes the bug and allows the correct aggregation of rolling volume.

The logic is the following:

If there is something in that table, we want to add the `dd > …` condition. If not, we want `dd` to be unrestricted.
