### PR TITLE
[ECO-1052] add tvl

### DIFF
--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -8,7 +8,10 @@ use aggregator::Pipeline;
 use anyhow::{anyhow, Result};
 use aptos_sdk::rest_client::AptosBaseUrl;
 use clap::{Parser, ValueEnum};
-use pipelines::{Candlesticks, Coins, Leaderboards, OrderHistory, RefreshMaterializedView, RollingVolume, UserHistory};
+use pipelines::{
+    Candlesticks, Coins, Leaderboards, OrderHistory, RefreshMaterializedView, RollingVolume,
+    UserHistory,
+};
 use sqlx::Executor;
 use sqlx_postgres::PgPoolOptions;
 use tokio::{sync::Mutex, task::JoinSet};
@@ -162,10 +165,12 @@ async fn main() -> Result<()> {
 
     let env_config: EnvConfig = EnvConfig::new();
 
-    let network = env_config.aptos_network.unwrap_or_else(|| args.aptos_network.unwrap_or_else(|| {
-        tracing::warn!("APTOS_NETWORK is not set. Using AptosNetwork::Testnet by default.");
-        AptosNetwork::Testnet
-    }));
+    let network = env_config.aptos_network.unwrap_or_else(|| {
+        args.aptos_network.unwrap_or_else(|| {
+            tracing::warn!("APTOS_NETWORK is not set. Using AptosNetwork::Testnet by default.");
+            AptosNetwork::Testnet
+        })
+    });
 
     let database_url = env_config.database_url.unwrap_or_else(|| {
         args.database_url.unwrap_or_else(|| {
@@ -174,35 +179,34 @@ async fn main() -> Result<()> {
         })
     });
 
-    let pipelines =
-        if env_config.no_default || args.no_default {
-            let mut include = env_config.include.clone();
-            include.append(&mut args.include);
-            include.sort();
-            include.dedup();
-            if include.is_empty() {
-                    tracing::error!("No pipelines are included and --no-default is set.");
-                    panic!();
-            }
-            include
-        } else {
-            let mut x = vec![
-                Pipelines::Candlesticks,
-                Pipelines::Coins,
-                Pipelines::Market24hData,
-                Pipelines::UserHistory,
-                Pipelines::Tvl,
-            ];
-            let mut exclude = env_config.exclude.clone();
-            let mut include = env_config.include.clone();
-            exclude.append(&mut args.exclude);
-            include.append(&mut args.include);
-            x = x.into_iter().filter(|a| !exclude.contains(a)).collect();
-            x.append(&mut include);
-            x.sort();
-            x.dedup();
-            x
-        };
+    let pipelines = if env_config.no_default || args.no_default {
+        let mut include = env_config.include.clone();
+        include.append(&mut args.include);
+        include.sort();
+        include.dedup();
+        if include.is_empty() {
+            tracing::error!("No pipelines are included and --no-default is set.");
+            panic!();
+        }
+        include
+    } else {
+        let mut x = vec![
+            Pipelines::Candlesticks,
+            Pipelines::Coins,
+            Pipelines::Market24hData,
+            Pipelines::UserHistory,
+            Pipelines::Tvl,
+        ];
+        let mut exclude = env_config.exclude.clone();
+        let mut include = env_config.include.clone();
+        exclude.append(&mut args.exclude);
+        include.append(&mut args.include);
+        x = x.into_iter().filter(|a| !exclude.contains(a)).collect();
+        x.append(&mut include);
+        x.sort();
+        x.dedup();
+        x
+    };
     tracing::info!("Using pipelines {pipelines:?}.");
     tracing::info!("Using network {network:?}.");
 
@@ -272,13 +276,21 @@ async fn main() -> Result<()> {
                     Duration::from_secs(5 * 60),
                 ))))
             }
-            Pipelines::OrderHistory => data.push(Arc::new(Mutex::new(OrderHistory::new(pool.clone())))),
-            Pipelines::RollingVolume => data.push(Arc::new(Mutex::new(RollingVolume::new(pool.clone())))),
+            Pipelines::OrderHistory => {
+                data.push(Arc::new(Mutex::new(OrderHistory::new(pool.clone()))))
+            }
+            Pipelines::RollingVolume => {
+                data.push(Arc::new(Mutex::new(RollingVolume::new(pool.clone()))))
+            }
             Pipelines::UserHistory => {
                 data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
             }
             Pipelines::Tvl => {
-                data.push(Arc::new(Mutex::new(RefreshMaterializedView::new(pool.clone(), "aggregator.tvl", Duration::from_secs(60)))));
+                data.push(Arc::new(Mutex::new(RefreshMaterializedView::new(
+                    pool.clone(),
+                    "aggregator.tvl",
+                    Duration::from_secs(60),
+                ))));
             }
         }
     }

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -49,6 +49,7 @@ pub enum Pipelines {
     Market24hData,
     OrderHistory,
     RollingVolume,
+    Tvl,
     UserHistory,
 }
 
@@ -190,6 +191,7 @@ async fn main() -> Result<()> {
                 Pipelines::Coins,
                 Pipelines::Market24hData,
                 Pipelines::UserHistory,
+                Pipelines::Tvl,
             ];
             let mut exclude = env_config.exclude.clone();
             let mut include = env_config.include.clone();
@@ -274,6 +276,9 @@ async fn main() -> Result<()> {
             Pipelines::RollingVolume => data.push(Arc::new(Mutex::new(RollingVolume::new(pool.clone())))),
             Pipelines::UserHistory => {
                 data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
+            }
+            Pipelines::Tvl => {
+                data.push(Arc::new(Mutex::new(RefreshMaterializedView::new(pool.clone(), "aggregator.tvl", Duration::from_secs(60)))));
             }
         }
     }

--- a/src/rust/aggregator/src/pipelines/candlesticks.rs
+++ b/src/rust/aggregator/src/pipelines/candlesticks.rs
@@ -3,7 +3,10 @@ use chrono::{DateTime, Duration, Utc};
 use sqlx::PgPool;
 use sqlx_postgres::PgConnection;
 
-use aggregator::{Pipeline, PipelineAggregationResult, PipelineError, util::{commit_transaction, create_repeatable_read_transaction}};
+use aggregator::{
+    util::{commit_transaction, create_repeatable_read_transaction},
+    Pipeline, PipelineAggregationResult, PipelineError,
+};
 
 pub struct Candlesticks {
     pool: PgPool,

--- a/src/rust/aggregator/src/pipelines/leaderboards.rs
+++ b/src/rust/aggregator/src/pipelines/leaderboards.rs
@@ -3,7 +3,10 @@ use bigdecimal::{BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{PgConnection, PgPool, Postgres, Transaction};
 
-use aggregator::{Pipeline, PipelineAggregationResult, PipelineError, util::{commit_transaction, create_repeatable_read_transaction}};
+use aggregator::{
+    util::{commit_transaction, create_repeatable_read_transaction},
+    Pipeline, PipelineAggregationResult, PipelineError,
+};
 
 pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 

--- a/src/rust/aggregator/src/pipelines/rolling_volume.rs
+++ b/src/rust/aggregator/src/pipelines/rolling_volume.rs
@@ -41,27 +41,20 @@ impl Pipeline for RollingVolume {
 
     async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {
         let mut transaction = create_repeatable_read_transaction(&self.pool).await?;
-        sqlx::query_file!(
-            "sqlx_queries/rolling_volume/insert_daily_rolling_volume.sql",
-        )
-        .execute(&mut transaction as &mut PgConnection)
-        .await
-        .map_err(to_pipeline_error)?;
+        sqlx::query_file!("sqlx_queries/rolling_volume/insert_daily_rolling_volume.sql",)
+            .execute(&mut transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
 
-        sqlx::query_file!(
-            "sqlx_queries/rolling_volume/delete_last_indexed_timestamp.sql",
-        )
-        .execute(&mut transaction as &mut PgConnection)
-        .await
-        .map_err(to_pipeline_error)?;
-        sqlx::query_file!(
-            "sqlx_queries/rolling_volume/update_last_indexed_timestamp.sql",
-        )
-        .execute(&mut transaction as &mut PgConnection)
-        .await
-        .map_err(to_pipeline_error)?;
+        sqlx::query_file!("sqlx_queries/rolling_volume/delete_last_indexed_timestamp.sql",)
+            .execute(&mut transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+        sqlx::query_file!("sqlx_queries/rolling_volume/update_last_indexed_timestamp.sql",)
+            .execute(&mut transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
         commit_transaction(transaction).await?;
         Ok(())
     }
 }
-

--- a/src/rust/aggregator/src/pipelines/user_history.rs
+++ b/src/rust/aggregator/src/pipelines/user_history.rs
@@ -3,7 +3,10 @@ use bigdecimal::{num_bigint::ToBigInt, BigDecimal, Zero};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{PgConnection, PgPool, Postgres, Transaction};
 
-use aggregator::{Pipeline, PipelineAggregationResult, PipelineError, util::{commit_transaction, create_repeatable_read_transaction}};
+use aggregator::{
+    util::{commit_transaction, create_repeatable_read_transaction},
+    Pipeline, PipelineAggregationResult, PipelineError,
+};
 
 use crate::dbtypes::OrderType;
 

--- a/src/rust/aggregator/src/util.rs
+++ b/src/rust/aggregator/src/util.rs
@@ -20,8 +20,6 @@ pub async fn create_repeatable_read_transaction<'a>(
 }
 
 pub async fn commit_transaction<'a>(tx: Transaction<'a, Postgres>) -> PipelineAggregationResult {
-    tx.commit()
-        .await
-        .map_err(to_pipeline_error)?;
+    tx.commit().await.map_err(to_pipeline_error)?;
     Ok(())
 }

--- a/src/rust/dbv2/check_db.sh
+++ b/src/rust/dbv2/check_db.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+echo "Starting a dedicated PostgreSQL Docker instance"
+
+docker run -d --rm --name econia_db_test -e POSTGRES_PASSWORD=pgpw -p 1984:5432 postgres > /dev/null
+
+DATABASE_URL=postgres://postgres:pgpw@localhost:1984/econia
+
+echo "Waiting 5 seconds for the database to start..." && sleep 5
+
+echo "Running migrations back and forth"
+
+if diesel database setup && diesel migration redo --all; then
+    echo "All good !"
+else
+    echo "An error occured."
+fi
+
+docker stop econia_db_test > /dev/null

--- a/src/rust/dbv2/check_db.sh
+++ b/src/rust/dbv2/check_db.sh
@@ -2,9 +2,9 @@
 
 echo "Starting a dedicated PostgreSQL Docker instance"
 
-docker run -d --rm --name econia_db_test -e POSTGRES_PASSWORD=pgpw -p 1984:5432 postgres > /dev/null
+docker run -d --rm --name econia_db_test -e POSTGRES_PASSWORD=pgpw -p 37949:5432 postgres > /dev/null
 
-DATABASE_URL=postgres://postgres:pgpw@localhost:1984/econia
+DATABASE_URL=postgres://postgres:pgpw@localhost:37949/econia
 
 echo "Waiting 5 seconds for the database to start..." && sleep 5
 

--- a/src/rust/dbv2/check_db.sh
+++ b/src/rust/dbv2/check_db.sh
@@ -4,13 +4,13 @@ echo "Starting a dedicated PostgreSQL Docker instance"
 
 docker run -d --rm --name econia_db_test -e POSTGRES_PASSWORD=pgpw -p 37949:5432 postgres > /dev/null
 
-DATABASE_URL=postgres://postgres:pgpw@localhost:37949/econia
+TEST_DATABASE_URL=postgres://postgres:pgpw@localhost:37949/econia
 
 echo "Waiting 5 seconds for the database to start..." && sleep 5
 
 echo "Running migrations back and forth"
 
-if diesel database setup && diesel migration redo --all; then
+if diesel database setup --database-url $TEST_DATABASE_URL && diesel migration redo --database-url $TEST_DATABASE_URL --all; then
     echo "All good !"
 else
     echo "An error occured."

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.tvl;
+
+
+DROP MATERIALIZED VIEW api.tvl;

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/down.sql
@@ -1,5 +1,11 @@
 -- This file should undo anything in `up.sql`
-DROP VIEW api.tvl;
+DROP VIEW api.tvl_per_market;
 
 
-DROP MATERIALIZED VIEW api.tvl;
+DROP MATERIALIZED VIEW aggregator.tvl_per_market;
+
+
+DROP VIEW api.tvl_per_asset;
+
+
+DROP MATERIALIZED VIEW aggregator.tvl_per_asset;

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -83,10 +83,17 @@ UNION
 SELECT value, NULL AS coin, coin_name_generic, market_id
 FROM fake_coins;
 
-CREATE VIEW api.tvl AS
-SELECT * FROM aggregator.tvl;
+CREATE VIEW api.tvl_per_market AS
+SELECT * FROM aggregator.tvl_per_market;
 
 GRANT
 SELECT
-  ON api.tvl TO web_anon;
+  ON api.tvl_per_market TO web_anon;
+
+CREATE VIEW api.tvl_per_asset AS
+SELECT * FROM aggregator.tvl_per_asset;
+
+GRANT
+SELECT
+  ON api.tvl_per_asset TO web_anon;
 

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -4,9 +4,9 @@ SELECT
     SUM(base_total) AS base_value,
     SUM(quote_total) AS quote_value,
     markets.market_id,
-    base_account_address ||'::'|| base_module_name ||'::'|| base_struct_name AS base,
+    base_account_address, base_module_name, base_struct_name,
     base_name_generic,
-    quote_account_address ||'::'|| quote_module_name ||'::'|| quote_struct_name AS quote
+    quote_account_address, quote_module_name, quote_struct_name
 FROM
     api.user_balances,
     api.markets
@@ -27,7 +27,7 @@ CREATE MATERIALIZED VIEW aggregator.tvl_per_asset AS
 WITH sums AS (
 SELECT
     SUM(base_total) AS value,
-    base_account_address ||'::'|| base_module_name ||'::'|| base_struct_name AS coin
+    base_account_address AS address, base_module_name AS module, base_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -44,7 +44,7 @@ GROUP BY
 UNION
 SELECT
     SUM(quote_total) AS value,
-    quote_account_address ||'::'|| quote_module_name ||'::'|| quote_struct_name AS coin
+    quote_account_address AS address, quote_module_name AS module, quote_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -57,9 +57,9 @@ GROUP BY
     markets.market_id
 ),
 real_coins AS (
-    SELECT SUM(value) AS value, coin
+    SELECT SUM(value) AS value, address, module, struct
     FROM sums
-    GROUP BY coin
+    GROUP BY address, module, struct
 ),
 fake_coins AS (
 SELECT
@@ -77,10 +77,10 @@ GROUP BY
     base_name_generic,
     markets.market_id
 )
-SELECT value, coin, NULL AS coin_name_generic, NULL AS market_id
+SELECT value, address, module, struct, NULL AS coin_name_generic, NULL AS market_id
 FROM real_coins
 UNION
-SELECT value, NULL AS coin, coin_name_generic, market_id
+SELECT value, NULL AS address, NULL AS module, NULL AS struct, coin_name_generic, market_id
 FROM fake_coins;
 
 CREATE VIEW api.tvl_per_market AS

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -1,0 +1,92 @@
+-- Your SQL goes here
+CREATE MATERIALIZED VIEW aggregator.tvl_per_market AS
+SELECT
+    SUM(base_total) AS base_value,
+    SUM(quote_total) AS quote_value,
+    markets.market_id,
+    base_account_address ||'::'|| base_module_name ||'::'|| base_struct_name AS base,
+    base_name_generic,
+    quote_account_address ||'::'|| quote_module_name ||'::'|| quote_struct_name AS quote
+FROM
+    api.user_balances,
+    api.markets
+WHERE
+    user_balances.market_id = markets.market_id
+GROUP BY
+    markets.market_id,
+    base_account_address,
+    base_module_name,
+    base_struct_name,
+    base_name_generic,
+    quote_account_address,
+    quote_module_name,
+    quote_struct_name;
+
+
+CREATE MATERIALIZED VIEW aggregator.tvl_per_asset AS
+WITH sums AS (
+SELECT
+    SUM(base_total) AS value,
+    base_account_address ||'::'|| base_module_name ||'::'|| base_struct_name AS coin
+FROM
+    api.user_balances,
+    api.markets
+WHERE
+    user_balances.market_id = markets.market_id
+AND
+    base_name_generic IS NULL
+GROUP BY
+    markets.market_id,
+    base_account_address,
+    base_module_name,
+    base_struct_name,
+    base_name_generic
+UNION
+SELECT
+    SUM(quote_total) AS value,
+    quote_account_address ||'::'|| quote_module_name ||'::'|| quote_struct_name AS coin
+FROM
+    api.user_balances,
+    api.markets
+WHERE
+    user_balances.market_id = markets.market_id
+GROUP BY
+    quote_account_address,
+    quote_module_name,
+    quote_struct_name,
+    markets.market_id
+),
+real_coins AS (
+    SELECT SUM(value) AS value, coin
+    FROM sums
+    GROUP BY coin
+),
+fake_coins AS (
+SELECT
+    SUM(base_total) AS value,
+    base_name_generic AS coin_name_generic,
+    markets.market_id
+FROM
+    api.user_balances,
+    api.markets
+WHERE
+    user_balances.market_id = markets.market_id
+AND
+    base_name_generic IS NOT NULL
+GROUP BY
+    base_name_generic,
+    markets.market_id
+)
+SELECT value, coin, NULL AS coin_name_generic, NULL AS market_id
+FROM real_coins
+UNION
+SELECT value, NULL AS coin, coin_name_generic, market_id
+FROM fake_coins;
+
+CREATE VIEW api.tvl AS
+SELECT * FROM aggregator.tvl;
+
+GRANT
+SELECT
+  ON api.tvl TO web_anon;
+

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -4,9 +4,13 @@ SELECT
     SUM(base_total) AS base_value,
     SUM(quote_total) AS quote_value,
     markets.market_id,
-    base_account_address, base_module_name, base_struct_name,
+    base_account_address,
+    base_module_name,
+    base_struct_name,
     base_name_generic,
-    quote_account_address, quote_module_name, quote_struct_name
+    quote_account_address,
+    quote_module_name,
+    quote_struct_name
 FROM
     api.user_balances,
     api.markets
@@ -27,7 +31,9 @@ CREATE MATERIALIZED VIEW aggregator.tvl_per_asset AS
 WITH sums AS (
 SELECT
     SUM(base_total) AS "value",
-    base_account_address AS "address", base_module_name AS module, base_struct_name AS struct
+    base_account_address AS "address",
+    base_module_name AS module,
+    base_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -44,7 +50,9 @@ GROUP BY
 UNION
 SELECT
     SUM(quote_total) AS "value",
-    quote_account_address AS "address", quote_module_name AS module, quote_struct_name AS struct
+    quote_account_address AS "address",
+    quote_module_name AS module,
+    quote_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -77,10 +85,22 @@ GROUP BY
     base_name_generic,
     markets.market_id
 )
-SELECT "value", "address", module, struct, NULL AS coin_name_generic, NULL AS market_id
+SELECT
+    "value",
+    "address",
+    module,
+    struct,
+    NULL AS coin_name_generic,
+    NULL AS market_id
 FROM coin_assets
 UNION
-SELECT "value", NULL AS "address", NULL AS module, NULL AS struct, coin_name_generic, market_id
+SELECT
+    "value",
+    NULL AS "address",
+    NULL AS module,
+    NULL AS struct,
+    coin_name_generic,
+    market_id
 FROM generic_assets;
 
 CREATE VIEW api.tvl_per_market AS

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -104,14 +104,31 @@ SELECT
 FROM generic_assets;
 
 CREATE VIEW api.tvl_per_market AS
-SELECT * FROM aggregator.tvl_per_market;
+SELECT
+    tvl.*,
+    base.name AS base_name,
+    base.symbol AS base_symbol,
+    base.decimals AS base_decimals,
+    quote.name AS quote_name,
+    quote.symbol AS quote_symbol,
+    quote.decimals AS quote_decimals
+FROM aggregator.tvl_per_market tvl
+LEFT JOIN aggregator.coins base
+ON base_account_address = base.address
+AND base_module_name = base.module
+AND base_struct_name = base.struct
+INNER JOIN aggregator.coins quote
+ON quote_account_address = quote.address
+AND quote_module_name = quote.module
+AND quote_struct_name = quote.struct;
 
 GRANT
 SELECT
   ON api.tvl_per_market TO web_anon;
 
 CREATE VIEW api.tvl_per_asset AS
-SELECT * FROM aggregator.tvl_per_asset;
+SELECT * FROM aggregator.tvl_per_asset
+NATURAL LEFT JOIN aggregator.coins;
 
 GRANT
 SELECT

--- a/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-07-231321_tvl/up.sql
@@ -26,8 +26,8 @@ GROUP BY
 CREATE MATERIALIZED VIEW aggregator.tvl_per_asset AS
 WITH sums AS (
 SELECT
-    SUM(base_total) AS value,
-    base_account_address AS address, base_module_name AS module, base_struct_name AS struct
+    SUM(base_total) AS "value",
+    base_account_address AS "address", base_module_name AS module, base_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -43,8 +43,8 @@ GROUP BY
     base_name_generic
 UNION
 SELECT
-    SUM(quote_total) AS value,
-    quote_account_address AS address, quote_module_name AS module, quote_struct_name AS struct
+    SUM(quote_total) AS "value",
+    quote_account_address AS "address", quote_module_name AS module, quote_struct_name AS struct
 FROM
     api.user_balances,
     api.markets
@@ -56,14 +56,14 @@ GROUP BY
     quote_struct_name,
     markets.market_id
 ),
-real_coins AS (
-    SELECT SUM(value) AS value, address, module, struct
+coin_assets AS (
+    SELECT SUM("value") AS "value", "address", module, struct
     FROM sums
-    GROUP BY address, module, struct
+    GROUP BY "address", module, struct
 ),
-fake_coins AS (
+generic_assets AS (
 SELECT
-    SUM(base_total) AS value,
+    SUM(base_total) AS "value",
     base_name_generic AS coin_name_generic,
     markets.market_id
 FROM
@@ -77,11 +77,11 @@ GROUP BY
     base_name_generic,
     markets.market_id
 )
-SELECT value, address, module, struct, NULL AS coin_name_generic, NULL AS market_id
-FROM real_coins
+SELECT "value", "address", module, struct, NULL AS coin_name_generic, NULL AS market_id
+FROM coin_assets
 UNION
-SELECT value, NULL AS address, NULL AS module, NULL AS struct, coin_name_generic, market_id
-FROM fake_coins;
+SELECT "value", NULL AS "address", NULL AS module, NULL AS struct, coin_name_generic, market_id
+FROM generic_assets;
 
 CREATE VIEW api.tvl_per_market AS
 SELECT * FROM aggregator.tvl_per_market;


### PR DESCRIPTION
This PR adds the ~`/tvl`~ `/tvl_per_market` and `/tvl_per_asset` endpoints required to integrate with DeFi discovery tools.

- [x] Choose between per market or per asset tvl. (Chose both)
- [X] Add example response.

Also added a dev script to check migrations really quickly without having to modify your main database (or even have one up !).

# Example

```http
GET /tvl_per_market
```

```json
[
  {
    "base_value": 1000000,
    "quote_value": 10000000,
    "market_id": 1,
    "base_account_address": "0x5e156f1207d0ebfa19a9eeff00d62a282278fb8719f4fab3a586a0a2c0fffbea",
    "base_module_name": "coin",
    "base_struct_name": "T",
    "base_name_generic": null,
    "quote_account_address": "0x1",
    "quote_module_name": "aptos_coin",
    "quote_struct_name": "AptosCoin",
    "base_name": "USD Coin",
    "base_symbol": "USDC",
    "base_decimals": 6,
    "quote_name": "Aptos Coin",
    "quote_symbol": "APT",
    "quote_decimals": 8
  }
]
```

```http
GET /tvl_per_asset
```

```json
[
  {
    "address": "0x1",
    "module": "aptos_coin",
    "struct": "AptosCoin",
    "value": 3142036072296,
    "coin_name_generic": null,
    "market_id": null,
    "name": "Aptos Coin",
    "symbol": "APT",
    "decimals": 8
  }
]
```