### PR TITLE
[ECO-1125] add views for integration with coingecko

### DIFF
--- a/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/down.sql
@@ -2,11 +2,12 @@
 DROP VIEW api.historical_trades;
 DROP FUNCTION api.orderbook;
 DROP VIEW api.tickers;
+DROP FUNCTION api.get_market_mid_price;
 DROP FUNCTION api.get_market_liquidity;
 DROP FUNCTION api.get_market_24h_low;
 DROP FUNCTION api.get_market_24h_high;
-DROP FUNCTION api.get_market_bid;
-DROP FUNCTION api.get_market_ask;
+DROP FUNCTION api.get_market_best_bid_price;
+DROP FUNCTION api.get_market_best_ask_price;
 DROP FUNCTION api.get_market_last_price;
 DROP FUNCTION integer_price_to_quote_nominal;
 

--- a/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/down.sql
@@ -1,0 +1,60 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.historical_trades;
+DROP FUNCTION api.orderbook;
+DROP VIEW api.tickers;
+DROP FUNCTION api.get_market_liquidity;
+DROP FUNCTION api.get_market_24h_low;
+DROP FUNCTION api.get_market_24h_high;
+DROP FUNCTION api.get_market_bid;
+DROP FUNCTION api.get_market_ask;
+DROP FUNCTION api.get_market_last_price;
+DROP FUNCTION integer_price_to_quote_nominal;
+
+
+CREATE OR REPLACE FUNCTION integer_price_to_quote_indivisible_subunits(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT ($2 * tick_size * POW(10,COALESCE(base.decimals, 0))) / lot_size
+    FROM market_registration_events
+    LEFT JOIN aggregator.coins base
+    ON base_account_address = base."address" AND base_module_name = base.module AND base_struct_name = base.struct
+    INNER JOIN aggregator.coins quote
+    ON quote_account_address = quote."address" AND quote_module_name = quote.module AND quote_struct_name = quote.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION quote_indivisible_subunits_to_integer_price(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT ($2 * POW(10,COALESCE(base.decimals, 0)) * lot_size) / tick_size
+    FROM market_registration_events
+    LEFT JOIN aggregator.coins base
+    ON base_account_address = base."address" AND base_module_name = base.module AND base_struct_name = base.struct
+    INNER JOIN aggregator.coins quote
+    ON quote_account_address = quote."address" AND quote_module_name = quote.module AND quote_struct_name = quote.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION size_to_base_indivisible_subunits(market_id numeric, "size" numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT $2 * lot_size
+    FROM market_registration_events
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION size_and_price_to_quote_indivisible_subunits(market_id numeric, "size" numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT $2 * $3 * tick_size
+    FROM market_registration_events
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION get_quote_volume_divisor_for_market(numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT tick_size * POW(10::numeric,decimals::numeric)
+    FROM market_registration_events AS m
+    INNER JOIN aggregator.coins AS c
+    ON m.quote_account_address = c."address"
+    AND m.quote_module_name = c.module
+    AND m.quote_struct_name = c.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+DROP VIEW api.coins;

--- a/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-17-184459_coingecko/up.sql
@@ -1,0 +1,192 @@
+-- Your SQL goes here
+
+-- Replace old utility functions to use api.coins instead of aggregator.coins to allow the functions to be used by web_anon
+CREATE VIEW api.coins AS SELECT * FROM aggregator.coins;
+
+
+CREATE OR REPLACE FUNCTION integer_price_to_quote_indivisible_subunits(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT ($2 * tick_size * POW(10,COALESCE(base.decimals, 0))) / lot_size
+    FROM market_registration_events
+    LEFT JOIN api.coins base
+    ON base_account_address = base."address" AND base_module_name = base.module AND base_struct_name = base.struct
+    INNER JOIN api.coins quote
+    ON quote_account_address = quote."address" AND quote_module_name = quote.module AND quote_struct_name = quote.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION quote_indivisible_subunits_to_integer_price(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT ($2 * POW(10,COALESCE(base.decimals, 0)) * lot_size) / tick_size
+    FROM market_registration_events
+    LEFT JOIN api.coins base
+    ON base_account_address = base."address" AND base_module_name = base.module AND base_struct_name = base.struct
+    INNER JOIN api.coins quote
+    ON quote_account_address = quote."address" AND quote_module_name = quote.module AND quote_struct_name = quote.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION size_to_base_indivisible_subunits(market_id numeric, "size" numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT $2 * lot_size
+    FROM market_registration_events
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION size_and_price_to_quote_indivisible_subunits(market_id numeric, "size" numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT $2 * $3 * tick_size
+    FROM market_registration_events
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION get_quote_volume_divisor_for_market(numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT tick_size * POW(10::numeric,decimals::numeric)
+    FROM market_registration_events AS m
+    INNER JOIN api.coins AS c
+    ON m.quote_account_address = c."address"
+    AND m.quote_module_name = c.module
+    AND m.quote_struct_name = c.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;
+
+
+-- Create utility functions used by the views
+CREATE FUNCTION integer_price_to_quote_nominal(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT integer_price_to_quote_indivisible_subunits(market_id, price) / get_quote_volume_divisor_for_market(market_id);
+$$ LANGUAGE sql;
+
+
+CREATE FUNCTION api.get_market_liquidity (market_id numeric, depth numeric) RETURNS NUMERIC AS $$
+    WITH mid_price AS (
+        SELECT
+          (MIN(price) FILTER (WHERE direction = 'ask') + MAX(price) FILTER (WHERE direction = 'bid')) / 2 AS mid_price
+        FROM api.orders
+        WHERE orders.market_id = $1
+        AND order_status = 'open'
+    )
+    SELECT SUM(CASE
+        WHEN direction = 'bid' THEN size_and_price_to_quote_indivisible_subunits($1,remaining_size,price)
+        ELSE size_and_price_to_quote_indivisible_subunits($1,remaining_size,mid_price)
+    END)
+    AS liquidity_in_quote
+    FROM api.orders, mid_price
+    WHERE order_status = 'open'
+    AND market_id = $1
+    AND price::numeric BETWEEN mid_price::numeric * (1::numeric - $2::numeric/10000::numeric) AND mid_price::numeric * (1::numeric + $2::numeric/10000::numeric);
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.get_market_24h_low (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT MIN(price)
+    FROM fill_events
+    WHERE "time" > CURRENT_TIMESTAMP - interval '1 day'
+    AND fill_events.market_id = $1;
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.get_market_24h_high (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT MAX(price)
+    FROM fill_events
+    WHERE "time" > CURRENT_TIMESTAMP - interval '1 day'
+    AND fill_events.market_id = $1;
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.get_market_ask (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT MIN(price)
+    FROM api.orders
+    WHERE orders.market_id = $1
+    AND order_status = 'open'
+    AND direction = 'ask';
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.get_market_bid (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT MAX(price)
+    FROM api.orders
+    WHERE orders.market_id = $1
+    AND order_status = 'open'
+    AND direction = 'bid';
+$$ LANGUAGE SQL;
+
+
+CREATE FUNCTION api.get_market_last_price (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT price
+    FROM fill_events
+    ORDER BY txn_version DESC, event_idx DESC
+    LIMIT 1;
+$$ LANGUAGE SQL;
+
+
+-- Create the views
+CREATE VIEW api.tickers AS
+SELECT
+    market_id,
+    base_account_address || '::' || base_module_name || '::' || base_struct_name AS base_currency,
+    quote_account_address || '::' || quote_module_name || '::' || quote_struct_name AS quote_currency,
+    base_volume_24h AS base_volume,
+    quote_volume_24h AS quote_volume,
+    integer_price_to_quote_nominal(market_id, api.get_market_last_price(market_id)) AS last_price,
+    integer_price_to_quote_nominal(market_id, api.get_market_ask(market_id)) AS ask,
+    integer_price_to_quote_nominal(market_id, api.get_market_bid(market_id)) AS bid,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_high(market_id)) AS high,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_low(market_id)) AS low,
+    api.get_market_liquidity(market_id,200) / get_quote_volume_divisor_for_market(market_id) AS liquidity_in_quote
+FROM
+    api.markets;
+
+
+CREATE FUNCTION api.orderbook (market_id numeric, depth numeric) RETURNS TABLE(market_id numeric(20,0), txn_version numeric(20,0), bids numeric[], asks numeric[]) AS $$
+    WITH mid_price AS (
+        SELECT
+          (MIN(price) FILTER (WHERE direction = 'ask') + MAX(price) FILTER (WHERE direction = 'bid')) / 2 AS mid_price
+        FROM api.orders
+        WHERE orders.market_id = $1 AND order_status = 'open'
+    ),
+    t AS (
+      SELECT
+          price,
+          SUM(size_to_base_indivisible_subunits($1,remaining_size)) FILTER (WHERE direction = 'bid') as bid,
+          SUM(size_to_base_indivisible_subunits($1,remaining_size)) FILTER (WHERE direction = 'ask') as ask,
+          direction
+      FROM api.orders, mid_price
+      WHERE order_status = 'open'
+      AND market_id = $1
+      AND price::numeric BETWEEN mid_price::numeric * (1::numeric - $2::numeric/10000::numeric) AND mid_price::numeric * (1::numeric + $2::numeric/10000::numeric)
+      GROUP BY direction, price
+      ORDER BY price
+    )
+    SELECT
+        $1::numeric(20,0) AS market_id,
+        (SELECT * FROM api.user_history_last_indexed_txn) AS txn_version,
+        array_agg(ARRAY[price,ask]) FILTER (WHERE direction = 'ask') AS asks,
+        array_agg(ARRAY[price,bid]) FILTER (WHERE direction = 'bid') AS bids
+    FROM t
+$$ LANGUAGE SQL;
+
+
+CREATE VIEW api.historical_trades AS
+SELECT
+    txn_version,
+    event_idx,
+    market_id,
+    "time",
+    integer_price_to_quote_nominal(market_id, price),
+    size_to_base_indivisible_subunits(market_id, "size") AS base_volume,
+    size_to_base_indivisible_subunits(market_id, "size") * integer_price_to_quote_nominal(market_id, price) AS quote_volume,
+    CASE
+        WHEN maker_side = true THEN 'buy'
+        ELSE 'sell'
+    END AS "type"
+FROM fill_events
+WHERE emit_address = maker_address;
+
+
+GRANT
+SELECT
+  ON api.tickers TO web_anon;
+
+
+GRANT
+SELECT
+  ON api.historical_trades TO web_anon;


### PR DESCRIPTION
This PR adds views and functions to create endpoints needed to integrate with CoinGecko.

See [provided doc](https://docs.google.com/document/d/1v27QFoQq1SKT3Priq3aqPgB70Xd_PnDzbOCiuoCyixw/edit).

# Tickers

## Parameters

This can take the usual PostgREST parameters, but since CoinGecko does not ask for any parameters to be implemented for this endpoint, they are not documented here.

[Here](https://postgrest.org/en/stable/references/api/tables_views.html) is a link for a more in depth description of PostgREST parameters.

[Here](https://econia.dev/off-chain/dss/rest-api#tag/place_swap_order_events) is a link to our internal API documentation.

## Example

```http
GET /tickers
```

```json
[
  {
    "market_id": 7,
    "base_currency": "0x1::aptos_coin::AptosCoin",
    "quote_currency": "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC",
    "base_volume": 1234.0000000000000000,
    "quote_volume": 123456.0000000000000000,
    "last_price": 9.4990000000000000,
    "ask": 9.4990000000000000,
    "bid": 9.4730000000000000,
    "high": 9.6410000000000000,
    "low": 9.4120000000000000,
    "liquidity_in_quote": 20954.2560610000000000
  }
]
```

# Orderbook

## Parameters

- `market`: the id of the market to get the orderbook for
- `depth`: depth in bps

## Example
```http
GET /rpc/orderbook?market=7&depth=5
```

```json
[
  {
    "market_id": 7,
    "txn_version": 375583627,
    "bids": [
      [
        9430,
        7200900000
      ]
    ],
    "asks": [
      [
        9425,
        1912700000
      ]
    ]
  }
]
```

# Historical trades

## Parameters

Since this is a view and not a function, note that this endpoint uses the `<operator>.<value>` notation when querying.

But, since `limit` is a built-in filter, it uses the normal notation (`limit=100`)

- `market_id`: the ID of the market to get the history for
- `type`: the type of trades to get (either `buy` or `sell`)
- `limit`: the number of trades to get
- `time`: a time filter (use `gt.<time>`, `gte.<time>`, `lt.<time>` and `lte.<time>`)

All parameters are optional.

If no limit specified, a default one may be present depending on what server parameters are used by the host.

## Example

```http
GET /historical_trades?market_id=eq.7&type=eq.buy&time=gte.2023-11-25&time=lt.2023-11-26&limit=10
```

```json
[
  {
    "txn_version": 342026731,
    "event_idx": 2,
    "market_id": 7,
    "time": "2023-11-26T05:20:54.369276+00:00",
    "integer_price_to_quote_nominal": 7.3820000000000000,
    "base_volume": 100000000,
    "quote_volume": 738200000.0000000000000000,
    "type": "buy"
  },
  {
    "txn_version": 342027596,
    "event_idx": 2,
    "market_id": 7,
    "time": "2023-11-26T05:22:10.002462+00:00",
    "integer_price_to_quote_nominal": 7.3820000000000000,
    "base_volume": 50000000,
    "quote_volume": 369100000.0000000000000000,
    "type": "buy"
  },
  {
    "txn_version": 342047501,
    "event_idx": 2,
    "market_id": 7,
    "time": "2023-11-26T05:50:24.737977+00:00",
    "integer_price_to_quote_nominal": 7.3820000000000000,
    "base_volume": 110000000,
    "quote_volume": 812020000.0000000000000000,
    "type": "buy"
  }
]
```

