### PR TITLE
[ECO-1153] add more documentation before publishing the rust crate

### DIFF
--- a/src/rust/sdk/README.md
+++ b/src/rust/sdk/README.md
@@ -1,4 +1,4 @@
 # Econia SDK
 
 The Econia SDK is documented using Rust comments.
-You can check it out on the [docs.rs](https://docs.rs/) website, or locally, by running `cargo doc` and then opening the generated files (the one which's path is printed during doc compilation).
+You can check it out on the [docs.rs](https://docs.rs/) website, or locally, by running `cargo doc --open`.

--- a/src/rust/sdk/README.md
+++ b/src/rust/sdk/README.md
@@ -1,0 +1,4 @@
+# Econia SDK
+
+The Econia SDK is documented using Rust comments.
+You can check it out on the [docs.rs](https://docs.rs/) website, or locally, by running `cargo doc` and then opening the generated files (the one which's path is printed during doc compilation).

--- a/src/rust/sdk/src/entry.rs
+++ b/src/rust/sdk/src/entry.rs
@@ -1,3 +1,10 @@
+//! The [`entry`](crate::entry) module exposes the entry functionalities of the Econia package.
+//!
+//! Here you can find helper functions to generate payloads for the
+//! [`EconiaClient::submit_tx`](crate::EconiaClient::submit_tx).
+//!
+//! For every entry function that the Econia package exposes, there is a corresponding function
+//! here.
 use std::str::FromStr;
 
 use aptos_api_types::MoveModuleId;

--- a/src/rust/sdk/src/errors.rs
+++ b/src/rust/sdk/src/errors.rs
@@ -1,3 +1,5 @@
+//! Misc error types.
+
 use aptos_sdk::{
     bcs,
     crypto::CryptoMaterialError,

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -1,3 +1,16 @@
+//! # Econia SDK
+//!
+//! The Econia Rust SDK is an SDK to interact with the Econia V4 protocol. You can read more about
+//! the protocol at <https://econia.dev/>.
+//!
+//! The workflow to use this SDK is quite straight forward (only 3 steps):
+//!
+//! 1. Create a [`EconiaClient`]
+//! 2.
+//!     - Either use it to get a [`EconiaViewClient`]
+//!     - Or create a payload using helper functions from the [`entry`] module
+//! 3. There is no 3rd step.
+
 use aptos_api_types::{
     AptosErrorCode, MoveType, Transaction, TransactionInfo, UserTransactionRequest, VersionedEvent,
     U64,

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -3,13 +3,9 @@
 //! The Econia Rust SDK is an SDK to interact with the Econia V4 protocol. You can read more about
 //! the protocol at <https://econia.dev/>.
 //!
-//! The workflow to use this SDK is quite straight forward (only 3 steps):
-//!
-//! 1. Create a [`EconiaClient`]
-//! 2.
-//!     - Either use it to get a [`EconiaViewClient`]
-//!     - Or create a payload using helper functions from the [`entry`] module
-//! 3. There is no 3rd step.
+//! To use the SDK create an [EconiaClient], then either use it to get an [EconiaViewClient], or
+//! create a payload using helper functions from the [entry] module and submit it using
+//! [`EconiaClient::submit_tx`].
 
 use aptos_api_types::{
     AptosErrorCode, MoveType, Transaction, TransactionInfo, UserTransactionRequest, VersionedEvent,

--- a/src/rust/sdk/src/view.rs
+++ b/src/rust/sdk/src/view.rs
@@ -1,12 +1,12 @@
 //! The [`view`](crate::view) module exposes the view functionalities of the Econia package.
 //!
-//! You can create a [`EconiaViewClient`] from a [`EconiaClient`](crate::EconiaClient) using the
+//! You can create an [`EconiaViewClient`] from an [`EconiaClient`](crate::EconiaClient) using the
 //! [`EconiaClient::view_client`](crate::EconiaClient::view_client) function.
 //!
 //! You can then call the functions provided here.
 //!
-//! There are also stand alone functions which do not need any blockchain state and compute
-//! locally. Those do not need a [`EconiaViewClient`] to execute.
+//! There are also standalone functions which do not need any blockchain state and compute
+//! locally. Those do not need an [`EconiaViewClient`] to execute.
 
 use std::fmt::Display;
 use std::str::FromStr;

--- a/src/rust/sdk/src/view.rs
+++ b/src/rust/sdk/src/view.rs
@@ -1,3 +1,13 @@
+//! The [`view`](crate::view) module exposes the view functionalities of the Econia package.
+//!
+//! You can create a [`EconiaViewClient`] from a [`EconiaClient`](crate::EconiaClient) using the
+//! [`EconiaClient::view_client`](crate::EconiaClient::view_client) function.
+//!
+//! You can then call the functions provided here.
+//!
+//! There are also stand alone functions which do not need any blockchain state and compute
+//! locally. Those do not need a [`EconiaViewClient`] to execute.
+
 use std::fmt::Display;
 use std::str::FromStr;
 


### PR DESCRIPTION
Add some more Rust doc before publishing the crate to make reading the doc and using the crate more intuitive.
