### PR TITLE
[ECO-1171] expose the rolling volume enpoint

### DIFF
--- a/src/rust/dbv2/migrations/2024-01-30-170803_expose_daily_volume/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-30-170803_expose_daily_volume/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.daily_rolling_volume_history;

--- a/src/rust/dbv2/migrations/2024-01-30-170803_expose_daily_volume/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-30-170803_expose_daily_volume/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+CREATE VIEW api.daily_rolling_volume_history AS
+SELECT * FROM aggregator.daily_rolling_volume_history;
+
+GRANT SELECT ON api.daily_rolling_volume_history TO web_anon;


### PR DESCRIPTION
This PR exposes the rolling volume endpoint.

# Example

```http
GET /daily_rolling_volume_history
```

```json
{

}
```
