### PR TITLE
[ECO-1182] add volume history endpoint

### DIFF
--- a/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/down.sql
+++ b/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP FUNCTION api.volume_history;
+
+
+DROP VIEW api.daily_rolling_volume_history;

--- a/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/up.sql
@@ -2,8 +2,11 @@
 CREATE VIEW api.daily_rolling_volume_history AS SELECT * FROM aggregator.daily_rolling_volume_history;
 
 
+GRANT SELECT ON api.daily_rolling_volume_history TO web_anon;
+
+
 CREATE FUNCTION api.volume_history (market_id numeric(20,0), "time" timestamptz) RETURNS TABLE(daily NUMERIC(20,0), total NUMERIC(20,0)) AS $$
     SELECT
-        (SELECT volume_in_quote_subunits FROM api.daily_rolling_volume_history WHERE market_id = $1 AND $2 BETWEEN "time" AND "time" + interval '1 minute') AS daily,
+        (SELECT volume_in_quote_subunits FROM api.daily_rolling_volume_history WHERE market_id = $1 AND $2 BETWEEN "time" AND "time" + interval '1 minute' ORDER BY "time" DESC LIMIT 1) AS daily,
         (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time < $2);
 $$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/up.sql
+++ b/src/rust/dbv2/migrations/2024-01-31-084306_volume_history/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE VIEW api.daily_rolling_volume_history AS SELECT * FROM aggregator.daily_rolling_volume_history;
+
+
+CREATE FUNCTION api.volume_history (market_id numeric(20,0), "time" timestamptz) RETURNS TABLE(daily NUMERIC(20,0), total NUMERIC(20,0)) AS $$
+    SELECT
+        (SELECT volume_in_quote_subunits FROM api.daily_rolling_volume_history WHERE market_id = $1 AND $2 BETWEEN "time" AND "time" + interval '1 minute') AS daily,
+        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time < $2);
+$$ LANGUAGE SQL;


### PR DESCRIPTION
This PR adds the `/rpc/volume_history` endpoint which returns the total and daily volume at a given timestamp.

This is done in order to support the DefiLlama integration.

# Example

```http
GET /rpc/volume_history?market_id=7&time=2023-12-01
```

```json
[
  {
    "daily": 13850323219,
    "total": 92596968702
  }
]
```
