### PR TITLE
[ECO-1192] add rolling volume as a default pipeline

### DIFF
--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -198,6 +198,7 @@ async fn main() -> Result<()> {
                 Pipelines::Coins,
                 Pipelines::EnumeratedVolume,
                 Pipelines::Market24hData,
+                Pipelines::RollingVolume,
                 Pipelines::UserHistory,
                 Pipelines::TvlPerAsset,
                 Pipelines::TvlPerMarket,


### PR DESCRIPTION
This PR adds rolling volume as a default pipeline as it is now a core dependency for the `/volume_history` endpoint.
