### PR TITLE
[ECO-1194] Remove aggregator rolling volume extra config

### DIFF
--- a/src/terraform/dss-ci-cd/dss/modules/aggregator/main.tf
+++ b/src/terraform/dss-ci-cd/dss/modules/aggregator/main.tf
@@ -34,7 +34,7 @@ resource "terraform_data" "instance" {
       "gcloud compute instances create-with-container aggregator",
       "--container-env",
       join(",", [
-        "AGGREGATOR_INCLUDE=order-history+rolling-volume",
+        "AGGREGATOR_INCLUDE=order-history",
         "APTOS_NETWORK=${var.aptos_network}",
         "DATABASE_URL=${var.db_conn_str_private}"
       ]),


### PR DESCRIPTION
The rolling volume endpoint will be required on community DSS deployments to support DeFi LLama integration. Remove the config in anticipation for it to become a default pipeline per https://github.com/econia-labs/econia/pull/683