### PR TITLE
[ECO-1199] update rust packages metadata

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2270,6 +2270,7 @@ version = "1.0.0"
 dependencies = [
  "aptos-api-types",
  "aptos-sdk",
+ "econia-types",
  "futures",
  "hex",
  "reqwest",
@@ -2277,7 +2278,17 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.25",
  "thiserror",
- "types",
+]
+
+[[package]]
+name = "econia-types"
+version = "1.0.0"
+dependencies = [
+ "chrono",
+ "serde 1.0.188",
+ "serde_json",
+ "sqlx",
+ "thiserror",
 ]
 
 [[package]]
@@ -6842,17 +6853,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "types"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "serde 1.0.188",
- "serde_json",
- "sqlx",
- "thiserror",
-]
 
 [[package]]
 name = "ucd-trie"

--- a/src/rust/sdk/Cargo.toml
+++ b/src/rust/sdk/Cargo.toml
@@ -7,13 +7,14 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "SDK for interacting with Econia on Aptos"
 homepage = "https://econialabs.com"
-repository = "https://github.com/econia-labs/rust_sdk"
+documentation = "https://econia.dev"
+repository = "https://github.com/econia-labs/econia"
 keywords = ["aptos", "econia", "dex", "clob", "sdk", "blockchain"]
 
 [dependencies]
 aptos-api-types = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.7.2" }
 aptos-sdk.workspace = true
-econia-types = { package = "types", path = "../types", features = ["serde"] }
+econia-types = { package = "econia-types", path = "../types", features = ["serde"] }
 futures = "0.3.24"
 hex = { version = "0.4.3" }
 reqwest = { version = "0.11.11" }

--- a/src/rust/types/Cargo.toml
+++ b/src/rust/types/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-name = "types"
-version = "0.1.0"
+name = "econia-types"
+version = "1.0.0"
 edition = "2021"
+categories = ["crypto", "defi", "trading", "sdk"]
+license = "MIT OR Apache-2.0"
+description = "Types for interacting with Econia on Aptos"
+homepage = "https://econialabs.com"
+documentation = "https://econia.dev"
+repository = "https://github.com/econia-labs/econia"
+keywords = ["aptos", "econia", "dex", "clob", "sdk", "blockchain"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Some of the links in `Cargo.toml`s were outdated/missing.

This PR updates that.
