### PR TITLE
[ECO-1275] Correct inconsistent formatting in DSS changelog

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -16,7 +16,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 
 ### Fixed
 
-- Processing of events that are not a struct type ([#694], [processor #22])
+- Processing of events that are not a struct type ([#694], [processor #22]).
 
 ## [v1.6.0]
 


### PR DESCRIPTION
Add a period to a bullet point that is missing one, to enforce stylistic consistency.