### PR TITLE
Add restart option and postgrest max row environment

### DIFF
--- a/src/docker/compose.dss-core.yaml
+++ b/src/docker/compose.dss-core.yaml
@@ -45,7 +45,7 @@ services:
       PGRST_DB_URI: "postgres://econia:econia@postgres:5432/econia"
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_DB_SCHEMA: api
-      PGRST_DB_MAX_ROWS: 500
+      PGRST_DB_MAX_ROWS: ${POSTGREST_MAX_ROWS}
     image: postgrest/postgrest
     ports:
       - "3000:3000"

--- a/src/docker/compose.dss-core.yaml
+++ b/src/docker/compose.dss-core.yaml
@@ -18,6 +18,8 @@ services:
     environment:
       APTOS_NETWORK: ${APTOS_NETWORK}
       DATABASE_URL: "postgres://econia:econia@postgres:5432/econia"
+    restart: unless-stopped
+
 
   grafana_annotations:
     build:
@@ -43,9 +45,11 @@ services:
       PGRST_DB_URI: "postgres://econia:econia@postgres:5432/econia"
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_DB_SCHEMA: api
+      PGRST_DB_MAX_ROWS: 500
     image: postgrest/postgrest
     ports:
       - "3000:3000"
+    restart: unless-stopped
 
   ws:
     build:
@@ -66,3 +70,4 @@ services:
       - PGWS_LISTEN_CHANNEL=econiaws
     ports:
       - "3001:3000"
+    restart: unless-stopped

--- a/src/docker/compose.dss-core.yaml
+++ b/src/docker/compose.dss-core.yaml
@@ -20,7 +20,6 @@ services:
       DATABASE_URL: "postgres://econia:econia@postgres:5432/econia"
     restart: unless-stopped
 
-
   grafana_annotations:
     build:
       context: ../../

--- a/src/docker/compose.dss-global.yaml
+++ b/src/docker/compose.dss-global.yaml
@@ -13,3 +13,4 @@ services:
       extends:
         file: compose.processor-template.yaml
         service: processor-template
+      restart: unless-stopped

--- a/src/docker/compose.dss-global.yaml
+++ b/src/docker/compose.dss-global.yaml
@@ -13,4 +13,3 @@ services:
       extends:
         file: compose.processor-template.yaml
         service: processor-template
-      restart: unless-stopped

--- a/src/docker/compose.processor-template.yaml
+++ b/src/docker/compose.processor-template.yaml
@@ -13,3 +13,4 @@ services:
       - postgres
     ports:
       - "8085:8085"
+    restart: unless-stopped

--- a/src/docker/example.env
+++ b/src/docker/example.env
@@ -39,3 +39,7 @@ GRPC_AUTH_TOKEN="<API_TOKEN>"
 # For the official Econia package on testnet: 649555969
 # For local end-to-end testing chain: 0
 STARTING_VERSION="154106802"
+
+# A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure.
+# Limits payload size for accidental or malious requests.
+POSTGREST_MAX_ROWS="100"


### PR DESCRIPTION
To resolve a few issues that arose while operating the node, added several options to the docker-compose file.

1. Add option `restart: unless-stopped` to 
     1. aggregator
     2. postgrest
     3.  ws
     4. processor

2. Add enviroment value `PGRST_DB_MAX_ROWS:500` to postgrest

 