### PR TITLE
[ECO-1280] add spreads

### DIFF
--- a/src/rust/.sqlx/query-6d0ae6fd5f1dca3a60979fcf01611c95a5d2ea96678841c51fd04de89bf757de.json
+++ b/src/rust/.sqlx/query-6d0ae6fd5f1dca3a60979fcf01611c95a5d2ea96678841c51fd04de89bf757de.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH parameters AS (\n    SELECT\n        $1::numeric(20,0) AS \"market_id\",\n        $2::timestamptz AS \"time\",\n        $3::numeric(20,0) AS min_ask,\n        $4::numeric(20,0) AS max_bid\n)\nINSERT INTO aggregator.spreads\nSELECT\n    *\nFROM\n    parameters;\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Timestamptz",
+        "Numeric",
+        "Numeric"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6d0ae6fd5f1dca3a60979fcf01611c95a5d2ea96678841c51fd04de89bf757de"
+}

--- a/src/rust/.sqlx/query-7abb8665afc6387f18c86596d78732295810b8d134ce633e590a09098c1b277c.json
+++ b/src/rust/.sqlx/query-7abb8665afc6387f18c86596d78732295810b8d134ce633e590a09098c1b277c.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH parameters AS (\n    SELECT\n        $1::numeric(20,0) AS txn_version_start,\n        $2::numeric(20,0) AS txn_version_end\n)\nSELECT\n    market_id,\n    order_id,\n    initial_size AS \"size\",\n    side,\n    price\nFROM\n    place_limit_order_events,\n    parameters\nWHERE\n    txn_version > txn_version_start\nAND\n    txn_version <= txn_version_end;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "market_id",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 1,
+        "name": "order_id",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 2,
+        "name": "size",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 3,
+        "name": "side",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "price",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Numeric"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7abb8665afc6387f18c86596d78732295810b8d134ce633e590a09098c1b277c"
+}

--- a/src/rust/.sqlx/query-c4604c7e125351bac2954a191260af83205710d32561bbab5dafec0d872d2b54.json
+++ b/src/rust/.sqlx/query-c4604c7e125351bac2954a191260af83205710d32561bbab5dafec0d872d2b54.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH parameters AS (\n    SELECT\n        $1::timestamptz AS \"time\"\n)\nUPDATE aggregator.spreads_last_indexed_timestamp\nSET\n    \"time\" = parameters.\"time\"\nFROM parameters\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c4604c7e125351bac2954a191260af83205710d32561bbab5dafec0d872d2b54"
+}

--- a/src/rust/.sqlx/query-c9496ff3014e7c623e886775b92509d612190a3a4d101c05ddc84e1428a7faec.json
+++ b/src/rust/.sqlx/query-c9496ff3014e7c623e886775b92509d612190a3a4d101c05ddc84e1428a7faec.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n    *\nFROM\n    aggregator.spreads_last_indexed_timestamp\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "time",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c9496ff3014e7c623e886775b92509d612190a3a4d101c05ddc84e1428a7faec"
+}

--- a/src/rust/.sqlx/query-cc462e52c6ec09a136bf9357d4434ff325cd3a56926fa1e7829e552ab8eeac9c.json
+++ b/src/rust/.sqlx/query-cc462e52c6ec09a136bf9357d4434ff325cd3a56926fa1e7829e552ab8eeac9c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- We can assume that everything before this timestamp was indexed, since\n-- there's nothing to index.\nINSERT INTO aggregator.spreads_last_indexed_timestamp (\"time\")\nSELECT\n    DATE_TRUNC('minute', \"time\")\nFROM\n    place_limit_order_events\nORDER BY\n    \"time\"\nLIMIT 1\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "cc462e52c6ec09a136bf9357d4434ff325cd3a56926fa1e7829e552ab8eeac9c"
+}

--- a/src/rust/.sqlx/query-e30bb0204bdfd3aac19f247eff3245cadb89d8ff7b8d677a2aad9d37f60b7b8d.json
+++ b/src/rust/.sqlx/query-e30bb0204bdfd3aac19f247eff3245cadb89d8ff7b8d677a2aad9d37f60b7b8d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM aggregator.spreads_latest_event_timestamp;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "time",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "e30bb0204bdfd3aac19f247eff3245cadb89d8ff7b8d677a2aad9d37f60b7b8d"
+}

--- a/src/rust/aggregator/sqlx_queries/spreads/get_cancel_order_events_between_txn_versions.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_cancel_order_events_between_txn_versions.sql
@@ -1,0 +1,15 @@
+WITH parameters AS (
+    SELECT
+        $1::numeric(20,0) AS txn_version_start,
+        $2::numeric(20,0) AS txn_version_end
+)
+SELECT
+    market_id,
+    order_id
+FROM
+    cancel_order_events,
+    parameters
+WHERE
+    txn_version > txn_version_start
+AND
+    txn_version <= txn_version_end;

--- a/src/rust/aggregator/sqlx_queries/spreads/get_change_order_size_events_between_txn_versions.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_change_order_size_events_between_txn_versions.sql
@@ -1,0 +1,21 @@
+WITH parameters AS (
+    SELECT
+        $1::numeric(20,0) AS txn_version_start,
+        $2::numeric(20,0) AS txn_version_end
+)
+SELECT
+    txn_version,
+    event_idx,
+    market_id,
+    order_id,
+    new_size
+FROM
+    change_order_size_events,
+    parameters
+WHERE
+    txn_version > txn_version_start
+AND
+    txn_version <= txn_version_end
+ORDER BY
+    txn_version,
+    event_idx;

--- a/src/rust/aggregator/sqlx_queries/spreads/get_fill_events_between_txn_versions.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_fill_events_between_txn_versions.sql
@@ -1,0 +1,24 @@
+WITH parameters AS (
+    SELECT
+        $1::numeric(20,0) AS txn_version_start,
+        $2::numeric(20,0) AS txn_version_end
+)
+SELECT
+    txn_version,
+    event_idx,
+    market_id,
+    maker_order_id,
+    taker_order_id,
+    "size"
+FROM
+    fill_events,
+    parameters
+WHERE
+    txn_version > txn_version_start
+AND
+    txn_version <= txn_version_end
+AND
+    emit_address = maker_address
+ORDER BY
+    txn_version,
+    event_idx;

--- a/src/rust/aggregator/sqlx_queries/spreads/get_last_indexed_timestamp.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_last_indexed_timestamp.sql
@@ -1,0 +1,4 @@
+SELECT
+    *
+FROM
+    aggregator.spreads_last_indexed_timestamp

--- a/src/rust/aggregator/sqlx_queries/spreads/get_latest_event_timestamp.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_latest_event_timestamp.sql
@@ -1,0 +1,1 @@
+SELECT * FROM aggregator.spreads_latest_event_timestamp;

--- a/src/rust/aggregator/sqlx_queries/spreads/get_max_txn_version_before_timestamp.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_max_txn_version_before_timestamp.sql
@@ -1,0 +1,69 @@
+WITH max_place AS (
+    SELECT
+        txn_version
+    FROM
+        place_limit_order_events
+    WHERE
+        make_time_version("time", txn_version) < make_time_version($1, 0)
+    ORDER BY
+        make_time_version("time", txn_version) DESC
+    LIMIT 1
+),
+max_fill AS (
+    SELECT
+        txn_version
+    FROM
+        fill_events
+    WHERE
+        make_time_version("time", txn_version) < make_time_version($1, 0)
+    ORDER BY
+        make_time_version("time", txn_version) DESC
+    LIMIT 1
+),
+max_change AS (
+    SELECT
+        txn_version
+    FROM
+        change_order_size_events
+    WHERE
+        make_time_version("time", txn_version) < make_time_version($1, 0)
+    ORDER BY
+        make_time_version("time", txn_version) DESC
+    LIMIT 1
+),
+max_cancel AS (
+    SELECT
+        txn_version
+    FROM
+        cancel_order_events
+    WHERE
+        make_time_version("time", txn_version) < make_time_version($1, 0)
+    ORDER BY
+        make_time_version("time", txn_version) DESC
+    LIMIT 1
+),
+maxes AS (
+    SELECT
+        *
+    FROM
+        max_place
+    UNION
+    SELECT
+        *
+    FROM
+        max_fill
+    UNION
+    SELECT
+        *
+    FROM
+        max_change
+    UNION
+    SELECT
+        *
+    FROM
+        max_cancel
+)
+SELECT
+    MAX(txn_version) AS txn_version
+FROM
+    maxes;

--- a/src/rust/aggregator/sqlx_queries/spreads/get_place_limit_order_events_between_txn_versions.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/get_place_limit_order_events_between_txn_versions.sql
@@ -1,0 +1,18 @@
+WITH parameters AS (
+    SELECT
+        $1::numeric(20,0) AS txn_version_start,
+        $2::numeric(20,0) AS txn_version_end
+)
+SELECT
+    market_id,
+    order_id,
+    initial_size AS "size",
+    side,
+    price
+FROM
+    place_limit_order_events,
+    parameters
+WHERE
+    txn_version > txn_version_start
+AND
+    txn_version <= txn_version_end;

--- a/src/rust/aggregator/sqlx_queries/spreads/init_last_indexed_timestamp.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/init_last_indexed_timestamp.sql
@@ -1,0 +1,10 @@
+-- We can assume that everything before this timestamp was indexed, since
+-- there's nothing to index.
+INSERT INTO aggregator.spreads_last_indexed_timestamp ("time")
+SELECT
+    DATE_TRUNC('minute', "time")
+FROM
+    place_limit_order_events
+ORDER BY
+    "time"
+LIMIT 1

--- a/src/rust/aggregator/sqlx_queries/spreads/insert_spread.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/insert_spread.sql
@@ -1,0 +1,12 @@
+WITH parameters AS (
+    SELECT
+        $1::numeric(20,0) AS "market_id",
+        $2::timestamptz AS "time",
+        $3::numeric(20,0) AS min_ask,
+        $4::numeric(20,0) AS max_bid
+)
+INSERT INTO aggregator.spreads
+SELECT
+    *
+FROM
+    parameters;

--- a/src/rust/aggregator/sqlx_queries/spreads/update_last_indexed_timestamp.sql
+++ b/src/rust/aggregator/sqlx_queries/spreads/update_last_indexed_timestamp.sql
@@ -1,0 +1,8 @@
+WITH parameters AS (
+    SELECT
+        $1::timestamptz AS "time"
+)
+UPDATE aggregator.spreads_last_indexed_timestamp
+SET
+    "time" = parameters."time"
+FROM parameters

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -9,8 +9,8 @@ use anyhow::{anyhow, Result};
 use aptos_sdk::rest_client::AptosBaseUrl;
 use clap::{Parser, ValueEnum};
 use pipelines::{
-    Candlesticks, Coins, EnumeratedVolume, Fees, Leaderboards, OrderHistory, Prices, RefreshMaterializedView,
-    RollingVolume, Spreads, UserBalances, UserHistory,
+    Candlesticks, Coins, EnumeratedVolume, Fees, Leaderboards, OrderHistory, Prices,
+    RefreshMaterializedView, RollingVolume, Spreads, UserBalances, UserHistory,
 };
 use sqlx::Executor;
 use sqlx_postgres::PgPoolOptions;
@@ -298,9 +298,7 @@ async fn main() -> Result<()> {
             Pipelines::OrderHistory => {
                 data.push(Arc::new(Mutex::new(OrderHistory::new(pool.clone()))))
             }
-            Pipelines::Prices => {
-                data.push(Arc::new(Mutex::new(Prices::new(pool.clone()))))
-            }
+            Pipelines::Prices => data.push(Arc::new(Mutex::new(Prices::new(pool.clone())))),
             Pipelines::RollingVolume => {
                 data.push(Arc::new(Mutex::new(RollingVolume::new(pool.clone()))))
             }

--- a/src/rust/aggregator/src/main.rs
+++ b/src/rust/aggregator/src/main.rs
@@ -10,7 +10,7 @@ use aptos_sdk::rest_client::AptosBaseUrl;
 use clap::{Parser, ValueEnum};
 use pipelines::{
     Candlesticks, Coins, EnumeratedVolume, Fees, Leaderboards, OrderHistory, Prices, RefreshMaterializedView,
-    RollingVolume, UserBalances, UserHistory,
+    RollingVolume, Spreads, UserBalances, UserHistory,
 };
 use sqlx::Executor;
 use sqlx_postgres::PgPoolOptions;
@@ -57,6 +57,7 @@ pub enum Pipelines {
     OrderHistory,
     Prices,
     RollingVolume,
+    Spreads,
     TvlPerAsset,
     TvlPerMarket,
     UserBalances,
@@ -207,6 +208,7 @@ async fn main() -> Result<()> {
             Pipelines::RollingVolume,
             Pipelines::UserBalances,
             Pipelines::UserHistory,
+            Pipelines::Spreads,
             Pipelines::TvlPerAsset,
             Pipelines::TvlPerMarket,
         ];
@@ -302,11 +304,8 @@ async fn main() -> Result<()> {
             Pipelines::RollingVolume => {
                 data.push(Arc::new(Mutex::new(RollingVolume::new(pool.clone()))))
             }
-            Pipelines::UserBalances => {
-                data.push(Arc::new(Mutex::new(UserBalances::new(pool.clone()))));
-            }
-            Pipelines::UserHistory => {
-                data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
+            Pipelines::Spreads => {
+                data.push(Arc::new(Mutex::new(Spreads::new(pool.clone()))));
             }
             Pipelines::TvlPerAsset => {
                 data.push(Arc::new(Mutex::new(RefreshMaterializedView::new(
@@ -321,6 +320,12 @@ async fn main() -> Result<()> {
                     "aggregator.tvl_per_market",
                     Duration::from_secs(60),
                 ))));
+            }
+            Pipelines::UserBalances => {
+                data.push(Arc::new(Mutex::new(UserBalances::new(pool.clone()))));
+            }
+            Pipelines::UserHistory => {
+                data.push(Arc::new(Mutex::new(UserHistory::new(pool.clone()))));
             }
         }
     }

--- a/src/rust/aggregator/src/pipelines.rs
+++ b/src/rust/aggregator/src/pipelines.rs
@@ -5,9 +5,10 @@ pub mod fees;
 pub mod leaderboards;
 pub mod markets;
 pub mod order_history;
+pub mod prices;
 pub mod refresh_materialized_view;
 pub mod rolling_volume;
-pub mod prices;
+pub mod spreads;
 pub mod user_balances;
 pub mod user_history;
 
@@ -21,5 +22,6 @@ pub use order_history::OrderHistory;
 pub use prices::Prices;
 pub use refresh_materialized_view::RefreshMaterializedView;
 pub use rolling_volume::RollingVolume;
+pub use spreads::Spreads;
 pub use user_balances::UserBalances;
 pub use user_history::UserHistory;

--- a/src/rust/aggregator/src/pipelines/spreads.rs
+++ b/src/rust/aggregator/src/pipelines/spreads.rs
@@ -1,0 +1,373 @@
+use std::collections::HashMap;
+
+use bigdecimal::{BigDecimal, Zero};
+use chrono::{DateTime, Duration, Utc};
+use sqlx::{PgConnection, PgPool, Transaction};
+
+use aggregator::{util::*, Pipeline, PipelineAggregationResult, PipelineError};
+use sqlx_postgres::Postgres;
+
+use crate::MAX_BATCH_SIZE;
+
+pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+pub struct Spreads {
+    pool: PgPool,
+    last_indexed_timestamp: Option<DateTime<Utc>>,
+    state: Option<SpreadsState>,
+}
+
+impl Spreads {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            last_indexed_timestamp: None,
+            state: None,
+        }
+    }
+}
+
+type OrderKey = (BigDecimal, BigDecimal);
+
+#[derive(Clone)]
+struct SpreadsState {
+    orders: HashMap<OrderKey, Order>,
+    last_txn_indexed: BigDecimal,
+}
+
+impl SpreadsState {
+    pub fn new(last_txn: BigDecimal, orders: HashMap<OrderKey, Order>) -> Self {
+        Self {
+            last_txn_indexed: last_txn,
+            orders,
+        }
+    }
+}
+
+impl Default for SpreadsState {
+    fn default() -> Self {
+        Self {
+            orders: HashMap::new(),
+            last_txn_indexed: BigDecimal::zero(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Order {
+    market_id: BigDecimal,
+    order_id: BigDecimal,
+    size: BigDecimal,
+    side: bool,
+    price: BigDecimal,
+}
+
+struct Fill {
+    market_id: BigDecimal,
+    maker_order_id: BigDecimal,
+    taker_order_id: BigDecimal,
+    txn_version: BigDecimal,
+    event_idx: BigDecimal,
+    size: BigDecimal,
+}
+
+fn handle_fill(fill: &Fill, orders: &mut HashMap<OrderKey, Order>, index: &mut usize) {
+    *index += 1;
+    let order_key_maker = (fill.market_id.clone(), fill.maker_order_id.clone());
+    if let Some(order) = orders.get_mut(&order_key_maker) {
+        order.size -= fill.size.clone();
+        if order.size.is_zero() {
+            orders.remove(&order_key_maker);
+        }
+    }
+    let order_key_taker = (fill.market_id.clone(), fill.taker_order_id.clone());
+    if let Some(order) = orders.get_mut(&order_key_taker) {
+        order.size -= fill.size.clone();
+        if order.size.is_zero() {
+            orders.remove(&order_key_taker);
+        }
+    }
+}
+
+struct Change {
+    market_id: BigDecimal,
+    order_id: BigDecimal,
+    txn_version: BigDecimal,
+    event_idx: BigDecimal,
+    new_size: BigDecimal,
+}
+
+fn handle_change(change: &Change, orders: &mut HashMap<OrderKey, Order>, index: &mut usize) {
+    *index += 1;
+    let order_key = (change.market_id.clone(), change.order_id.clone());
+    if let Some(order) = orders.get_mut(&order_key) {
+        order.size = change.new_size.clone();
+        if order.size.is_zero() {
+            orders.remove(&order_key);
+        }
+    }
+}
+
+impl Spreads {
+    /// Given a previous state (and the last transaction version included in that state), computes
+    /// the new state at the given timestamp.
+    async fn get_state_from_timestamp_with_state<'a>(
+        &self,
+        mut orders: HashMap<OrderKey, Order>,
+        mut txn_version_of_state: BigDecimal,
+        timestamp: &DateTime<Utc>,
+        transaction: &mut Transaction<'a, Postgres>,
+    ) -> Result<SpreadsState, PipelineError> {
+        loop {
+            // Get the biggest transaction version that happened before the given timestamp.
+            let txn_version = sqlx::query_file!(
+                "sqlx_queries/spreads/get_max_txn_version_before_timestamp.sql",
+                timestamp
+            )
+            .fetch_one(transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?
+            .txn_version
+            .unwrap_or(BigDecimal::zero());
+
+            if txn_version == txn_version_of_state {
+                return Ok(SpreadsState::new(txn_version, orders));
+            }
+
+            // Limit the number of transactions that will be processed in one batch. Not limiting this
+            // could cause out of memory issues.
+            let txn_version =
+                (txn_version_of_state.clone() + BigDecimal::from(MAX_BATCH_SIZE)).min(txn_version);
+
+            // Get all place events that happened between the last transaction included in the previous
+            // state and the last transaction that happened before the given timestamp.
+            let places = sqlx::query_file_as!(
+                Order,
+                "sqlx_queries/spreads/get_place_limit_order_events_between_txn_versions.sql",
+                txn_version_of_state,
+                txn_version,
+            )
+            .fetch_all(transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+
+            // Get all fill events that happened between the last transaction included in the previous
+            // state and the last transaction that happened before the given timestamp.
+            let fills = sqlx::query_file_as!(
+                Fill,
+                "sqlx_queries/spreads/get_fill_events_between_txn_versions.sql",
+                txn_version_of_state,
+                txn_version
+            )
+            .fetch_all(transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+
+            // Get all change events that happened between the last transaction included in the previous
+            // state and the last transaction that happened before the given timestamp.
+            let changes = sqlx::query_file_as!(
+                Change,
+                "sqlx_queries/spreads/get_change_order_size_events_between_txn_versions.sql",
+                txn_version_of_state,
+                txn_version
+            )
+            .fetch_all(transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+
+            // Get all cancel events that happened between the last transaction included in the previous
+            // state and the last transaction that happened before the given timestamp.
+            let cancels = sqlx::query_file!(
+                "sqlx_queries/spreads/get_cancel_order_events_between_txn_versions.sql",
+                txn_version_of_state,
+                txn_version
+            )
+            .fetch_all(transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+
+            // Insert all places as orders into the state.
+            for place in places {
+                orders.insert((place.market_id.clone(), place.order_id.clone()), place);
+            }
+
+            // Remove all orders that have been cancelled.
+            for cancel in cancels {
+                orders.remove(&(cancel.market_id, cancel.order_id));
+            }
+
+            // Handle fills and changes chronologically.
+            let mut fills_index = 0;
+            let mut changes_index = 0;
+            for _ in 0..(fills.len() + changes.len()) {
+                let fill = fills.get(fills_index);
+                let change = changes.get(changes_index);
+                let (f, c) = match (fill, change) {
+                    (Some(fill), Some(change)) => {
+                        if (fill.txn_version.clone(), fill.event_idx.clone())
+                            < (change.txn_version.clone(), change.event_idx.clone())
+                        {
+                            (Some(fill), None)
+                        } else {
+                            (None, Some(change))
+                        }
+                    }
+                    (None, None) => unreachable!(),
+                    other => other,
+                };
+                match (f, c) {
+                    (Some(fill), None) => {
+                        handle_fill(fill, &mut orders, &mut fills_index);
+                    }
+                    (None, Some(change)) => {
+                        handle_change(change, &mut orders, &mut changes_index);
+                    }
+                    _ => unreachable!(),
+                };
+            }
+
+            txn_version_of_state = txn_version;
+        }
+    }
+    fn get_spreads_form_state<'a>(
+        &self,
+        orders: &HashMap<OrderKey, Order>,
+    ) -> (HashMap<BigDecimal, BigDecimal>, HashMap<BigDecimal, BigDecimal>) {
+
+        let mut min_asks: HashMap<BigDecimal, BigDecimal> = Default::default();
+        let mut max_bids: HashMap<BigDecimal, BigDecimal> = Default::default();
+
+        for element in orders.values().cloned() {
+            if element.side {
+                if let Some(min) = min_asks.get(&element.market_id).clone() {
+                    if min > &element.price {
+                        min_asks.insert(element.market_id, element.price);
+                    }
+                } else {
+                    min_asks.insert(element.market_id, element.price);
+                }
+            } else {
+                if let Some(max) = max_bids.get(&element.market_id).clone() {
+                    if max < &element.price {
+                        max_bids.insert(element.market_id, element.price);
+                    }
+                } else {
+                    max_bids.insert(element.market_id, element.price);
+                }
+            }
+        }
+
+        (min_asks, max_bids)
+    }
+}
+#[async_trait::async_trait]
+impl Pipeline for Spreads {
+    fn model_name(&self) -> String {
+        String::from("Spreads")
+    }
+
+    fn ready(&self) -> bool {
+        self.last_indexed_timestamp.is_none()
+            || self.last_indexed_timestamp.unwrap() + Duration::from_std(TIMEOUT).unwrap()
+                < Utc::now()
+    }
+
+    async fn process_and_save_historical_data(&mut self) -> PipelineAggregationResult {
+        self.process_and_save_internal().await
+    }
+
+    fn poll_interval(&self) -> Option<std::time::Duration> {
+        Some(TIMEOUT)
+    }
+
+    async fn process_and_save_internal(&mut self) -> PipelineAggregationResult {
+        let mut transaction = create_repeatable_read_transaction(&self.pool).await?;
+        let last_indexed_timestamp =
+            sqlx::query_file!("sqlx_queries/spreads/get_last_indexed_timestamp.sql")
+                .fetch_optional(&mut transaction as &mut PgConnection)
+                .await
+                .map_err(to_pipeline_error)?;
+        if last_indexed_timestamp.is_none() {
+            sqlx::query_file!("sqlx_queries/spreads/init_last_indexed_timestamp.sql")
+                .execute(&mut transaction as &mut PgConnection)
+                .await
+                .map_err(to_pipeline_error)?;
+        }
+        let last_indexed_timestamp =
+            sqlx::query_file!("sqlx_queries/spreads/get_last_indexed_timestamp.sql")
+                .fetch_optional(&mut transaction as &mut PgConnection)
+                .await
+                .map_err(to_pipeline_error)?;
+        if last_indexed_timestamp.is_none() {
+            return Ok(());
+        }
+        let last_indexed_timestamp = last_indexed_timestamp.unwrap().time;
+        let latest_event_timestamp =
+            sqlx::query_file!("sqlx_queries/spreads/get_latest_event_timestamp.sql")
+                .fetch_one(&mut transaction as &mut PgConnection)
+                .await
+                .map_err(to_pipeline_error)?
+                .time;
+        let latest_event_timestamp = if let Some(e) = latest_event_timestamp {
+            e
+        } else {
+            return Ok(());
+        };
+        let intervals = (latest_event_timestamp - last_indexed_timestamp).num_minutes() as usize;
+        let mut timestamps = Vec::with_capacity(intervals);
+        for i in 0..intervals {
+            timestamps.push(last_indexed_timestamp + chrono::Duration::minutes(i as i64 + 1));
+        }
+        if timestamps.len() == 0 {
+            return Ok(());
+        }
+        let mut state = self.state.clone().unwrap_or_default();
+        for timestamp in &timestamps {
+            state = if state.orders.is_empty() && state.last_txn_indexed == BigDecimal::zero() {
+                self.get_state_from_timestamp_with_state(
+                    state.orders,
+                    BigDecimal::zero(),
+                    timestamp,
+                    &mut transaction,
+                )
+                .await?
+            } else {
+                self.get_state_from_timestamp_with_state(
+                    state.orders,
+                    state.last_txn_indexed.clone(),
+                    timestamp,
+                    &mut transaction,
+                )
+                .await?
+            };
+            let (min_asks, max_bids) = self.get_spreads_form_state(&state.orders);
+            let mut markets = min_asks.keys().chain(max_bids.keys()).collect::<Vec<_>>();
+            markets.sort();
+            markets.dedup();
+            for market in markets {
+                sqlx::query_file!(
+                    "sqlx_queries/spreads/insert_spread.sql",
+                    market,
+                    timestamp,
+                    min_asks.get(market),
+                    max_bids.get(market),
+                )
+                .execute(&mut transaction as &mut PgConnection)
+                .await
+                .map_err(to_pipeline_error)?;
+            }
+        }
+        if let Some(last) = timestamps.last() {
+            sqlx::query_file!(
+                "sqlx_queries/spreads/update_last_indexed_timestamp.sql",
+                last,
+            )
+            .execute(&mut transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
+        }
+        commit_transaction(transaction).await?;
+        self.state = Some(state);
+        Ok(())
+    }
+}

--- a/src/rust/dbv2/migrations/2024-02-12-145642_spreads/down.sql
+++ b/src/rust/dbv2/migrations/2024-02-12-145642_spreads/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.spreads;
+DROP TABLE aggregator.spreads;
+DROP VIEW aggregator.spreads_latest_event_timestamp;
+DROP TABLE aggregator.spreads_last_indexed_timestamp;

--- a/src/rust/dbv2/migrations/2024-02-12-145642_spreads/up.sql
+++ b/src/rust/dbv2/migrations/2024-02-12-145642_spreads/up.sql
@@ -1,0 +1,41 @@
+-- Your SQL goes here
+CREATE TABLE aggregator.spreads (
+    "market_id" NUMERIC(20,0),
+    "time" TIMESTAMPTZ,
+    "min_ask" NUMERIC(20,0),
+    "max_bid" NUMERIC(20,0)
+);
+
+CREATE VIEW aggregator.spreads_latest_event_timestamp AS
+WITH place_max AS (
+    SELECT "time" FROM place_limit_order_events ORDER BY "time" DESC LIMIT 1
+), cancel_max AS (
+    SELECT "time" FROM cancel_order_events ORDER BY "time" DESC LIMIT 1
+),
+change_max AS (
+    SELECT "time" FROM change_order_size_events ORDER BY "time" DESC LIMIT 1
+),
+fill_max AS (
+    SELECT "time" FROM fill_events ORDER BY "time" DESC LIMIT 1
+),
+maxes AS (
+    SELECT * FROM place_max
+    UNION
+    SELECT * FROM cancel_max
+    UNION
+    SELECT * FROM change_max
+    UNION
+    SELECT * FROM fill_max
+)
+SELECT MAX("time") AS "time" FROM maxes;
+
+CREATE TABLE aggregator.spreads_last_indexed_timestamp (
+    "time" timestamptz PRIMARY KEY
+);
+
+CREATE VIEW api.spreads AS
+SELECT * FROM aggregator.spreads;
+
+GRANT SELECT ON api.spreads TO web_anon;
+GRANT SELECT ON aggregator.spreads TO grafana;
+GRANT SELECT ON api.spreads TO grafana;


### PR DESCRIPTION
This PR adds a new table that can be used to get min ask, max bid, spread and mid price.

# Example

```http
GET /spreads
```

```json
[
  {
    "market_id": 7,
    "time": "2023-12-26T08:11:00+00:00",
    "min_ask": 10990,
    "max_bid": 9510
  }
]
```
