### PR TITLE
[ECO-1301] Fix typo in config file

### DIFF
--- a/src/docker/example.env
+++ b/src/docker/example.env
@@ -41,5 +41,5 @@ GRPC_AUTH_TOKEN="<API_TOKEN>"
 STARTING_VERSION="154106802"
 
 # A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure.
-# Limits payload size for accidental or malious requests.
+# Limits payload size for accidental or malicious requests.
 POSTGREST_MAX_ROWS="100"


### PR DESCRIPTION
Change the word `malious` to `malicious`, introduced in #699