### PR TITLE
[ECO-1322] fix quoting issue in terraform script

### DIFF
--- a/src/terraform/dss-ci-cd/scripts/upload-base64-text-to-file.sh
+++ b/src/terraform/dss-ci-cd/scripts/upload-base64-text-to-file.sh
@@ -3,7 +3,7 @@
 (
     local encoded_text=$1
     local destination_path=$2
-    source scripts/run.sh "echo $encoded | \
+    source scripts/run.sh "echo \"$encoded\" | \
         base64 --decode | \
         sudo tee $destination_path >/dev/null"
 )


### PR DESCRIPTION
This PR fixes an issue with the script where the output of the `base64` command would be treated as multiple lines, and thus commands, by `bash`.