### PR TITLE
[ECO-1325] Escape quotes in hot upgrade script

### DIFF
--- a/src/terraform/dss-ci-cd/scripts/hot-upgrade.sh
+++ b/src/terraform/dss-ci-cd/scripts/hot-upgrade.sh
@@ -14,7 +14,7 @@
     local new_tfvars_encoded=$(echo $new_tfvars | base64)
     echo "Uploading variables, checking out revisions, redeploying..."
     source scripts/run.sh " \
-        echo $new_tfvars_encoded | base64 --decode | \
+        echo \"$new_tfvars_encoded\" | base64 --decode | \
             sudo tee dss/terraform.tfvars >/dev/null; \
         git fetch;
         git checkout $terraform_project_rev; \


### PR DESCRIPTION
Escape quotes in hot upgrade script for cross-platform usability