### PR TITLE
[ECO-1344] remove order-history from terraform aggregator args

### DIFF
--- a/src/terraform/dss-ci-cd/dss/modules/aggregator/main.tf
+++ b/src/terraform/dss-ci-cd/dss/modules/aggregator/main.tf
@@ -34,7 +34,6 @@ resource "terraform_data" "instance" {
       "gcloud compute instances create-with-container aggregator",
       "--container-env",
       join(",", [
-        "AGGREGATOR_INCLUDE=order-history",
         "APTOS_NETWORK=${var.aptos_network}",
         "DATABASE_URL=${var.db_conn_str_private}"
       ]),


### PR DESCRIPTION
Since the order history pipeline was removed, this needs to be removed from terraform as well.