### PR TITLE
[ECO-1332] allow egress traffic from cloud run

### DIFF
--- a/src/terraform/dss-ci-cd/dss/modules/db/main.tf
+++ b/src/terraform/dss-ci-cd/dss/modules/db/main.tf
@@ -140,10 +140,46 @@ resource "google_compute_subnetwork" "sql_connector_subnetwork" {
   network       = google_compute_network.sql_network.id
 }
 
+resource "google_project_service" "vpc" {
+  provider           = google-beta
+  service            = "vpcaccess.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_vpc_access_connector" "sql_vpc_connector" {
-  depends_on = [terraform_data.run_migrations]
+  depends_on = [terraform_data.run_migrations, google_project_service.vpc]
   name       = "sql-vpc-connector"
   subnet {
     name = google_compute_subnetwork.sql_connector_subnetwork.name
   }
 }
+
+resource "google_compute_router" "default" {
+  provider = google-beta
+  name     = "cr-static-ip-router"
+  network  = google_compute_network.sql_network.name
+  region   = google_compute_subnetwork.sql_connector_subnetwork.region
+}
+
+resource "google_compute_address" "default" {
+  provider = google-beta
+  name     = "cr-static-ip-addr"
+  region   = google_compute_subnetwork.sql_connector_subnetwork.region
+}
+
+resource "google_compute_router_nat" "default" {
+  provider = google-beta
+  name     = "cr-static-nat"
+  router   = google_compute_router.default.name
+  region   = google_compute_subnetwork.sql_connector_subnetwork.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = [google_compute_address.default.self_link]
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.sql_connector_subnetwork.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}
+

--- a/src/terraform/dss-ci-cd/dss/modules/grafana/main.tf
+++ b/src/terraform/dss-ci-cd/dss/modules/grafana/main.tf
@@ -42,7 +42,9 @@ resource "google_cloud_run_v2_service" "grafana" {
       connector = var.sql_vpc_connector_id
       egress    = "ALL_TRAFFIC"
     }
+
   }
+  ingress = "INGRESS_TRAFFIC_ALL"
 }
 
 # After Grafana starts, wait until HTTP API is available.


### PR DESCRIPTION
This PR makes it so that Grafana can make outbound requests thus allowing it to alert other platforms.