### PR TITLE
[ECO-1349] allow grafana to access tvl tables

### DIFF
--- a/src/rust/dbv2/migrations/2024-03-11-101756_grafana_allow_tvl/down.sql
+++ b/src/rust/dbv2/migrations/2024-03-11-101756_grafana_allow_tvl/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+REVOKE SELECT ON api.tvl_per_market FROM grafana;
+REVOKE SELECT ON api.tvl_per_asset FROM grafana;

--- a/src/rust/dbv2/migrations/2024-03-11-101756_grafana_allow_tvl/up.sql
+++ b/src/rust/dbv2/migrations/2024-03-11-101756_grafana_allow_tvl/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+GRANT SELECT ON api.tvl_per_market TO grafana;
+GRANT SELECT ON api.tvl_per_asset TO grafana;


### PR DESCRIPTION
In order to display graphs like vol/TVL, we need access to the TVL tables in Grafana.