### PR TITLE
[ECO-1359] Remove dead link to WebSockets Docs

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/gcp.md
+++ b/doc/doc-site/docs/off-chain/dss/gcp.md
@@ -714,7 +714,7 @@ ZONE=a-zone
    echo $WS_URL
    ```
 
-1. Monitor events using the [WebSockets listening script](./websocket.md):
+1. Monitor events using the WebSockets listening script:
 
    ```sh
    echo $WS_URL


### PR DESCRIPTION
Remove a dead link to WS docs from an old deployment guide