### PR TITLE
[ECO-1444] add MQTT over WS support

### DIFF
--- a/src/docker/compose.dss-core.yaml
+++ b/src/docker/compose.dss-core.yaml
@@ -52,6 +52,7 @@ services:
       MQTT_PASSWORD: ${MQTT_PASSWORD}
     ports:
       - "21883:21883"
+      - "21884:21884"
     restart: unless-stopped
 
   postgres:

--- a/src/docker/mqtt/mosquitto.conf
+++ b/src/docker/mqtt/mosquitto.conf
@@ -1,6 +1,18 @@
+per_listener_settings true
+
 listener 21883
 
 protocol mqtt
+
+allow_anonymous true
+
+password_file /password_file
+
+acl_file /acl_file
+
+listener 21884
+
+protocol websockets
 
 allow_anonymous true
 

--- a/src/terraform/dss-ci-cd/dss/modules/db/main.tf
+++ b/src/terraform/dss-ci-cd/dss/modules/db/main.tf
@@ -95,7 +95,7 @@ resource "google_compute_firewall" "default" {
 
   allow {
     protocol = "tcp"
-    ports    = ["21883"]
+    ports    = ["21883", "21884"]
   }
 
   source_ranges = ["0.0.0.0/0"]


### PR DESCRIPTION
This is needed so that browsers can subscribe to MQTT topics.