### PR TITLE
[ECO-1432] add all group by default

### DIFF
--- a/src/rust/.sqlx/query-16a97d275816539edd170312e678908210c38d52775966fb33ba2fe035713b96.json
+++ b/src/rust/.sqlx/query-16a97d275816539edd170312e678908210c38d52775966fb33ba2fe035713b96.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO aggregator.liquidity_groups (name, market_id)\nSELECT 'all', market_id FROM market_registration_events m WHERE NOT EXISTS (\n    SELECT *\n    FROM aggregator.liquidity_groups lg\n    WHERE lg.market_id = m.market_id\n    AND lg.name = 'all'\n);\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "16a97d275816539edd170312e678908210c38d52775966fb33ba2fe035713b96"
+}

--- a/src/rust/aggregator/sqlx_queries/order_history_pipelines/insert_new_liquidity_groups.sql
+++ b/src/rust/aggregator/sqlx_queries/order_history_pipelines/insert_new_liquidity_groups.sql
@@ -1,0 +1,7 @@
+INSERT INTO aggregator.liquidity_groups (name, market_id)
+SELECT 'all', market_id FROM market_registration_events m WHERE NOT EXISTS (
+    SELECT *
+    FROM aggregator.liquidity_groups lg
+    WHERE lg.market_id = m.market_id
+    AND lg.name = 'all'
+);

--- a/src/rust/aggregator/src/pipelines/order_history_pipelines.rs
+++ b/src/rust/aggregator/src/pipelines/order_history_pipelines.rs
@@ -453,6 +453,10 @@ impl Pipeline for OrderHistoryPipelines {
                 .map(|e| (e.address, e.group_id));
         let address_to_group = HashMap::from_iter(address_to_group);
 
+        sqlx::query_file!("sqlx_queries/order_history_pipelines/insert_new_liquidity_groups.sql")
+            .execute(&mut transaction as &mut PgConnection)
+            .await
+            .map_err(to_pipeline_error)?;
         let market_id_to_group =
             sqlx::query_file!("sqlx_queries/order_history_pipelines/get_liquidity_group_all.sql")
                 .fetch_all(&mut transaction as &mut PgConnection)


### PR DESCRIPTION
This PR makes it so that an 'æll' liquidity group is created by default.
