### PR TITLE
[ECO-1452] Add hot upgrade docs support

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -9,10 +9,11 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
    1. Bump changelog with PRs since last preparatory PR:
       1. In `econia` repo.
       1. In processor submodule.
+      1. Note if a hot upgrade is possible relative to the last release.
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
-## [v2.0.1]
+## [v2.0.1] (hot upgradable)
 
 ### Fixed
 

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -62,6 +62,7 @@ Before you start working with the DSS, make sure you are on the right branch and
 ```bash
 # From Econia repo root
 git checkout dss-stable
+git pull
 git submodule update --init --recursive
 ```
 
@@ -129,7 +130,6 @@ See the [changelog](./changelog.md) to verify that the latest release supports a
 1. Clean your Docker containers and image cache:
 
    ```bash
-   docker ps -aq | xargs docker stop | xargs docker rm
    docker system prune -af
    ```
 
@@ -141,13 +141,14 @@ See the [changelog](./changelog.md) to verify that the latest release supports a
 
    ```bash
    git checkout dss-stable
+   git pull
    git submodule update --init --recursive
    ```
 
 1. Restart the DSS:
 
    ```bash
-   docker compose --file src/docker/compose.dss-core.yaml up
+   docker compose --file src/docker/compose.dss-core.yaml up --force-recreate
    ```
 
 ### Verifying the DSS

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -109,6 +109,47 @@ Finally, to fully shut it down:
 docker compose --file src/docker/compose.dss-core.yaml down
 ```
 
+### Conducting a hot upgrade
+
+If you'd like to upgrade your DSS to the latest version without having to backfill the entire database, you can conduct a "hot upgrade".
+This process leverage's Docker compose' underlying capability to preserve database volumes across environment builds, so that you can recompile binaries without having to sync to chain tip for each new release.
+
+:::note
+The Econia Labs team strives to enable a hot upgrade for every DSS release (relative to the most recent release).
+Occasionally, however, upstream changes (like breaking changes to the Aptos indexing framework) may require backfilling from Move package genesis.
+See the [changelog](./changelog.md) to verify that the latest release supports a hot upgrade.
+:::
+
+1. Shut down the DSS
+
+   ```bash
+   docker compose --file src/docker/compose.dss-core.yaml down
+   ```
+
+1. Clean your Docker containers and image cache:
+
+   ```bash
+   docker ps -aq | xargs docker stop | xargs docker rm
+   docker system prune -af
+   ```
+
+   :::tip
+   This is similar to starting a DSS from scratch, but it preserves the `db` volume.
+   :::
+
+1. Check out the latest stable DSS source code:
+
+   ```bash
+   git checkout dss-stable
+   git submodule update --init --recursive
+   ```
+
+1. Restart the DSS:
+
+   ```bash
+   docker compose --file src/docker/compose.dss-core.yaml up
+   ```
+
 ### Verifying the DSS
 
 Verify that the database is accessible by navigating your browser to `http://0.0.0.0:3000`.

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -148,6 +148,7 @@ See the [changelog](./changelog.md) to verify that the latest release supports a
 1. Restart the DSS:
 
    ```bash
+   docker compose --file src/docker/compose.dss-core.yaml build --no-cache
    docker compose --file src/docker/compose.dss-core.yaml up --force-recreate
    ```
 


### PR DESCRIPTION
1. Add a hot upgrade section to the DSS landing page
2. Annotate v2.0.1 as hot upgradable
3. Update release procedure with hot upgrade step