### PR TITLE
[ECO-1451] strip leading zeros in handles

### DIFF
--- a/src/rust/dbv2/migrations/2024-03-22-105856_handle_leading_zeros/down.sql
+++ b/src/rust/dbv2/migrations/2024-03-22-105856_handle_leading_zeros/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+UPDATE balance_updates_by_handle SET handle = regexp_replace(handle, '0x', '0x0000000000000000000000000000000000000000000000000000000000000000');
+UPDATE balance_updates_by_handle SET handle = regexp_replace(handle, '^0x0*(.{64})$', '0x\1');
+UPDATE market_account_handles SET handle = regexp_replace(handle, '0x', '0x0000000000000000000000000000000000000000000000000000000000000000');
+UPDATE market_account_handles SET handle = regexp_replace(handle, '^0x0*(.{64})$', '0x\1');

--- a/src/rust/dbv2/migrations/2024-03-22-105856_handle_leading_zeros/up.sql
+++ b/src/rust/dbv2/migrations/2024-03-22-105856_handle_leading_zeros/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+UPDATE balance_updates_by_handle SET handle = regexp_replace(handle, '0x0*', '0x');
+UPDATE market_account_handles SET handle = regexp_replace(handle, '0x0*', '0x');


### PR DESCRIPTION
1. Add a migration to strip leading zeroes from event handles
2. Bump the submodule per https://github.com/econia-labs/aptos-indexer-processors/pull/25