### PR TITLE
[ECO-1478] update sdk to accept api key

### DIFF
--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -48,6 +48,9 @@ This package contains `EconiaClient`, which takes care of executing transactions
 These are not meant to be used without help from this Python SDK.
 Both are sufficiently capable to handle all possible functions to which they may apply, as long as those functions exist in the deployed Move contract code.
 
+Note that you can get an API key and add it using the [Aptos Developer Portal](https://developers.aptoslabs.com).
+You can then use this key when creating the `EconiaClient` to avoid being rate limited.
+
 ## `econia_sdk.types`
 
 This package contains various enum types useful for parsing and referring to important values.

--- a/doc/doc-site/docs/off-chain/rust-sdk.md
+++ b/doc/doc-site/docs/off-chain/rust-sdk.md
@@ -8,6 +8,7 @@ The SDK provides direct access to the Econia protocol, and comes with an example
 - The main struct of the SDK is `EconiaClient`.
   This allows you to submit transactions, query events and get a view client (`EconiaViewClient`).
   To create a new `EconiaClient`, you need a node URL, the Econia package address, an `aptos_sdk::types::LocalAccount`, and you can optionally pass a client config.
+  You can also pass an API key, that you can get on the [Aptos Developer Portal](https://developers.aptoslabs.com).
 
 - In `econia_sdk::entry`, you can find helper functions to create transactions for every entry function of the Econia package.
   These can then be submitted using the `EconiaClient::submit_tx`.

--- a/src/python/sdk/econia_sdk/lib.py
+++ b/src/python/sdk/econia_sdk/lib.py
@@ -19,14 +19,21 @@ class EconiaClient:
             econia: AccountAddress,
             account: Account,
             rest_client: Optional[RestClient] = None,
-            rest_client_async: Optional[AsyncRestClient] = None
+            rest_client_async: Optional[AsyncRestClient] = None,
+            node_api_key: Optional[str] = None
         ):
         self.econia_address = econia
         if rest_client == None and rest_client_async == None:
             self.aptos_client = RestClient(node_url)
+            if node_api_key != None:
+                self.aptos_client.client.headers["Authorization"] = f"Bearer {node_api_key}"
         elif rest_client != None:
+            if node_api_key != None:
+                rest_client.client.headers["Authorization"] = f"Bearer {node_api_key}"
             self.aptos_client = rest_client
         elif rest_client_async != None:
+            if node_api_key != None:
+                rest_client_async.client.headers["Authorization"] = f"Bearer {node_api_key}"
             self.aptos_client_async = rest_client_async
         self.user_account = account
 
@@ -59,9 +66,11 @@ class EconiaViewer:
     econia_address: AccountAddress
     aptos_client: RestClient
 
-    def __init__(self, node_url: str, econia: AccountAddress):
+    def __init__(self, node_url: str, econia: AccountAddress, node_api_key: Optional[str] = None):
         self.econia_address = econia
         self.aptos_client = RestClient(node_url)
+        if node_api_key != None:
+            self.aptos_client.client.headers["Authorization"] = f"Bearer {node_api_key}"
 
     def get_returns(
         self,

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "abstract-domain-derive"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,14 +82,14 @@ dependencies = [
  "env_logger",
  "log",
  "reqwest",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sqlx",
  "sqlx-postgres",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
  "url",
 ]
 
@@ -96,14 +106,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.10",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -208,29 +219,27 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-state-view",
- "aptos-table-natives",
+ "aptos-logger",
  "aptos-types",
  "bcs 0.1.4",
- "better_any",
+ "claims",
  "move-binary-format",
  "move-core-types",
- "once_cell",
- "smallvec",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-db-indexer",
  "aptos-framework",
  "aptos-logger",
  "aptos-openapi",
@@ -248,50 +257,59 @@ dependencies = [
  "poem",
  "poem-openapi",
  "poem-openapi-derive",
- "serde 1.0.188",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-drop-helper",
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-mvhashmap",
- "aptos-state-view",
  "aptos-types",
  "aptos-vm-logging",
+ "aptos-vm-types",
  "arc-swap",
  "bcs 0.1.4",
+ "bytes",
  "claims",
+ "concurrent-queue",
  "crossbeam",
  "dashmap",
+ "derivative",
+ "fail 0.5.1",
  "move-binary-format",
  "move-core-types",
+ "move-vm-types",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
+ "rand 0.7.3",
  "rayon",
+ "scopeguard",
+ "serde",
 ]
 
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -307,15 +325,17 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
+ "anyhow",
  "aptos-framework",
+ "aptos-package-builder",
  "aptos-types",
  "bcs 0.1.4",
  "include_dir 0.7.3",
@@ -326,7 +346,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -337,6 +357,7 @@ dependencies = [
  "aptos-short-hex-str",
  "aptos-temppath",
  "aptos-types",
+ "arr_macro",
  "bcs 0.1.4",
  "byteorder",
  "cfg-if",
@@ -345,9 +366,11 @@ dependencies = [
  "maplit",
  "mirai-annotations",
  "num_cpus",
+ "number_range",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.188",
+ "serde",
+ "serde_json",
  "serde_merge",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -357,13 +380,15 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-crypto-derive",
+ "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-std",
+ "base64 0.13.1",
  "bcs 0.1.4",
  "blst",
  "bulletproofs",
@@ -377,17 +402,20 @@ dependencies = [
  "libsecp256k1",
  "merlin",
  "more-asserts",
+ "num-bigint 0.3.3",
+ "num-integer",
  "once_cell",
- "proptest",
- "proptest-derive",
+ "p256",
+ "poseidon-ark",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "serde 1.0.188",
+ "serde",
  "serde-name",
  "serde_bytes",
  "sha2 0.10.8",
  "sha2 0.9.9",
+ "signature 2.1.0",
  "static_assertions",
  "thiserror",
  "tiny-keccak",
@@ -397,17 +425,70 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "aptos-db-indexer"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "aptos-config",
+ "aptos-crypto",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-metrics-core",
+ "aptos-rocksdb-options",
+ "aptos-schemadb",
+ "aptos-scratchpad",
+ "aptos-storage-interface",
+ "aptos-types",
+ "aptos-vm",
+ "bcs 0.1.4",
+ "byteorder",
+ "bytes",
+ "dashmap",
+ "move-core-types",
+ "move-resource-viewer",
+ "num-derive",
+ "serde",
+]
+
+[[package]]
+name = "aptos-drop-helper"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
+ "aptos-metrics-core",
+ "once_cell",
+ "threadpool",
+]
+
+[[package]]
+name = "aptos-experimental-runtimes"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "aptos-runtimes",
+ "core_affinity",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "tokio",
 ]
 
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -417,10 +498,11 @@ dependencies = [
  "aptos-move-stdlib",
  "aptos-native-interface",
  "aptos-sdk-builder",
- "aptos-state-view",
  "aptos-table-natives",
  "aptos-types",
+ "aptos-vm-types",
  "ark-bls12-381",
+ "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
@@ -442,8 +524,10 @@ dependencies = [
  "itertools 0.10.5",
  "libsecp256k1",
  "log",
+ "lru",
  "merlin",
  "move-binary-format",
+ "move-cli",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
@@ -456,13 +540,13 @@ dependencies = [
  "move-stackless-bytecode",
  "move-vm-runtime",
  "move-vm-types",
- "num-traits 0.2.16",
+ "num-traits",
  "once_cell",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
  "ripemd",
- "serde 1.0.188",
+ "serde",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -479,7 +563,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "either",
  "move-core-types",
@@ -488,13 +572,14 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-logger",
  "aptos-types",
  "aptos-vm-types",
+ "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
@@ -503,7 +588,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -512,22 +597,23 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "paste",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -541,17 +627,17 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -563,23 +649,24 @@ dependencies = [
  "hostname",
  "once_cell",
  "prometheus",
- "serde 1.0.188",
+ "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
  "aptos-types",
+ "aptos-vm-types",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
@@ -588,7 +675,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -597,7 +684,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -623,26 +710,35 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-crypto",
  "aptos-infallible",
  "aptos-types",
+ "aptos-vm-types",
  "bcs 0.1.4",
+ "bytes",
+ "claims",
  "crossbeam",
  "dashmap",
+ "derivative",
+ "move-binary-format",
+ "move-core-types",
+ "serde",
 ]
 
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-types",
+ "bcs 0.1.4",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
@@ -653,7 +749,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -665,20 +761,46 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "async-trait",
  "percent-encoding",
  "poem",
  "poem-openapi",
- "serde 1.0.188",
+ "serde",
  "serde_json",
+]
+
+[[package]]
+name = "aptos-package-builder"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "aptos-framework",
+ "itertools 0.10.5",
+ "move-command-line-common",
+ "move-package",
+ "tempfile",
+]
+
+[[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost",
+ "prost-types",
+ "serde",
+ "tonic",
 ]
 
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -694,7 +816,7 @@ dependencies = [
  "move-core-types",
  "poem-openapi",
  "reqwest",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -704,19 +826,56 @@ dependencies = [
 [[package]]
 name = "aptos-retrier"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-logger",
  "tokio",
 ]
 
 [[package]]
+name = "aptos-rocksdb-options"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "aptos-config",
+ "rocksdb",
+]
+
+[[package]]
+name = "aptos-runtimes"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "rayon",
+ "tokio",
+]
+
+[[package]]
+name = "aptos-schemadb"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-metrics-core",
+ "aptos-storage-interface",
+ "dunce",
+ "once_cell",
+ "rand 0.7.3",
+ "rocksdb",
+]
+
+[[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-crypto",
+ "aptos-drop-helper",
+ "aptos-experimental-runtimes",
  "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bitvec 1.0.1",
@@ -729,7 +888,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -743,25 +902,25 @@ dependencies = [
  "ed25519-dalek-bip32",
  "move-core-types",
  "rand_core 0.5.1",
- "serde 1.0.188",
+ "serde",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-types",
  "bcs 0.1.4",
  "clap 4.4.6",
- "heck 0.3.3",
+ "heck 0.4.1",
  "move-core-types",
  "once_cell",
  "regex",
  "serde-generate",
- "serde-reflection 0.3.5",
+ "serde-reflection",
  "serde_yaml 0.8.26",
  "textwrap 0.15.2",
 ]
@@ -769,22 +928,26 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-protos",
  "aptos-retrier",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
- "serde 1.0.188",
+ "serde",
  "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-reflection",
 ]
 
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -798,7 +961,7 @@ dependencies = [
  "chrono",
  "enum_dispatch",
  "rand 0.7.3",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -806,10 +969,10 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "mirai-annotations",
- "serde 1.0.188",
+ "serde",
  "static_assertions",
  "thiserror",
 ]
@@ -817,7 +980,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -827,56 +990,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-state-view"
-version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
-dependencies = [
- "anyhow",
- "aptos-crypto",
- "aptos-types",
- "bcs 0.1.4",
- "serde 1.0.188",
- "serde_bytes",
- "serde_json",
-]
-
-[[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-experimental-runtimes",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",
- "aptos-state-view",
  "aptos-types",
  "aptos-vm",
  "arr_macro",
  "bcs 0.1.4",
+ "bytes",
  "crossbeam-channel",
  "dashmap",
  "itertools 0.10.5",
  "move-core-types",
  "once_cell",
  "parking_lot 0.12.1",
+ "proptest",
+ "proptest-derive",
  "rayon",
- "serde 1.0.188",
+ "rocksdb",
+ "serde",
  "thiserror",
+ "threadpool",
 ]
 
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
  "aptos-native-interface",
  "aptos-types",
  "better_any",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
@@ -890,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -899,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -912,31 +1067,47 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
+ "aptos-experimental-runtimes",
+ "ark-bn254",
+ "ark-ff",
+ "ark-groth16",
+ "ark-serialize",
  "arr_macro",
+ "base64 0.13.1",
  "bcs 0.1.4",
+ "bytes",
  "chrono",
  "derivative",
  "hex",
  "itertools 0.10.5",
+ "jsonwebtoken",
+ "move-binary-format",
  "move-core-types",
  "move-table-extension",
+ "move-vm-types",
+ "num-bigint 0.3.3",
  "num-derive",
- "num-traits 0.2.16",
+ "num-traits",
  "once_cell",
- "proptest",
- "proptest-derive",
+ "passkey-types",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.188",
+ "ring",
+ "rsa",
+ "serde",
+ "serde-big-array",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "serde_yaml 0.8.26",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
  "tiny-keccak",
 ]
@@ -944,19 +1115,19 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
  "chrono",
  "native-tls",
  "once_cell",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "thiserror",
  "ureq",
@@ -965,14 +1136,16 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-bitvec",
  "aptos-block-executor",
  "aptos-block-partitioner",
  "aptos-crypto",
  "aptos-crypto-derive",
+ "aptos-experimental-runtimes",
  "aptos-framework",
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -984,30 +1157,33 @@ dependencies = [
  "aptos-move-stdlib",
  "aptos-mvhashmap",
  "aptos-native-interface",
- "aptos-state-view",
  "aptos-table-natives",
  "aptos-types",
  "aptos-utils",
  "aptos-vm-logging",
  "aptos-vm-types",
+ "base64-url",
  "bcs 0.1.4",
+ "bytes",
+ "claims",
  "crossbeam-channel",
  "dashmap",
  "fail 0.5.1",
  "futures",
+ "hex",
+ "jsonwebtoken",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-core-types",
  "move-vm-runtime",
- "move-vm-test-utils",
  "move-vm-types",
  "num_cpus",
  "once_cell",
  "ouroboros 0.15.6",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "smallvec",
  "tracing",
@@ -1016,43 +1192,36 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-speculative-state-helper",
- "aptos-state-view",
  "aptos-types",
  "arc-swap",
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-gas-algebra",
  "aptos-gas-schedule",
- "aptos-state-view",
  "aptos-types",
  "bcs 0.1.4",
+ "bytes",
+ "claims",
  "either",
  "move-binary-format",
  "move-core-types",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
-dependencies = [
- "derive_arbitrary",
+ "rand 0.7.3",
+ "serde",
 ]
 
 [[package]]
@@ -1074,6 +1243,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2",
+ "derivative",
+ "digest 0.10.7",
+ "rayon",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1285,8 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits 0.2.16",
+ "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -1103,9 +1303,10 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
- "num-traits 0.2.16",
+ "num-bigint 0.4.4",
+ "num-traits",
  "paste",
+ "rayon",
  "rustc_version",
  "zeroize",
 ]
@@ -1116,7 +1317,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1126,11 +1327,27 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
- "num-traits 0.2.16",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "rayon",
 ]
 
 [[package]]
@@ -1144,6 +1361,19 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
+ "rayon",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "tracing",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -1155,7 +1385,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.4",
 ]
 
 [[package]]
@@ -1164,9 +1394,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
+dependencies = [
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -1175,8 +1417,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
  "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]
@@ -1197,7 +1440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6368f9ae5c6ec403ca910327ae0c9437b0a85255b6950c90d497e6177f6e5e"
 dependencies = [
  "proc-macro-hack",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1229,13 +1472,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1251,7 +1516,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -1273,7 +1538,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -1294,6 +1559,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,15 +1632,18 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64-url"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9fb9fb058cc3063b5fc88d9a21eefa2735871498a04e1650da76ed511c8569"
+dependencies = [
+ "base64 0.21.4",
+]
 
 [[package]]
 name = "base64ct"
@@ -1337,7 +1656,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "thiserror",
 ]
 
@@ -1347,7 +1666,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "thiserror",
 ]
 
@@ -1366,8 +1685,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1377,10 +1696,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-integer",
- "num-traits 0.2.16",
- "serde 1.0.188",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1389,7 +1708,28 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.188",
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1419,7 +1759,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1453,6 +1793,15 @@ dependencies = [
  "radium 0.7.0",
  "tap",
  "wyz 0.5.1",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1509,7 +1858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1525,7 +1874,7 @@ dependencies = [
  "merlin",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde 1.0.188",
+ "serde",
  "serde_derive",
  "sha3",
  "subtle-ng",
@@ -1555,6 +1904,20 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "c_linked_list"
@@ -1563,12 +1926,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1592,8 +1971,8 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.16",
- "serde 1.0.188",
+ "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -1627,6 +2006,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +2049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6995bbe186456c36307f8ea36be3eefe42f49d106896414e18efc4fb2f846b5"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1689,8 +2106,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1716,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1725,7 +2142,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -1743,24 +2160,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
- "lazy_static 1.4.0",
+ "lazy_static",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "config"
-version = "0.11.0"
+name = "combine"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "lazy_static 1.4.0",
- "nom 5.1.3",
- "rust-ini",
- "serde 1.0.188",
- "serde-hjson",
- "serde_json",
- "toml",
- "yaml-rust",
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1770,7 +2190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "unicode-width",
  "windows-sys 0.45.0",
@@ -1800,8 +2220,19 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
  "aes-gcm",
- "base64 0.20.0",
+ "base64 0.21.4",
  "hkdf 0.12.3",
  "hmac 0.12.1",
  "percent-encoding",
@@ -1818,11 +2249,11 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
 dependencies = [
- "cookie",
+ "cookie 0.16.2",
  "idna 0.2.3",
  "log",
  "publicsuffix",
- "serde 1.0.188",
+ "serde",
  "serde_derive",
  "serde_json",
  "time",
@@ -1844,6 +2275,27 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "coset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c7f688ee58418b8614848a05bf392cc622f92451e79998c131b9d22c91abd9"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1946,10 +2398,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -2013,7 +2518,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "serde 1.0.188",
+ "serde",
  "subtle-ng",
  "zeroize",
 ]
@@ -2024,8 +2529,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -2036,10 +2551,24 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2048,9 +2577,20 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
- "quote 1.0.33",
+ "darling_core 0.14.4",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core 0.20.8",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2060,7 +2600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -2079,7 +2619,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "diesel",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sqlx",
 ]
@@ -2100,6 +2640,9 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "derivation-path"
@@ -2113,20 +2656,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
-dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
 ]
 
 [[package]]
@@ -2136,8 +2668,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -2160,9 +2692,9 @@ dependencies = [
  "chrono",
  "diesel_derives",
  "itoa",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-integer",
- "num-traits 0.2.16",
+ "num-traits",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -2175,8 +2707,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
  "diesel_table_macro_syntax",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2217,15 +2749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,17 +2756,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2270,6 +2782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "e2e"
 version = "0.1.0"
 dependencies = [
@@ -2284,7 +2802,7 @@ dependencies = [
  "metadata",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sqlx",
  "tokio",
@@ -2294,21 +2812,36 @@ dependencies = [
 name = "e2e-proc-macro"
 version = "0.1.0"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.1.0",
+ "spki",
 ]
 
 [[package]]
 name = "econia-sdk"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "aptos-api-types",
  "aptos-sdk",
  "econia-types",
  "futures",
  "hex",
  "reqwest",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_yaml 0.9.25",
  "thiserror",
@@ -2319,7 +2852,7 @@ name = "econia-types"
 version = "1.0.0"
 dependencies = [
  "chrono",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sqlx",
  "thiserror",
@@ -2331,7 +2864,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "signature 1.6.4",
 ]
 
@@ -2344,7 +2877,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.188",
+ "serde",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -2368,7 +2901,27 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
- "serde 1.0.188",
+ "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2393,8 +2946,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2423,7 +2976,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -2476,7 +3029,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "rand 0.7.3",
 ]
@@ -2497,6 +3050,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -2523,12 +3086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +3093,22 @@ checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469e584c031833564840fb0cdbce99bdfe946fd45480a188545e73a76f45461c"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "lazy_static",
+ "log",
+ "nu-ansi-term 0.49.0",
+ "regex",
+ "thiserror",
 ]
 
 [[package]]
@@ -2580,12 +3153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,9 +3166,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2614,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2624,15 +3191,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2652,38 +3219,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2711,6 +3278,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2806,6 +3374,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +3404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,16 +3428,16 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -2858,7 +3447,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2923,6 +3512,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hidapi"
@@ -3089,6 +3681,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,7 +3772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
  "globset",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "memchr",
  "regex",
@@ -3207,7 +3811,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3216,8 +3820,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3250,8 +3854,8 @@ checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3261,8 +3865,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3273,6 +3877,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3282,7 +3887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3378,22 +3984,30 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.3.2"
+version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
 [[package]]
 name = "jemallocator"
-version = "0.3.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
  "libc",
 ]
 
@@ -3407,6 +4021,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.4",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,18 +4045,18 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "ledger-apdu"
@@ -3468,29 +4096,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -3506,7 +4147,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -3552,6 +4193,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,7 +4231,26 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
- "serde 1.0.188",
+ "serde",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -3608,6 +4279,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -3677,6 +4354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -3696,7 +4374,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3707,13 +4385,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3721,19 +4399,19 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "ref-cast",
- "serde 1.0.188",
+ "serde",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3742,48 +4420,112 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "petgraph 0.5.1",
- "serde-reflection 0.3.6",
+ "petgraph",
+ "serde-reflection",
 ]
 
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
- "petgraph 0.5.1",
+ "petgraph",
+ "serde",
  "typed-arena",
+]
+
+[[package]]
+name = "move-bytecode-viewer"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "clap 4.4.6",
+ "crossterm 0.26.1",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-disassembler",
+ "move-ir-types",
+ "regex",
+ "tui",
+]
+
+[[package]]
+name = "move-cli"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "bytes",
+ "clap 4.4.6",
+ "codespan-reporting",
+ "colored",
+ "difference",
+ "itertools 0.10.5",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
+ "move-bytecode-viewer",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-disassembler",
+ "move-docgen",
+ "move-errmapgen",
+ "move-ir-types",
+ "move-model",
+ "move-package",
+ "move-prover",
+ "move-resource-viewer",
+ "move-stdlib",
+ "move-symbol-pool",
+ "move-unit-test",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "tempfile",
+ "toml_edit 0.14.4",
+ "walkdir",
 ]
 
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "difference",
  "dirs-next",
  "hex",
  "move-core-types",
- "num-bigint",
+ "num-bigint 0.4.4",
  "once_cell",
- "serde 1.0.188",
+ "serde",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -3791,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3808,9 +4550,9 @@ dependencies = [
  "move-ir-to-bytecode",
  "move-ir-types",
  "move-symbol-pool",
- "num-bigint",
+ "num-bigint 0.4.4",
  "once_cell",
- "petgraph 0.5.1",
+ "petgraph",
  "regex",
  "sha3",
  "tempfile",
@@ -3820,47 +4562,51 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
+ "abstract-domain-derive",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.4.6",
  "codespan",
  "codespan-reporting",
  "ethnum",
+ "flexi_logger",
+ "im",
  "itertools 0.10.5",
+ "log",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
+ "move-disassembler",
  "move-ir-types",
  "move-model",
  "move-stackless-bytecode",
  "move-symbol-pool",
  "num",
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
- "arbitrary",
  "bcs 0.1.4",
+ "bytes",
  "ethnum",
+ "hashbrown 0.14.3",
  "hex",
  "num",
  "once_cell",
  "primitive-types",
- "proptest",
- "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.188",
+ "serde",
  "serde_bytes",
  "thiserror",
  "uint",
@@ -3869,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3882,14 +4628,14 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "once_cell",
- "petgraph 0.5.1",
- "serde 1.0.188",
+ "petgraph",
+ "serde",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "clap 4.4.6",
@@ -3907,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3920,13 +4666,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3934,13 +4680,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3959,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "hex",
@@ -3972,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "hex",
@@ -3980,13 +4726,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4004,16 +4750,17 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "num",
+ "num-traits",
  "once_cell",
  "regex",
- "serde 1.0.188",
+ "serde",
  "trace",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4034,11 +4781,10 @@ dependencies = [
  "move-symbol-pool",
  "named-lock",
  "once_cell",
- "petgraph 0.5.1",
- "ptree",
+ "petgraph",
  "regex",
  "reqwest",
- "serde 1.0.188",
+ "serde",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
@@ -4051,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4079,7 +4825,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "simplelog",
  "tokio",
@@ -4089,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4110,7 +4856,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "tera",
  "tokio",
@@ -4119,8 +4865,9 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
+ "abstract-domain-derive",
  "anyhow",
  "async-trait",
  "atty",
@@ -4139,7 +4886,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "simplelog",
  "tokio",
@@ -4149,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4158,14 +4905,15 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
+ "abstract-domain-derive",
  "codespan",
  "codespan-reporting",
  "ethnum",
@@ -4183,27 +4931,51 @@ dependencies = [
  "num",
  "once_cell",
  "paste",
- "petgraph 0.5.1",
- "serde 1.0.188",
+ "petgraph",
+ "serde",
+]
+
+[[package]]
+name = "move-stdlib"
+version = "0.1.1"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "hex",
+ "log",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
+ "move-errmapgen",
+ "move-prover",
+ "move-vm-runtime",
+ "move-vm-types",
+ "sha2 0.9.9",
+ "sha3",
+ "smallvec",
+ "walkdir",
 ]
 
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "better_any",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
@@ -4214,47 +4986,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-unit-test"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
+dependencies = [
+ "anyhow",
+ "better_any",
+ "bytes",
+ "clap 4.4.6",
+ "codespan-reporting",
+ "colored",
+ "itertools 0.10.5",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-model",
+ "move-resource-viewer",
+ "move-stdlib",
+ "move-symbol-pool",
+ "move-table-extension",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
+ "once_cell",
+ "rayon",
+ "regex",
+]
+
+[[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "better_any",
+ "bytes",
  "fail 0.4.0",
+ "hashbrown 0.14.3",
+ "lazy_static",
+ "lru",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
  "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",
+ "serde",
  "sha3",
+ "smallbitvec",
  "tracing",
+ "triomphe",
+ "typed-arena",
 ]
 
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "anyhow",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
  "move-vm-types",
  "once_cell",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.7.2#6bddb7790e24b13e45a67e7f044560d0d958b824"
+source = "git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.10.1#4174fd615d442ccac6e5d77db00ba693d0d57108"
 dependencies = [
  "bcs 0.1.4",
+ "derivative",
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.188",
+ "serde",
+ "smallbitvec",
  "smallvec",
+ "triomphe",
 ]
 
 [[package]]
@@ -4264,7 +5079,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "rumqttc",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sqlx",
  "sqlx-postgres",
@@ -4310,7 +5125,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -4320,6 +5135,17 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4333,17 +5159,6 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
 
 [[package]]
 name = "nom"
@@ -4366,17 +5181,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.16",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -4387,7 +5223,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4397,11 +5233,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
  "byteorder",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
- "num-traits 0.2.16",
+ "num-traits",
  "rand 0.8.5",
  "smallvec",
  "zeroize",
@@ -4413,7 +5249,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4422,8 +5258,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4434,7 +5270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4445,7 +5281,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4455,18 +5291,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-integer",
- "num-traits 0.2.16",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4494,6 +5321,17 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "number_range"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60080faccd4ca50ad0b801b2be686136376b13f691f6eac84817e40973b2e1bb"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "num",
+]
 
 [[package]]
 name = "object"
@@ -4537,8 +5375,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4558,15 +5396,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -4597,8 +5426,8 @@ checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4610,8 +5439,8 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4620,6 +5449,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -4632,7 +5473,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -4641,9 +5482,9 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4705,10 +5546,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "passkey-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499cff8432e71c5f8784d9645aac0f9fca604d67f59b68a606170b5e229c6538"
+dependencies = [
+ "bitflags 2.4.0",
+ "ciborium",
+ "coset",
+ "data-encoding",
+ "indexmap 2.0.2",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "strum 0.25.0",
+ "typeshare",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pbjson"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -4717,6 +5587,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
  "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4763,8 +5648,8 @@ checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4785,18 +5670,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset",
  "indexmap 1.9.3",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.0.2",
 ]
 
 [[package]]
@@ -4862,8 +5737,8 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4908,30 +5783,31 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "poem"
-version = "1.3.55"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0608069d4999c3c02d49dff261663f2e73a8f7b00b7cd364fb5e93e419dafa1"
+checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
- "cookie",
+ "cookie 0.17.0",
  "futures-util",
  "headers",
  "http",
  "hyper",
  "mime",
  "multer",
+ "nix",
  "parking_lot 0.12.1",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
- "quick-xml 0.26.0",
+ "quick-xml 0.30.0",
  "regex",
  "rfc7239",
  "rustls-pemfile",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
@@ -4939,21 +5815,22 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "wildmatch",
 ]
 
 [[package]]
 name = "poem-derive"
-version = "1.3.58"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2550a0bce7273b278894ef3ccc5a6869e7031b6870042f3cc6826ed9faa980a6"
+checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro-crate 2.0.2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4968,12 +5845,12 @@ dependencies = [
  "derive_more",
  "futures-util",
  "mime",
- "num-traits 0.2.16",
+ "num-traits",
  "poem",
  "poem-openapi-derive",
  "quick-xml 0.23.1",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.25",
@@ -4988,13 +5865,13 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "http",
  "indexmap 1.9.3",
  "mime",
- "proc-macro-crate",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
  "regex",
  "syn 1.0.109",
  "thiserror",
@@ -5017,6 +5894,16 @@ name = "portable-atomic"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+
+[[package]]
+name = "poseidon-ark"
+version = "0.0.1"
+source = "git+https://github.com/arnaucube/poseidon-ark.git?rev=6d2487aa1308d9d3860a2b724c485d73095c1c68#6d2487aa1308d9d3860a2b724c485d73095c1c68"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "ark-std",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -5044,6 +5931,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5062,7 +5968,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -5072,8 +5988,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -5084,8 +6000,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "version_check",
 ]
 
@@ -5100,15 +6016,6 @@ name = "proc-macro-nested"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -5127,7 +6034,7 @@ checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
  "cfg-if",
  "fnv",
- "lazy_static 1.4.0",
+ "lazy_static",
  "memchr",
  "parking_lot 0.12.1",
  "thiserror",
@@ -5135,19 +6042,19 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.4.0",
- "lazy_static 1.4.0",
- "num-traits 0.2.16",
+ "lazy_static",
+ "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.3",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5155,13 +6062,45 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5169,22 +6108,6 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "ptree"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
-dependencies = [
- "ansi_term",
- "atty",
- "config",
- "directories",
- "petgraph 0.6.4",
- "serde 1.0.188",
- "serde-value",
- "tint",
-]
 
 [[package]]
 name = "publicsuffix"
@@ -5218,26 +6141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
- "serde 1.0.188",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "serde",
 ]
 
 [[package]]
@@ -5246,7 +6160,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.67",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -5425,8 +6339,8 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -5475,6 +6389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "reqwest"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5482,7 +6402,7 @@ checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.4",
  "bytes",
- "cookie",
+ "cookie 0.16.2",
  "cookie_store",
  "encoding_rs",
  "futures-core",
@@ -5500,7 +6420,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
@@ -5514,6 +6434,16 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -5550,18 +6480,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.2"
+name = "rocksdb"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
- "byteorder",
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
  "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
- "num-traits 0.2.16",
+ "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
@@ -5588,16 +6526,10 @@ dependencies = [
  "rustls-webpki",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "url",
  "ws_stream_tungstenite",
 ]
-
-[[package]]
-name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -5637,18 +6569,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -5775,6 +6695,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,47 +6739,38 @@ checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
-version = "1.0.188"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-generate"
 version = "0.20.6"
-source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
+source = "git+https://github.com/aptos-labs/serde-reflection?rev=73b6bbf748334b71ff6d7d09d06a29e3062ca075#73b6bbf748334b71ff6d7d09d06a29e3062ca075"
 dependencies = [
  "bcs 0.1.5",
  "bincode",
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.188",
- "serde-reflection 0.3.5",
+ "serde",
+ "serde-reflection",
  "serde_bytes",
  "serde_yaml 0.8.26",
  "structopt",
  "textwrap 0.13.4",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static 1.4.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -5854,39 +6779,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "serde-reflection"
 version = "0.3.5"
-source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
+source = "git+https://github.com/aptos-labs/serde-reflection?rev=73b6bbf748334b71ff6d7d09d06a29e3062ca075#73b6bbf748334b71ff6d7d09d06a29e3062ca075"
 dependencies = [
  "once_cell",
- "serde 1.0.188",
+ "serde",
  "thiserror",
-]
-
-[[package]]
-name = "serde-reflection"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
-dependencies = [
- "once_cell",
- "serde 1.0.188",
- "thiserror",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde 1.0.188",
 ]
 
 [[package]]
@@ -5895,17 +6799,17 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -5918,7 +6822,7 @@ dependencies = [
  "indexmap 2.0.2",
  "itoa",
  "ryu",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -5927,7 +6831,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -5941,7 +6845,37 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.188",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+dependencies = [
+ "base64 0.21.4",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+dependencies = [
+ "darling 0.20.8",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5952,7 +6886,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.188",
+ "serde",
  "yaml-rust",
 ]
 
@@ -5965,7 +6899,7 @@ dependencies = [
  "indexmap 2.0.2",
  "itoa",
  "ryu",
- "serde 1.0.188",
+ "serde",
  "unsafe-libyaml",
 ]
 
@@ -6022,7 +6956,34 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -6048,6 +7009,18 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -6096,6 +7069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallbitvec"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3fc564a4b53fd1e8589628efafe57602d91bde78be18186b5f61e8faea470"
+
+[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6124,8 +7103,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6166,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -6181,7 +7160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7b278788e7be4d0d29c0f39497a0eef3fba6bbc8e70d8bf7fde46edeaa9e85"
 dependencies = [
  "itertools 0.11.0",
- "nom 7.1.3",
+ "nom",
  "unicode_categories",
 ]
 
@@ -6204,7 +7183,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6753e460c998bbd4cd8c6f0ed9a64346fcca0723d6e75e52fdc351c5d2169d"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "atoi",
  "bigdecimal",
  "byteorder",
@@ -6228,9 +7207,9 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.21.7",
+ "rustls",
  "rustls-pemfile",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sha2 0.10.8",
  "smallvec",
@@ -6249,8 +7228,8 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a793bb3ba331ec8359c1853bd39eed32cdd7baaf22c35ccf5c92a7e8d1189ec"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "sqlx-core",
  "sqlx-macros-core",
  "syn 1.0.109",
@@ -6267,9 +7246,9 @@ dependencies = [
  "heck 0.4.1",
  "hex",
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "serde 1.0.188",
+ "proc-macro2",
+ "quote",
+ "serde",
  "serde_json",
  "sha2 0.10.8",
  "sqlx-core",
@@ -6315,7 +7294,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
- "serde 1.0.188",
+ "serde",
  "sha1",
  "sha2 0.10.8",
  "smallvec",
@@ -6353,10 +7332,10 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.4",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sha1",
  "sha2 0.10.8",
@@ -6385,7 +7364,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "percent-encoding",
- "serde 1.0.188",
+ "serde",
  "sqlx-core",
  "tracing",
  "url",
@@ -6433,7 +7412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap 2.34.0",
- "lazy_static 1.4.0",
+ "lazy_static",
  "structopt-derive",
 ]
 
@@ -6445,8 +7424,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6457,16 +7436,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6483,23 +7484,12 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -6509,10 +7499,16 @@ version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
@@ -6564,13 +7560,13 @@ dependencies = [
  "chrono-tz",
  "globwalk",
  "humansize",
- "lazy_static 1.4.0",
+ "lazy_static",
  "percent-encoding",
  "pest",
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "slug",
  "unic-segment",
@@ -6630,8 +7626,8 @@ version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -6662,7 +7658,7 @@ checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
- "serde 1.0.188",
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -6680,15 +7676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "tint"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
-dependencies = [
- "lazy_static 0.2.11",
 ]
 
 [[package]]
@@ -6754,13 +7741,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -6776,22 +7773,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls",
  "tokio",
 ]
 
@@ -6826,7 +7812,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -6834,6 +7820,18 @@ name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -6847,6 +7845,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.2",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.4",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6858,8 +7938,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6882,8 +7962,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -6903,7 +7983,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "tracing-core",
 ]
@@ -6914,7 +7994,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.188",
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -6925,10 +8014,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -6940,10 +8029,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tui"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
+dependencies = [
+ "bitflags 1.3.2",
+ "cassowary",
+ "crossterm 0.25.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "tungstenite"
@@ -6958,7 +8070,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.7",
+ "rustls",
  "sha1",
  "thiserror",
  "url",
@@ -6976,6 +8088,28 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "typeshare"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99877a66770b25072a67101e80790fd7fe9ed9eff8c69ffb81e9bf5cbea7733f"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecce25dea8aeaadc44909f4c1226d22d84512fccd07d22447ecbad176bc09545"
+dependencies = [
+ "quote",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -7100,12 +8234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7145,7 +8273,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "url",
 ]
@@ -7159,7 +8287,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7186,7 +8314,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7267,8 +8395,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
@@ -7291,7 +8419,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7301,8 +8429,8 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -7338,16 +8466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7371,6 +8489,12 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+
+[[package]]
+name = "wildmatch"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939e59c1bc731542357fdaad98b209ef78c8743d652bb61439d16b16a79eb025"
 
 [[package]]
 name = "winapi"
@@ -7624,10 +8748,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "zerocopy"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -7638,7 +8782,17 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.70"
 aptos-indexer-protos = { path = "dependencies/aptos-indexer-processors/rust/aptos-indexer-protos" }
 server-framework = { path = "dependencies/aptos-indexer-processors/rust/server-framework" }
 aptos-moving-average = { path = "dependencies/aptos-indexer-processors/rust/moving-average" }
-aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.7.2" }
+aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.10.1" }
 
 anyhow = "1.0.62"
 async-trait = "0.1.53"
@@ -49,7 +49,7 @@ diesel-derive-enum = "2.1.0"
 dotenvy = "0.15.7"
 envy = "0.4.2"
 field_count = "0.1.1"
-futures = "0.3.24"
+futures = "0.3.29"
 futures-util = "0.3.28"
 gcloud-sdk = { version = "0.20.4", features = [
     "google-cloud-bigquery-storage-v1",

--- a/src/rust/e2e/src/utils.rs
+++ b/src/rust/e2e/src/utils.rs
@@ -164,6 +164,7 @@ pub async fn account(
 
     let econia_client = EconiaClient::connect(
         reqwest::Url::parse(&node_url).unwrap(),
+        None,
         econia_address.clone(),
         account,
         None,

--- a/src/rust/sdk/Cargo.toml
+++ b/src/rust/sdk/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/econia-labs/econia"
 keywords = ["aptos", "econia", "dex", "clob", "sdk", "blockchain"]
 
 [dependencies]
-aptos-api-types = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.7.2" }
+anyhow.workspace = true
+aptos-api-types = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.10.1" }
 aptos-sdk.workspace = true
 econia-types = { package = "econia-types", path = "../types", features = ["serde"] }
 futures = "0.3.24"

--- a/src/rust/sdk/example/src/main.rs
+++ b/src/rust/sdk/example/src/main.rs
@@ -152,6 +152,7 @@ pub async fn account(
 
     let econia_client = EconiaClient::connect(
         reqwest::Url::parse(&node_url).unwrap(),
+        None,
         econia_address.clone(),
         account,
         None,

--- a/src/rust/sdk/src/errors.rs
+++ b/src/rust/sdk/src/errors.rs
@@ -121,5 +121,5 @@ pub enum EconiaError {
     MarketError(#[from] MarketError),
 
     #[error("Custom error: {0}")]
-    Custom(Box<dyn std::error::Error + Send + Sync>),
+    Custom(#[from] anyhow::Error),
 }

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -7,6 +7,7 @@
 //! create a payload using helper functions from the [entry] module and submit it using
 //! [`EconiaClient::submit_tx`].
 
+use anyhow::anyhow;
 use aptos_api_types::{
     AptosErrorCode, MoveType, Transaction, TransactionInfo, UserTransactionRequest, VersionedEvent,
     U64,
@@ -16,7 +17,7 @@ use aptos_sdk::crypto::ValidCryptoMaterialStringExt;
 use aptos_sdk::move_types::language_storage::TypeTag;
 use aptos_sdk::rest_client::aptos::Balance;
 use aptos_sdk::rest_client::error::RestError;
-use aptos_sdk::rest_client::{Client, Resource};
+use aptos_sdk::rest_client::{Client, Resource, AptosBaseUrl};
 use aptos_sdk::transaction_builder::TransactionFactory;
 use aptos_sdk::types::account_address::AccountAddress;
 use aptos_sdk::types::chain_id::ChainId;
@@ -121,11 +122,18 @@ impl EconiaClient {
     /// * `config` - `EconiaClientConfig` to configure the Econia client, if `None` default values will be used.
     pub async fn connect(
         node_url: Url,
+        node_api_key: Option<String>,
         econia: AccountAddress,
         account: LocalAccount,
         config: Option<EconiaClientConfig>,
     ) -> EconiaResult<Self> {
-        let aptos = Client::new(node_url);
+        let builder = Client::builder(AptosBaseUrl::Custom(node_url));
+        let builder = if let Some(key) = node_api_key {
+            builder.api_key(&key).map_err(|e| errors::EconiaError::Custom(e))?
+        } else {
+            builder
+        };
+        let aptos = builder.build();
         let index = aptos.get_index().await?.into_inner();
         let chain_id = ChainId::new(index.chain_id);
         let account_info = aptos.get_account(account.address()).await?.into_inner();
@@ -153,6 +161,7 @@ impl EconiaClient {
     /// * `config` - `EconiaClientConfig` to configure the Econia client, if `None` default values will be used.
     pub async fn connect_with_strings(
         node_url: &str,
+        node_api_key: Option<String>,
         econia_address: &str,
         account_address: &str,
         account_private_key: &str,
@@ -164,7 +173,7 @@ impl EconiaClient {
         let private_key = Ed25519PrivateKey::from_encoded_string(account_private_key)?;
         let account_key = AccountKey::from(private_key);
         let account = LocalAccount::new(account_address, account_key, 0);
-        Self::connect(node_url, econia, account, config).await
+        Self::connect(node_url, node_api_key, econia, account, config).await
     }
 
     /// Connect to an Aptos node and initialize the econia client using a config file.
@@ -179,6 +188,7 @@ impl EconiaClient {
     /// * `config` - `EconiaClientConfig` to configure the Econia client, if `None` default values will be used.
     pub async fn connect_with_config(
         node_url: &str,
+        node_api_key: Option<String>,
         econia_address: &str,
         aptos_config_path: &str,
         aptos_config_profile_name: &str,
@@ -187,6 +197,7 @@ impl EconiaClient {
         let aptos_config = AptosConfig::from_config(aptos_config_path, aptos_config_profile_name);
         Self::connect_with_strings(
             node_url,
+            node_api_key,
             econia_address,
             &aptos_config.account,
             &aptos_config.private_key,
@@ -257,11 +268,11 @@ impl EconiaClient {
         let response = request
             .send()
             .await
-            .map_err(|e| EconiaError::Custom(Box::new(e)))?;
+            .map_err(|e| EconiaError::Custom(anyhow!(e)))?;
         Ok(response
             .json()
             .await
-            .map_err(|e| EconiaError::Custom(Box::new(e)))?)
+            .map_err(|e| EconiaError::Custom(anyhow!(e)))?)
     }
 
     /// Checks if a coin exists on the aptos chain.

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -117,6 +117,7 @@ impl EconiaClient {
     /// # Arguments:
     ///
     /// * `node_url` - Url of aptos node.
+    /// * `node_api_key` - API key to use when connecting to the node.
     /// * `econia_address` - Aptos `AccountAddress`.
     /// * `account` - `LocalAccount` representing Aptos user account.
     /// * `config` - `EconiaClientConfig` to configure the Econia client, if `None` default values will be used.
@@ -155,6 +156,7 @@ impl EconiaClient {
     /// # Arguments:
     ///
     /// * `node_url` - url string of aptos node to connect to.
+    /// * `node_api_key` - API key to use when connecting to the node.
     /// * `econia_address` - hex encoded address string of account that holds the econia modules.
     /// * `account_address` - hex encoded address string of user using this client.
     /// * `account_private_key` - hex encoded private key string of user using this client.
@@ -182,6 +184,7 @@ impl EconiaClient {
     /// # Arguments:
     ///
     /// * `node_url` - Url string of aptos node to connect to.
+    /// * `node_api_key` - API key to use when connecting to the node.
     /// * `econia_address` - Hex encoded address string of account that holds the econia modules.
     /// * `config_path` - Path to config file.
     /// * `config_profile_name` - Name of profile to use in the config file.


### PR DESCRIPTION
This PR adds support to add an API key when using the Rust or Python SDK.

- [x] update Rust SDK
- [x] update Python SDK