### PR TITLE
[ECO-1276] add suspend/resume runner scripts

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/ci-cd.md
+++ b/doc/doc-site/docs/off-chain/dss/ci-cd.md
@@ -150,11 +150,18 @@ In order to avoid getting charged for a mostly unused service, you can suspend t
 To do so, you can use `scripts/suspend-runner.sh` like so:
 
 ```bash
-source scripts/suspend-runner.sh
+source scripts/suspend-runner.sh GCP_PROJECT_ID
 ```
 
 and `scripts/resume-runner.sh` like so:
 
 ```bash
-source scripts/resume-runner.sh
+source scripts/resume-runner.sh GCP_PROJECT_ID
+```
+
+Note that when resuming, you should wait for the runner to be running before using it.
+You can check its status by running:
+
+```bash
+gcloud compute instances list --filter name=runner
 ```

--- a/doc/doc-site/docs/off-chain/dss/ci-cd.md
+++ b/doc/doc-site/docs/off-chain/dss/ci-cd.md
@@ -142,3 +142,19 @@ DSS_SOURCE_REV=dss-v1.5.0
 TERRAFORM_PROJECT_REV=dss-v1.5.0
 source scripts/hot-upgrade.sh $DSS_SOURCE_REV $TERRAFORM_PROJECT_REV
 ```
+
+## Suspend/resume runner
+
+In order to avoid getting charged for a mostly unused service, you can suspend the runner when you're not using it, and resume it before hot upgrading for example.
+
+To do so, you can use `scripts/suspend-runner.sh` like so:
+
+```bash
+source scripts/suspend-runner.sh
+```
+
+and `scripts/resume-runner.sh` like so:
+
+```bash
+source scripts/resume-runner.sh
+```

--- a/src/terraform/dss-ci-cd/scripts/resume-runner.sh
+++ b/src/terraform/dss-ci-cd/scripts/resume-runner.sh
@@ -1,0 +1,2 @@
+gcloud compute instances resume runner
+

--- a/src/terraform/dss-ci-cd/scripts/resume-runner.sh
+++ b/src/terraform/dss-ci-cd/scripts/resume-runner.sh
@@ -1,2 +1,2 @@
-gcloud compute instances resume runner
+gcloud compute instances resume runner --project "$1"
 

--- a/src/terraform/dss-ci-cd/scripts/suspend-runner.sh
+++ b/src/terraform/dss-ci-cd/scripts/suspend-runner.sh
@@ -1,0 +1,2 @@
+gcloud compute instances suspend runner
+

--- a/src/terraform/dss-ci-cd/scripts/suspend-runner.sh
+++ b/src/terraform/dss-ci-cd/scripts/suspend-runner.sh
@@ -1,2 +1,2 @@
-gcloud compute instances suspend runner
+gcloud compute instances suspend runner --project "$1"
 


### PR DESCRIPTION
This PR adds two scripts to suspend and resume the runner on GCP to reduce running costs.
