### PR TITLE
[ECO-1500] bump sdk versions

### DIFF
--- a/src/python/sdk/pyproject.toml
+++ b/src/python/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "econia-sdk"
-version = "2.0.0"
+version = "2.1.0"
 description = ""
 authors = ["Econia Labs <developers@econialabs.com>"]
 readme = "README.md"

--- a/src/rust/sdk/Cargo.toml
+++ b/src/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "econia-sdk"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 categories = ["crypto", "defi", "trading", "sdk"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This PR bumps the version number of both the Rust SDK and the Python SDK as they were recently updated.
