### PR TITLE
[ECO-1520] fix tickers

### DIFF
--- a/src/rust/dbv2/migrations/2024-04-10-175509_fix_tickers/down.sql
+++ b/src/rust/dbv2/migrations/2024-04-10-175509_fix_tickers/down.sql
@@ -1,0 +1,29 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION api.get_market_best_ask_price (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT min_ask
+    FROM aggregator.spreads
+    WHERE market_id = $1
+    ORDER BY "time" DESC
+    LIMIT 1
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION api.get_market_best_bid_price (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT max_bid
+    FROM aggregator.spreads
+    WHERE market_id = $1
+    ORDER BY "time" DESC
+    LIMIT 1
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION api.get_market_liquidity (market_id numeric, depth numeric) RETURNS NUMERIC AS $$
+    SELECT (amount_ask_ticks + amount_bid_ticks) / (SELECT tick_size FROM market_registration_events WHERE market_id = $1)
+    FROM aggregator.liquidity
+    WHERE group_id = (
+        SELECT group_id FROM aggregator.liquidity_groups WHERE name = 'all' AND market_id = $1
+    )
+    AND bps_times_ten = $2 * 10
+    ORDER BY "time" DESC
+    LIMIT 1;
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2024-04-10-175509_fix_tickers/up.sql
+++ b/src/rust/dbv2/migrations/2024-04-10-175509_fix_tickers/up.sql
@@ -1,0 +1,33 @@
+-- Your SQL goes here
+GRANT SELECT ON api.liquidity TO web_anon;
+GRANT SELECT ON api.liquidity_groups TO web_anon;
+
+
+CREATE OR REPLACE FUNCTION api.get_market_best_ask_price (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT min_ask
+    FROM api.spreads
+    WHERE market_id = $1
+    ORDER BY "time" DESC
+    LIMIT 1
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION api.get_market_best_bid_price (market_id numeric) RETURNS NUMERIC AS $$
+    SELECT max_bid
+    FROM api.spreads
+    WHERE market_id = $1
+    ORDER BY "time" DESC
+    LIMIT 1
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION api.get_market_liquidity (market_id numeric, depth numeric) RETURNS NUMERIC AS $$
+    SELECT (amount_ask_ticks + amount_bid_ticks) / (SELECT tick_size FROM market_registration_events WHERE market_id = $1)
+    FROM api.liquidity
+    WHERE group_id = (
+        SELECT group_id FROM api.liquidity_groups WHERE name = 'all' AND market_id = $1
+    )
+    AND bps_times_ten = $2 * 10
+    ORDER BY "time" DESC
+    LIMIT 1;
+$$ LANGUAGE SQL;


### PR DESCRIPTION
There was a problem as `web_anon` did not have the right to query the `aggregator` schema.

That was fixed by replacing refs to the `aggregator` schema by  the `api` schema.

The rights on the `api` schema were also given to `web_anon` where needed.
