### PR TITLE
[ECO-1523] Add integrator address env variable to the local section

### DIFF
--- a/doc/doc-site/docs/integrators/reference-frontend.md
+++ b/doc/doc-site/docs/integrators/reference-frontend.md
@@ -96,18 +96,19 @@ cp -R .env.example .env.local
 If you take a look at the `.env` files you may note that the environment variable for the REST URL is set to https://aptos-testnet-econia.nodeinfra.com/.
 This is because Nodeinfra runs a community deployment of the [Econia DSS](../off-chain/dss/data-service-stack.md), which provides data feeds for Econia reference frontend data.
 
-| Variable                                 | Meaning                                                                                                  |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia module address                                                                                |
-| `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                                |
-| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, "mainnet" or "testnet")                                                   |
-| `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                                  |
-| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                            |
-| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                              |
-| `NEXT_PUBLIC_READ_ONLY`                  | For setting read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can |
-| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode          |
-| `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                        |
-| `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                        |
+| Variable                                 | Meaning                                                                                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia module address                                                                                                          |
+| `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                                                          |
+| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, "mainnet" or "testnet")                                                                             |
+| `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                                                            |
+| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                                                      |
+| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                                                        |
+| `NEXT_PUBLIC_READ_ONLY`                  | For setting read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can                      |
+| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode                                    |
+| `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                                                  |
+| `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |
+| `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                                                  |
 
 - Run the development server
 


### PR DESCRIPTION
Adding the `NEXT_PUBLIC_INTEGRATOR_ADDRESS` to the local section, just to be more explicit