### PR TITLE
[ECO-1477] add experimental aggregator build

### DIFF
--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -1,3 +1,2 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -94,6 +94,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aggv2"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bigdecimal 0.3.1",
+ "chrono",
+ "dotenvy",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "sqlx-postgres",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,10 +1731,10 @@ checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-integer",
- "num-traits 0.2.16",
- "serde 1.0.188",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1999,9 +1999,9 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2009,7 +2009,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -8626,6 +8626,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8636,6 +8652,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8650,6 +8672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8660,6 +8688,18 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8674,6 +8714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8684,6 +8730,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8698,6 +8750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8708,6 +8766,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -35,7 +35,7 @@ backtrace = "0.3.58"
 base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 bigdecimal = { version = "0.4", features = ["serde"] }
-chrono = { version = "0.4.26", features = ["clock", "serde"] }
+chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }
 diesel = { version = "2.1.0", features = [
     "chrono",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ members = [
   "mqtt-publisher",
   "types",
   "sdk",
-  "sdk/example",
+  "sdk/example", "aggv2",
 ]
 exclude = ["api", "db", "dependencies"]
 

--- a/src/rust/aggv2/Cargo.toml
+++ b/src/rust/aggv2/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "aggv2"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+publish.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow.workspace = true
+async-trait = "0.1.73"
+bigdecimal = { version = "0.3.1", features = ["serde"] }
+chrono.workspace = true
+dotenvy.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx = { workspace = true, features = ["postgres", "chrono", "bigdecimal"] }
+sqlx-postgres.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/src/rust/aggv2/README.md
+++ b/src/rust/aggv2/README.md
@@ -1,5 +1,8 @@
 # Aggregator v2
 
+This directory contains an experimental aggregator for the Econia Data Service
+Stack.
+
 ## Architecture
 
 The new aggregator works using feeds.

--- a/src/rust/aggv2/README.md
+++ b/src/rust/aggv2/README.md
@@ -1,0 +1,26 @@
+# Aggregator v2
+
+## Architecture
+
+The new aggregator works using feeds.
+
+There are three types of feeds:
+
+- ones that can generate a result from their previous value and the events that occurred since that previous value was generated
+- ones that can generate a result from only events that occurred in a time period
+- ones that can generate a result from another feed
+
+You can generate the result for the first two types in parallel.
+Once done, you can generate the result of the third type in parallel.
+
+There are some unit numeric types defined that wrap `BigDecimal`.
+This avoids confusion (you can add lots and ticks together) and simplifies calculus (dividing a `Tick` value by a `Price` value outputs a `Lot`).
+
+## Findings
+
+Tests and benchmarks have not been conducted yet.
+
+Although some findings are already here:
+
+- This implementation is slower to backfill, as it will query events per 1 second batch, rather than bigger batches, although this can be optimized away.
+- This implementation is very likely to have higher throughput, as it is more efficient than the other one.

--- a/src/rust/aggv2/README.md
+++ b/src/rust/aggv2/README.md
@@ -6,21 +6,80 @@ The new aggregator works using feeds.
 
 There are three types of feeds:
 
-- ones that can generate a result from their previous value and the events that occurred since that previous value was generated
-- ones that can generate a result from only events that occurred in a time period
+- ones that can generate a result from their previous value and the events that
+  occurred since that previous value was generated
+- ones that can generate a result from only events that occurred in a time
+  period
 - ones that can generate a result from another feed
 
 You can generate the result for the first two types in parallel.
 Once done, you can generate the result of the third type in parallel.
 
 There are some unit numeric types defined that wrap `BigDecimal`.
-This avoids confusion (you can add lots and ticks together) and simplifies calculus (dividing a `Tick` value by a `Price` value outputs a `Lot`).
+This avoids confusion (you can add lots and ticks together) and simplifies
+calculus (dividing a `Tick` value by a `Price` value outputs a `Lot`).
+
+## In depth overview
+
+There are 3 main threads running (4 if you count the thread responsible for
+logging statistics):
+
+- an aggregator thread
+- an inserter thread
+- a cache manager thread
+
+They each play a part in the aggregating process.
+
+### The cache manager
+
+There is a piece of shared state called the `event_cache`, which is just a
+`BTreeMap` of events that have yet to be aggregated. That map is kept filled up
+by the cache manager thread, that checks the length of the cache every X
+milliseconds, and if a certain threshold is reached, a DB read will be
+triggered and the cached will be filled with the result. Since one of the
+current bottlenecks is DB reads, that means that right now, the cache is filled
+constantly. The reason this is done in a separate thread is because reading
+from the database is a slow process, and does not need to stop the processing
+of already read events.
+
+### The aggregator thread
+
+The aggregator thread uses the events in `event_cache` to generate data, that
+it then puts into the `insert_cache`. It will take all the events from
+`truncate(events.first().timestamp, second)` to
+`truncate(events.first().timestamp, second) + 1 second` that are in the
+`event_cache` and generate the data for that interval. This means that if the
+cache isn't filled fast enough, which currently happens for time to time, the
+aggregating process will hang briefly while the cache is filled. Once said data is generated, it will be added to the `insert_cache`, which is a map from timestamps to data. The timestamp represents the time frame of the generated data.
+
+### The inserter thread
+
+The inserter thread will loop every X milliseconds, and insert everything that
+is present in the `insert_cache` if nothing was inserted in the last Y
+milliseconds. Since writing to the database is currently a bottleneck, this
+means that the insert is triggered on every iteration of the loop. The reason this is done in a separate thread is because writing to the database is a slow process, and does not need so stop the aggregation process of other events.
 
 ## Findings
 
-Tests and benchmarks have not been conducted yet.
+- This implementation has a throughput of over 50k events per second
+- The current bottleneck is reads and writes into PostreSQL
+- The upcoming SDK will help alleviate some of the bottlenecks (reads)
+- Consider insert optimizations or using something else than PostgreSQL to overcome write bottlenecks
 
-Although some findings are already here:
+## Breaking changes
 
-- This implementation is slower to backfill, as it will query events per 1 second batch, rather than bigger batches, although this can be optimized away.
-- This implementation is very likely to have higher throughput, as it is more efficient than the other one.
+This aggregator has a fundamental difference in how it operates compared to the
+old aggregator. First of all, all data is timestamped and immutable (contract
+state is an exception because of how big the database would get if it wasn't),
+compared to the old one where some data is being updated (e.g. `user_history`).
+
+It also does not rely on SQL processing. All the calculations are made in Rust.
+This is not a breaking change itself, but that does mean that it does not rely
+on SQL views like the previous aggregator. This has the upper side of vastly
+improved performance, as nothing is calculated on request, but it has the
+downside of being less space efficient and also more time consuming to
+implement.
+
+For the preceding reasons, the aggv2 will not be replacing the old aggregator,
+but this should be the way to go for the next generations of the Econia
+protocol.

--- a/src/rust/aggv2/src/feed.rs
+++ b/src/rust/aggv2/src/feed.rs
@@ -1,26 +1,27 @@
-use std::{time::Duration, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use crate::{BlockchainTimestamp, Event, numeric::*, Direction};
+use crate::{numeric::*, Direction, Event};
 
 mod liquidity;
 mod spread;
 mod state;
 mod volume;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, DurationRound, Utc};
 use spread::Spread;
 use sqlx::{Executor, Transaction};
-use sqlx_postgres::{PgPool, PgPoolOptions, PgConnection, Postgres};
+use sqlx_postgres::{PgPool, PgPoolOptions, Postgres};
 use state::ContractState;
-use tracing::{span, Level, instrument, Instrument};
+use tokio::{sync::RwLock, try_join};
+use tracing::instrument;
 
 use self::{liquidity::Liquidity, volume::Volume};
 
-const INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+const INTERVAL: chrono::Duration = chrono::Duration::seconds(1);
 
 pub trait FeedFromEventsAndPrevState {
     async fn get_prev_state(pool: &PgPool) -> Self;
-    fn update(&mut self, events: &Vec<Event>);
+    fn update<'a>(&mut self, events: impl Iterator<Item = &'a Event>);
 }
 
 pub trait FeedFromEvents {
@@ -36,303 +37,370 @@ pub trait InsertableFeed {
     async fn save<'a>(&self, timestamp: DateTime<Utc>, transaction: &mut Transaction<'a, Postgres>);
 }
 
-pub async fn get_max_timestamp<'a>(transaction: &mut Transaction<'a, Postgres>) -> Option<DateTime<Utc>> {
-    let max_limit =
-        sqlx::query!(r#"SELECT "time" FROM place_limit_order_events ORDER BY "time" DESC LIMIT 1"#)
-            .fetch_optional(transaction as &mut PgConnection)
+pub async fn get_next_start_timestamp(
+    last_start_timestamp: &DateTime<Utc>,
+    event_cache: &Arc<RwLock<BTreeMap<DateTime<Utc>, Event>>>,
+) -> Option<DateTime<Utc>> {
+    event_cache
+        .read()
+        .await
+        .range(*last_start_timestamp + INTERVAL..)
+        .next()
+        .map(|e| e.0.duration_trunc(INTERVAL).unwrap())
+}
+
+pub async fn fill_cache(
+    amount_of_events: i64,
+    pool: &PgPool,
+    event_cache: &Arc<RwLock<BTreeMap<DateTime<Utc>, Event>>>,
+) {
+    tracing::trace!("Adding {} events to cache.", amount_of_events);
+    let start_timestamp = {
+        event_cache
+            .read()
             .await
-            .unwrap()
-            .map(|o| o.time);
-    let max_market = sqlx::query!(
-        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+            .last_key_value()
+            .map(|e| e.0.clone())
+            .unwrap_or(DateTime::UNIX_EPOCH)
+    };
+    let mut new_event_cache = BTreeMap::new();
+    let limit = sqlx::query!(
+        r#"SELECT "time" FROM events WHERE "time" > $1 ORDER BY "time" offset $2 limit 1"#,
+        start_timestamp,
+        amount_of_events - 1
     )
-    .fetch_optional(transaction as &mut PgConnection)
+    .fetch_optional(pool)
     .await
     .unwrap()
-    .map(|o| o.time);
-    let max_swap = sqlx::query!(
-        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    .map(|e| e.time);
+    let limit = if let Some(limit) = limit {
+        limit
+    } else {
+        return;
+    };
+    let place_limit = sqlx::query!(
+        r#"SELECT * FROM place_limit_order_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
     )
-    .fetch_optional(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .map(|o| o.time);
-    let max_fill = sqlx::query!(
-        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    .fetch_all(pool);
+    let place_market = sqlx::query!(
+        r#"SELECT * FROM place_market_order_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
     )
-    .fetch_optional(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .map(|o| o.time);
-    let max_market_reg = sqlx::query!(
-        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    .fetch_all(pool);
+    let place_swap = sqlx::query!(
+        r#"SELECT * FROM place_swap_order_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
     )
-    .fetch_optional(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .map(|o| o.time);
-    max_limit
-        .max(max_market)
-        .max(max_swap)
-        .max(max_fill)
-        .max(max_market_reg)
+    .fetch_all(pool);
+    let cancels = sqlx::query!(
+        r#"SELECT * FROM cancel_order_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let changes = sqlx::query!(
+        r#"SELECT * FROM change_order_size_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let fills = sqlx::query!(
+        r#"SELECT * FROM fill_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let market_registrations = sqlx::query!(
+        r#"SELECT * FROM market_registration_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let balance_update_by_handle = sqlx::query!(
+        r#"SELECT * FROM balance_updates_by_handle WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let recognized_markets = sqlx::query!(
+        r#"SELECT * FROM recognized_market_events WHERE "time" > $1 AND "time" <= $2"#,
+        start_timestamp,
+        limit,
+    )
+    .fetch_all(pool);
+    let (
+        place_limit,
+        place_market,
+        place_swap,
+        cancels,
+        changes,
+        fills,
+        market_registrations,
+        balance_update_by_handle,
+        recognized_markets,
+    ) = try_join!(
+        place_limit,
+        place_market,
+        place_swap,
+        cancels,
+        changes,
+        fills,
+        market_registrations,
+        balance_update_by_handle,
+        recognized_markets
+    )
+    .unwrap();
+
+    let place_limit = place_limit.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::PlaceLimitOrder {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                user: r.user,
+                custodian_id: r.custodian_id,
+                order_id: OrderId::new(r.order_id),
+                side: if r.side {
+                    Direction::Ask
+                } else {
+                    Direction::Bid
+                },
+                integrator: r.integrator,
+                initial_size: Lot::new(r.initial_size),
+                price: Price::new(r.price),
+                restriction: r.restriction,
+                self_match_behavior: r.self_match_behavior,
+                size: Lot::new(r.size),
+            },
+        )
+    });
+    new_event_cache.extend(place_limit);
+    let place_market = place_market.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::PlaceMarketOrder {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                user: r.user,
+                custodian_id: r.custodian_id,
+                order_id: OrderId::new(r.order_id),
+                integrator: r.integrator,
+                self_match_behavior: r.self_match_behavior,
+                size: Lot::new(r.size),
+                direction: if r.direction {
+                    Direction::Ask
+                } else {
+                    Direction::Bid
+                },
+            },
+        )
+    });
+    new_event_cache.extend(place_market);
+    let place_swap = place_swap.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::PlaceSwapOrder {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                order_id: OrderId::new(r.order_id),
+                integrator: r.integrator,
+                direction: if r.direction {
+                    Direction::Ask
+                } else {
+                    Direction::Bid
+                },
+                signing_account: r.signing_account,
+                min_base: r.min_base,
+                max_base: r.max_base,
+                min_quote: r.min_quote,
+                max_quote: r.max_quote,
+                limit_price: Price::new(r.limit_price),
+            },
+        )
+    });
+    new_event_cache.extend(place_swap);
+    let cancels = cancels.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::Cancel {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                user: r.user,
+                custodian_id: r.custodian_id,
+                order_id: OrderId::new(r.order_id),
+                reason: r.reason,
+            },
+        )
+    });
+    new_event_cache.extend(cancels);
+    let changes = changes.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::ChangeSize {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                user: r.user,
+                custodian_id: r.custodian_id,
+                order_id: OrderId::new(r.order_id),
+                side: if r.side {
+                    Direction::Ask
+                } else {
+                    Direction::Bid
+                },
+                new_size: Lot::new(r.new_size),
+            },
+        )
+    });
+    new_event_cache.extend(changes);
+    let fills = fills.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::Fill {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                emit_address: r.emit_address,
+                maker_address: r.maker_address,
+                maker_custodian_id: r.maker_custodian_id,
+                maker_order_id: OrderId::new(r.maker_order_id),
+                maker_side: if r.maker_side {
+                    Direction::Ask
+                } else {
+                    Direction::Bid
+                },
+                price: Price::new(r.price),
+                sequence_number_for_trade: r.sequence_number_for_trade,
+                size: Lot::new(r.size),
+                taker_address: r.taker_address,
+                taker_custodian_id: r.taker_custodian_id,
+                taker_order_id: OrderId::new(r.taker_order_id),
+                taker_quote_fees_paid: r.taker_quote_fees_paid,
+            },
+        )
+    });
+    new_event_cache.extend(fills);
+    let market_registrations = market_registrations.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::MarketRegistration {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                base_account_address: r.base_account_address,
+                base_module_name: r.base_module_name,
+                base_struct_name: r.base_struct_name,
+                base_name_generic: r.base_name_generic,
+                quote_account_address: r.quote_account_address,
+                quote_module_name: r.quote_module_name,
+                quote_struct_name: r.quote_struct_name,
+                lot_size: r.lot_size,
+                tick_size: r.tick_size,
+                min_size: Lot::new(r.min_size),
+                underwriter_id: r.underwriter_id,
+            },
+        )
+    });
+    new_event_cache.extend(market_registrations);
+    let balance_update_by_handle = balance_update_by_handle.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::BalanceUpdatesByHandle {
+                txn_version: TransactionVersion::new(r.txn_version),
+                time: r.time,
+                market_id: MarketId::new(r.market_id),
+                custodian_id: r.custodian_id,
+                base_total: BaseSubunit::new(r.base_total),
+                base_available: BaseSubunit::new(r.base_available),
+                base_ceiling: BaseSubunit::new(r.base_ceiling),
+                quote_total: QuoteSubunit::new(r.quote_total),
+                quote_available: QuoteSubunit::new(r.quote_available),
+                quote_ceiling: QuoteSubunit::new(r.quote_ceiling),
+            },
+        )
+    });
+    new_event_cache.extend(balance_update_by_handle);
+    let recognized_markets = recognized_markets.into_iter().map(|r| {
+        (
+            r.time.clone(),
+            Event::MarketRegistration {
+                txn_version: TransactionVersion::new(r.txn_version),
+                event_idx: EventIndex::new(r.event_idx),
+                time: r.time,
+                market_id: MarketId::new(r.market_id.unwrap()),
+                base_account_address: r.base_account_address,
+                base_module_name: r.base_module_name,
+                base_struct_name: r.base_struct_name,
+                base_name_generic: r.base_name_generic,
+                quote_account_address: r.quote_account_address,
+                quote_module_name: r.quote_module_name,
+                quote_struct_name: r.quote_struct_name,
+                lot_size: r.lot_size.unwrap(),
+                tick_size: r.tick_size.unwrap(),
+                min_size: Lot::new(r.min_size.unwrap()),
+                underwriter_id: r.underwriter_id.unwrap(),
+            },
+        )
+    });
+    new_event_cache.extend(recognized_markets);
+    let mut event_cache = event_cache.write().await;
+    event_cache.append(&mut new_event_cache);
 }
 
 pub async fn get_event_batch<'a>(
-    start_blockchain_timestamp: &BlockchainTimestamp,
-    max_timestamp: &DateTime<Utc>,
-    _amount_of_events: i64,
-    transaction: &mut Transaction<'a, Postgres>,
-) -> Vec<Event> {
-    let mut events: Vec<Event> = vec![];
-    let place_limit = sqlx::query!(
-        r#"SELECT * FROM place_limit_order_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::PlaceLimitOrder {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        user: r.user,
-        custodian_id: r.custodian_id,
-        order_id: OrderId::new(r.order_id),
-        side: if r.side {Direction::Ask} else {Direction::Bid},
-        integrator: r.integrator,
-        initial_size: Lot::new(r.initial_size),
-        price: Price::new(r.price),
-        restriction: r.restriction,
-        self_match_behavior: r.self_match_behavior,
-        size: Lot::new(r.size),
-    });
-    events.extend(place_limit);
-    let place_market = sqlx::query!(
-        r#"SELECT * FROM place_market_order_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::PlaceMarketOrder {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        user: r.user,
-        custodian_id: r.custodian_id,
-        order_id: OrderId::new(r.order_id),
-        integrator: r.integrator,
-        self_match_behavior: r.self_match_behavior,
-        size: Lot::new(r.size),
-        direction: if r.direction {Direction::Ask} else {Direction::Bid},
-    });
-    events.extend(place_market);
-    let place_swap = sqlx::query!(
-        r#"SELECT * FROM place_swap_order_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::PlaceSwapOrder {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        order_id: OrderId::new(r.order_id),
-        integrator: r.integrator,
-        direction: if r.direction {Direction::Ask} else {Direction::Bid},
-        signing_account: r.signing_account,
-        min_base: r.min_base,
-        max_base: r.max_base,
-        min_quote: r.min_quote,
-        max_quote: r.max_quote,
-        limit_price: Price::new(r.limit_price),
-    });
-    events.extend(place_swap);
-    let cancels = sqlx::query!(
-        r#"SELECT * FROM cancel_order_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::Cancel {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        user: r.user,
-        custodian_id: r.custodian_id,
-        order_id: OrderId::new(r.order_id),
-        reason: r.reason,
-    });
-    events.extend(cancels);
-    let changes = sqlx::query!(
-        r#"SELECT * FROM change_order_size_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::ChangeSize {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        user: r.user,
-        custodian_id: r.custodian_id,
-        order_id: OrderId::new(r.order_id),
-        side: if r.side {Direction::Ask} else {Direction::Bid},
-        new_size: Lot::new(r.new_size),
-    });
-    events.extend(changes);
-    let fills = sqlx::query!(
-        r#"SELECT * FROM fill_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::Fill {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        emit_address: r.emit_address,
-        maker_address: r.maker_address,
-        maker_custodian_id: r.maker_custodian_id,
-        maker_order_id: OrderId::new(r.maker_order_id),
-        maker_side: if r.maker_side {Direction::Ask} else {Direction::Bid},
-        price: Price::new(r.price),
-        sequence_number_for_trade: r.sequence_number_for_trade,
-        size: Lot::new(r.size),
-        taker_address: r.taker_address,
-        taker_custodian_id: r.taker_custodian_id,
-        taker_order_id: OrderId::new(r.taker_order_id),
-        taker_quote_fees_paid: r.taker_quote_fees_paid,
-    });
-    events.extend(fills);
-    let market_registrations = sqlx::query!(
-        r#"SELECT * FROM market_registration_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::MarketRegistration {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        base_account_address: r.base_account_address,
-        base_module_name: r.base_module_name,
-        base_struct_name: r.base_struct_name,
-        base_name_generic: r.base_name_generic,
-        quote_account_address: r.quote_account_address,
-        quote_module_name: r.quote_module_name,
-        quote_struct_name: r.quote_struct_name,
-        lot_size: r.lot_size,
-        tick_size: r.tick_size,
-        min_size: Lot::new(r.min_size),
-        underwriter_id: r.underwriter_id,
-    });
-    events.extend(market_registrations);
-    let balance_update_by_handle = sqlx::query!(
-        r#"SELECT * FROM balance_updates_by_handle WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::BalanceUpdatesByHandle {
-        txn_version: TxnVersion::new(r.txn_version),
-        time: r.time,
-        market_id: MarketId::new(r.market_id),
-        custodian_id: r.custodian_id,
-        base_total: BaseSubunit::new(r.base_total),
-        base_available: BaseSubunit::new(r.base_available),
-        base_ceiling: BaseSubunit::new(r.base_ceiling),
-        quote_total: QuoteSubunit::new(r.quote_total),
-        quote_available: QuoteSubunit::new(r.quote_available),
-        quote_ceiling: QuoteSubunit::new(r.quote_ceiling),
-    });
-    events.extend(balance_update_by_handle);
-    let recognized_markets = sqlx::query!(
-        r#"SELECT * FROM recognized_market_events WHERE txn_version >= $1 AND "time" < $2"#,
-        start_blockchain_timestamp
-            .get_transaction_version()
-            .clone()
-            .inner(),
-        max_timestamp
-    )
-    .fetch_all(transaction as &mut PgConnection)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| Event::MarketRegistration {
-        txn_version: TxnVersion::new(r.txn_version),
-        event_idx: EventId::new(r.event_idx),
-        time: r.time,
-        market_id: MarketId::new(r.market_id.unwrap()),
-        base_account_address: r.base_account_address,
-        base_module_name: r.base_module_name,
-        base_struct_name: r.base_struct_name,
-        base_name_generic: r.base_name_generic,
-        quote_account_address: r.quote_account_address,
-        quote_module_name: r.quote_module_name,
-        quote_struct_name: r.quote_struct_name,
-        lot_size: r.lot_size.unwrap(),
-        tick_size: r.tick_size.unwrap(),
-        min_size: Lot::new(r.min_size.unwrap()),
-        underwriter_id: r.underwriter_id.unwrap(),
-    });
-    events.extend(recognized_markets);
-    events.sort_unstable_by_key(|e| e.blockchain_timestamp());
-    events
+    start_timestamp: &DateTime<Utc>,
+    event_cache: &'a Arc<RwLock<BTreeMap<DateTime<Utc>, Event>>>,
+) -> BTreeMap<DateTime<Utc>, Event> {
+    tracing::trace!("Getting event batch.");
+    loop {
+        let last_value = {
+            event_cache
+                .read()
+                .await
+                .last_key_value()
+                .map(|e| (e.0.clone(), e.1.clone()))
+        };
+        match last_value {
+            Some((datetime, _)) if datetime >= *start_timestamp + INTERVAL => {
+                break;
+            }
+            _ => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    let mut ecw = event_cache.write().await;
+    let mut end = ecw.split_off(&(*start_timestamp + INTERVAL));
+    std::mem::swap(&mut *ecw, &mut end);
+    end
+}
+
+struct Cache {
+    state_insert_cache: Box<Option<ContractState>>,
+    spread_insert_cache: Box<Vec<(DateTime<Utc>, Spread)>>,
+    volume_insert_cache: Box<Vec<(DateTime<Utc>, Volume)>>,
+    liquidity_insert_cache: Box<Vec<(DateTime<Utc>, Liquidity)>>,
+}
+
+struct AggregatorState {
+    current_timestamp: DateTime<Utc>,
+    events: usize,
+    cached_events: usize,
 }
 
 #[instrument]
@@ -355,118 +423,253 @@ pub async fn run() -> anyhow::Result<()> {
     // Init feeds with state
     tracing::info!("Loading feeds.");
     let mut state = ContractState::get_prev_state(&pool).await;
-    let mut volume = Volume::get_prev_state(&pool).await;
+    let volume = Volume::get_prev_state(&pool).await;
     tracing::info!("Done loading feeds.");
 
-    let mut max_timestamp = state.timestamp + INTERVAL;
-    let mut start_blockchain_timestamp =
-        BlockchainTimestamp::from_transaction_version(state.transaction_version.clone());
-    start_blockchain_timestamp.bump_version();
+    state.update_timestamp(state.timestamp + INTERVAL);
 
     tracing::info!(
         from_timestamp = state.timestamp.to_string(),
-        form_blockchain_timestamp = start_blockchain_timestamp.to_string(),
         "Start aggregating."
     );
 
+    let cache = Arc::new(RwLock::new(Cache {
+        state_insert_cache: Default::default(),
+        spread_insert_cache: Default::default(),
+        volume_insert_cache: Default::default(),
+        liquidity_insert_cache: Default::default(),
+    }));
+
+    let event_cache = Arc::new(RwLock::new(BTreeMap::new()));
+    let agg_state = Arc::new(RwLock::new(AggregatorState {
+        current_timestamp: state.timestamp.clone(),
+        events: 0,
+        cached_events: 0,
+    }));
+
+    let agg_loop = tokio::spawn(aggregator(
+        state,
+        volume,
+        cache.clone(),
+        event_cache.clone(),
+        agg_state.clone(),
+    ));
+    let insert_loop = tokio::spawn(inserter(pool.clone(), cache.clone()));
+    let cache_manager = tokio::spawn(cache_manager(
+        pool.clone(),
+        event_cache.clone(),
+        agg_state.clone(),
+    ));
+    let logger = tokio::spawn(logger(agg_state));
+
+    let (res_agg, res_ins, res_cache_manager, res_logger) =
+        tokio::try_join!(agg_loop, insert_loop, cache_manager, logger)?;
+
+    res_agg?;
+    res_ins?;
+    res_cache_manager?;
+    res_logger?;
+
+    Ok(())
+}
+
+async fn logger(agg_state: Arc<RwLock<AggregatorState>>) -> anyhow::Result<()> {
     loop {
-        let timestamp_string = (max_timestamp - INTERVAL).to_string();
-        let blockchain_timestamp_string = start_blockchain_timestamp.to_string();
-        (state, volume) = aggregator_loop(&pool, state, volume, &mut max_timestamp, &mut start_blockchain_timestamp).await?;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let mut state = agg_state.write().await;
+        tracing::info!(
+            tps = state.events,
+            timestamp = state.current_timestamp.to_string(),
+            cached_events = state.cached_events,
+        );
+        state.events = 0;
     }
 }
 
-#[instrument(skip(pool, state, volume))]
-async fn aggregator_loop(pool: &PgPool, mut state: ContractState, mut volume: Volume, max_timestamp: &mut DateTime<Utc>, start_blockchain_timestamp: &mut BlockchainTimestamp) -> anyhow::Result<(ContractState, Volume)> {
-    tracing::trace!("Aggregator loop start.");
-
-    // Intro
-    let mut transaction = pool.begin().await?;
-    let t = if let Some(t) = get_max_timestamp(&mut transaction).await {
-        t
-    } else {
-        return Ok((state, volume));
-    };
-    if &t < max_timestamp {
-        tracing::debug!(max_db_timestamp = t.to_string(), "Max timestamp in DB is lower than required to run an aggregator loop.");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        return Ok((state, volume));
+#[instrument(skip(pool, event_cache, agg_state))]
+async fn cache_manager(
+    pool: PgPool,
+    event_cache: Arc<RwLock<BTreeMap<DateTime<Utc>, Event>>>,
+    agg_state: Arc<RwLock<AggregatorState>>,
+) -> anyhow::Result<()> {
+    loop {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let remaining_events = event_cache.read().await.len();
+        agg_state.write().await.cached_events = remaining_events;
+        if remaining_events < 500_000 {
+            fill_cache(100_000, &pool, &event_cache).await;
+        }
     }
+}
 
-    // Get events
-    tracing::trace!("Getting events between start blockchain timestamp and max timestamp.");
-    let events =
-        get_event_batch(&start_blockchain_timestamp, max_timestamp, 100_000, &mut transaction).await;
-    tracing::debug!("Got {} events", events.len());
-    if events.len() == 0 {
-        state.save(state.timestamp, &mut transaction).await;
-        transaction.commit().await?;
-        state.update_timestamp(max_timestamp.clone());
-        *max_timestamp += INTERVAL;
-        return Ok((state, volume));
+#[instrument(skip(pool, cache))]
+async fn inserter(pool: PgPool, cache: Arc<RwLock<Cache>>) -> anyhow::Result<()> {
+    let mut last_insert = Utc::now();
+    loop {
+        if microseconds_elapsed(last_insert) > 50_000 {
+            let mut cache_write = cache.write().await;
+            if cache_write.volume_insert_cache.is_empty()
+                && cache_write.spread_insert_cache.is_empty()
+                && cache_write.liquidity_insert_cache.is_empty()
+                && cache_write.state_insert_cache.is_none()
+            {
+                continue;
+            }
+            tracing::trace!(
+                "Inserting {} cached data.",
+                cache_write.volume_insert_cache.len()
+                    + cache_write.spread_insert_cache.len()
+                    + cache_write.liquidity_insert_cache.len()
+                    + if cache_write.state_insert_cache.is_some() {
+                        1
+                    } else {
+                        0
+                    }
+            );
+            let volumes = {
+                let w = &mut cache_write.volume_insert_cache;
+                let mut empty = Box::new(vec![]);
+                if !w.is_empty() {
+                    std::mem::swap(w, &mut empty);
+                }
+                empty
+            };
+            let spreads = {
+                let w = &mut cache_write.spread_insert_cache;
+                let mut empty = Box::new(vec![]);
+                if !w.is_empty() {
+                    std::mem::swap(w, &mut empty);
+                }
+                empty
+            };
+            let liquidities = {
+                let w = &mut cache_write.liquidity_insert_cache;
+                let mut empty = Box::new(vec![]);
+                if !w.is_empty() {
+                    std::mem::swap(w, &mut empty);
+                }
+                empty
+            };
+            let state = {
+                let sicw = &mut cache_write.state_insert_cache;
+                let state = (*sicw).clone();
+                state
+            };
+            drop(cache_write);
+            last_insert = Utc::now();
+            let mut transaction = pool.begin().await?;
+            for (timestamp, volume) in volumes.iter() {
+                volume.save(*timestamp, &mut transaction).await;
+            }
+            for (timestamp, spreads) in spreads.iter() {
+                spreads.save(*timestamp, &mut transaction).await;
+            }
+            for (timestamp, liquidity) in liquidities.iter() {
+                liquidity.save(*timestamp, &mut transaction).await;
+            }
+            if let Some(state) = *state {
+                state.save(state.timestamp, &mut transaction).await;
+            }
+            transaction.commit().await?;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    *start_blockchain_timestamp = events.last().unwrap().blockchain_timestamp();
+}
 
-    // Run first layer
-    tracing::trace!("Start first layer.");
-    let events = Arc::new(events);
-    let events2 = events.clone();
+fn microseconds_elapsed(time: DateTime<Utc>) -> i64 {
+    Utc::now()
+        .signed_duration_since(time)
+        .num_microseconds()
+        .unwrap()
+}
 
-    let state_handle = tokio::task::spawn_blocking(move || {
-        let events2 = events2.clone();
-        tracing::trace!("Start calculating.");
-        state.update(&events2);
-        tracing::trace!("Done calculating.");
-        state
-    }).instrument(span!(Level::TRACE, "state"));
-    let events2 = events.clone();
-    let volume_handle = tokio::task::spawn_blocking(move || {
-        let events2 = events2.clone();
-        tracing::trace!("Start calculating.");
-        volume.update(&events2);
-        tracing::trace!("Done calculating.");
-        volume
-    }).instrument(span!(Level::TRACE, "volume"));
-    let (state_new, volume_new) = tokio::try_join!(state_handle, volume_handle)?;
-    volume = volume_new;
-    state = state_new;
-    tracing::trace!("Done first layer.");
+#[instrument(skip(state, volume, cache, event_cache, agg_state))]
+async fn aggregator(
+    mut state: ContractState,
+    mut volume: Volume,
+    cache: Arc<RwLock<Cache>>,
+    event_cache: Arc<RwLock<BTreeMap<DateTime<Utc>, Event>>>,
+    agg_state: Arc<RwLock<AggregatorState>>,
+) -> anyhow::Result<()> {
+    loop {
+        loop {
+            if let Some(new_start_timestamp) =
+                get_next_start_timestamp(&state.timestamp, &event_cache).await
+            {
+                state.update_timestamp(new_start_timestamp);
+                {
+                    agg_state.write().await.current_timestamp = new_start_timestamp;
+                }
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
-    // Run second layer
-    tracing::trace!("Start second layer.");
-    let arc_state = Arc::new(state);
-    let arc_state2 = arc_state.clone();
+        tracing::debug!(
+            start_timestamp = state.timestamp.to_string(),
+            "Running aggregator loop."
+        );
 
-    let spreads_handle = tokio::task::spawn_blocking(move || {
-        tracing::trace!("Start calculating.");
-        let spreads = Spread::from_feed(&arc_state2);
-        tracing::trace!("Done calculating.");
-        spreads
-    }).instrument(span!(Level::TRACE, "spreads"));
-    let arc_state2 = arc_state.clone();
-    let liquidity_handle = tokio::task::spawn_blocking(move || {
-        tracing::trace!("Start calculating.");
-        let liquidity = Liquidity::from_feed(&arc_state2);
-        tracing::trace!("Done calculating.");
-        liquidity
-    }).instrument(span!(Level::TRACE, "liquidity"));
-    let (spreads, liquidity) = tokio::try_join!(spreads_handle, liquidity_handle)?;
-    state = Arc::<ContractState>::into_inner(arc_state).unwrap();
-    tracing::trace!("Done second layer.");
+        let time_total = Utc::now();
 
-    // Save
-    tracing::trace!("Start saving.");
-    state.save(state.timestamp.clone(), &mut transaction).await;
-    volume.save(state.timestamp.clone(), &mut transaction).await;
-    spreads.save(state.timestamp.clone(), &mut transaction).await;
-    liquidity.save(state.timestamp.clone(), &mut transaction).await;
-    transaction.commit().await?;
-    tracing::trace!("Done saving.");
+        // Get events
+        tracing::trace!("Getting events.");
+        let time = Utc::now();
+        let events = get_event_batch(&state.timestamp, &event_cache).await;
+        {
+            agg_state.write().await.events += events.len();
+        }
+        tracing::trace!(
+            "Got {} events in {} microseconds.",
+            events.len(),
+            microseconds_elapsed(time)
+        );
 
-    // Outro
-    state.update_timestamp(max_timestamp.clone());
-    *max_timestamp += INTERVAL;
-    start_blockchain_timestamp.bump_version();
+        // Run first layer
+        tracing::trace!("Start first layer.");
+        let time = Utc::now();
 
-    Ok((state, volume))
+        let events = events.iter().map(|e| e.1);
+
+        state.update(events.clone());
+        volume.update(events.clone());
+
+        tracing::trace!(
+            "Done first layer in {} microseconds.",
+            microseconds_elapsed(time)
+        );
+
+        // Run second layer
+        tracing::trace!("Start second layer.");
+        let time = Utc::now();
+
+        let spreads = Spread::from_feed(&state);
+        let liquidity = Liquidity::from_feed(&state);
+
+        tracing::trace!(
+            "Done second layer in {} microseconds.",
+            microseconds_elapsed(time)
+        );
+
+        let state2 = state.clone();
+        let volume2 = volume.clone();
+
+        let mut cache_write = cache.write().await;
+
+        cache_write
+            .spread_insert_cache
+            .push((state2.timestamp.clone(), spreads));
+        cache_write
+            .volume_insert_cache
+            .push((state2.timestamp.clone(), volume2));
+        cache_write
+            .liquidity_insert_cache
+            .push((state2.timestamp.clone(), liquidity));
+        cache_write.state_insert_cache = Box::new(Some(state2));
+
+        tracing::trace!(
+            "Ran aggregator loop in {} microseconds.",
+            microseconds_elapsed(time_total)
+        );
+    }
 }

--- a/src/rust/aggv2/src/feed.rs
+++ b/src/rust/aggv2/src/feed.rs
@@ -1,0 +1,472 @@
+use std::{time::Duration, sync::Arc};
+
+use crate::{BlockchainTimestamp, Event, numeric::*, Direction};
+
+mod liquidity;
+mod spread;
+mod state;
+mod volume;
+
+use chrono::{DateTime, Utc};
+use spread::Spread;
+use sqlx::{Executor, Transaction};
+use sqlx_postgres::{PgPool, PgPoolOptions, PgConnection, Postgres};
+use state::ContractState;
+use tracing::{span, Level, instrument, Instrument};
+
+use self::{liquidity::Liquidity, volume::Volume};
+
+const INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+pub trait FeedFromEventsAndPrevState {
+    async fn get_prev_state(pool: &PgPool) -> Self;
+    fn update(&mut self, events: &Vec<Event>);
+}
+
+pub trait FeedFromEvents {
+    fn new() -> Self;
+    fn update(&mut self, events: &Vec<Event>);
+}
+
+pub trait FeedFromFeed<T> {
+    fn from_feed(data: &T) -> Self;
+}
+
+pub trait InsertableFeed {
+    async fn save<'a>(&self, timestamp: DateTime<Utc>, transaction: &mut Transaction<'a, Postgres>);
+}
+
+pub async fn get_max_timestamp<'a>(transaction: &mut Transaction<'a, Postgres>) -> Option<DateTime<Utc>> {
+    let max_limit =
+        sqlx::query!(r#"SELECT "time" FROM place_limit_order_events ORDER BY "time" DESC LIMIT 1"#)
+            .fetch_optional(transaction as &mut PgConnection)
+            .await
+            .unwrap()
+            .map(|o| o.time);
+    let max_market = sqlx::query!(
+        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    )
+    .fetch_optional(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .map(|o| o.time);
+    let max_swap = sqlx::query!(
+        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    )
+    .fetch_optional(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .map(|o| o.time);
+    let max_fill = sqlx::query!(
+        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    )
+    .fetch_optional(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .map(|o| o.time);
+    let max_market_reg = sqlx::query!(
+        r#"SELECT "time" FROM place_market_order_events ORDER BY "time" DESC LIMIT 1"#
+    )
+    .fetch_optional(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .map(|o| o.time);
+    max_limit
+        .max(max_market)
+        .max(max_swap)
+        .max(max_fill)
+        .max(max_market_reg)
+}
+
+pub async fn get_event_batch<'a>(
+    start_blockchain_timestamp: &BlockchainTimestamp,
+    max_timestamp: &DateTime<Utc>,
+    _amount_of_events: i64,
+    transaction: &mut Transaction<'a, Postgres>,
+) -> Vec<Event> {
+    let mut events: Vec<Event> = vec![];
+    let place_limit = sqlx::query!(
+        r#"SELECT * FROM place_limit_order_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::PlaceLimitOrder {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        user: r.user,
+        custodian_id: r.custodian_id,
+        order_id: OrderId::new(r.order_id),
+        side: if r.side {Direction::Ask} else {Direction::Bid},
+        integrator: r.integrator,
+        initial_size: Lot::new(r.initial_size),
+        price: Price::new(r.price),
+        restriction: r.restriction,
+        self_match_behavior: r.self_match_behavior,
+        size: Lot::new(r.size),
+    });
+    events.extend(place_limit);
+    let place_market = sqlx::query!(
+        r#"SELECT * FROM place_market_order_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::PlaceMarketOrder {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        user: r.user,
+        custodian_id: r.custodian_id,
+        order_id: OrderId::new(r.order_id),
+        integrator: r.integrator,
+        self_match_behavior: r.self_match_behavior,
+        size: Lot::new(r.size),
+        direction: if r.direction {Direction::Ask} else {Direction::Bid},
+    });
+    events.extend(place_market);
+    let place_swap = sqlx::query!(
+        r#"SELECT * FROM place_swap_order_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::PlaceSwapOrder {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        order_id: OrderId::new(r.order_id),
+        integrator: r.integrator,
+        direction: if r.direction {Direction::Ask} else {Direction::Bid},
+        signing_account: r.signing_account,
+        min_base: r.min_base,
+        max_base: r.max_base,
+        min_quote: r.min_quote,
+        max_quote: r.max_quote,
+        limit_price: Price::new(r.limit_price),
+    });
+    events.extend(place_swap);
+    let cancels = sqlx::query!(
+        r#"SELECT * FROM cancel_order_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::Cancel {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        user: r.user,
+        custodian_id: r.custodian_id,
+        order_id: OrderId::new(r.order_id),
+        reason: r.reason,
+    });
+    events.extend(cancels);
+    let changes = sqlx::query!(
+        r#"SELECT * FROM change_order_size_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::ChangeSize {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        user: r.user,
+        custodian_id: r.custodian_id,
+        order_id: OrderId::new(r.order_id),
+        side: if r.side {Direction::Ask} else {Direction::Bid},
+        new_size: Lot::new(r.new_size),
+    });
+    events.extend(changes);
+    let fills = sqlx::query!(
+        r#"SELECT * FROM fill_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::Fill {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        emit_address: r.emit_address,
+        maker_address: r.maker_address,
+        maker_custodian_id: r.maker_custodian_id,
+        maker_order_id: OrderId::new(r.maker_order_id),
+        maker_side: if r.maker_side {Direction::Ask} else {Direction::Bid},
+        price: Price::new(r.price),
+        sequence_number_for_trade: r.sequence_number_for_trade,
+        size: Lot::new(r.size),
+        taker_address: r.taker_address,
+        taker_custodian_id: r.taker_custodian_id,
+        taker_order_id: OrderId::new(r.taker_order_id),
+        taker_quote_fees_paid: r.taker_quote_fees_paid,
+    });
+    events.extend(fills);
+    let market_registrations = sqlx::query!(
+        r#"SELECT * FROM market_registration_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::MarketRegistration {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        base_account_address: r.base_account_address,
+        base_module_name: r.base_module_name,
+        base_struct_name: r.base_struct_name,
+        base_name_generic: r.base_name_generic,
+        quote_account_address: r.quote_account_address,
+        quote_module_name: r.quote_module_name,
+        quote_struct_name: r.quote_struct_name,
+        lot_size: r.lot_size,
+        tick_size: r.tick_size,
+        min_size: Lot::new(r.min_size),
+        underwriter_id: r.underwriter_id,
+    });
+    events.extend(market_registrations);
+    let balance_update_by_handle = sqlx::query!(
+        r#"SELECT * FROM balance_updates_by_handle WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::BalanceUpdatesByHandle {
+        txn_version: TxnVersion::new(r.txn_version),
+        time: r.time,
+        market_id: MarketId::new(r.market_id),
+        custodian_id: r.custodian_id,
+        base_total: BaseSubunit::new(r.base_total),
+        base_available: BaseSubunit::new(r.base_available),
+        base_ceiling: BaseSubunit::new(r.base_ceiling),
+        quote_total: QuoteSubunit::new(r.quote_total),
+        quote_available: QuoteSubunit::new(r.quote_available),
+        quote_ceiling: QuoteSubunit::new(r.quote_ceiling),
+    });
+    events.extend(balance_update_by_handle);
+    let recognized_markets = sqlx::query!(
+        r#"SELECT * FROM recognized_market_events WHERE txn_version >= $1 AND "time" < $2"#,
+        start_blockchain_timestamp
+            .get_transaction_version()
+            .clone()
+            .inner(),
+        max_timestamp
+    )
+    .fetch_all(transaction as &mut PgConnection)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| Event::MarketRegistration {
+        txn_version: TxnVersion::new(r.txn_version),
+        event_idx: EventId::new(r.event_idx),
+        time: r.time,
+        market_id: MarketId::new(r.market_id.unwrap()),
+        base_account_address: r.base_account_address,
+        base_module_name: r.base_module_name,
+        base_struct_name: r.base_struct_name,
+        base_name_generic: r.base_name_generic,
+        quote_account_address: r.quote_account_address,
+        quote_module_name: r.quote_module_name,
+        quote_struct_name: r.quote_struct_name,
+        lot_size: r.lot_size.unwrap(),
+        tick_size: r.tick_size.unwrap(),
+        min_size: Lot::new(r.min_size.unwrap()),
+        underwriter_id: r.underwriter_id.unwrap(),
+    });
+    events.extend(recognized_markets);
+    events.sort_unstable_by_key(|e| e.blockchain_timestamp());
+    events
+}
+
+#[instrument]
+pub async fn run() -> anyhow::Result<()> {
+    tracing::info!("Starting.");
+    let pool = PgPoolOptions::new()
+        .after_connect(|conn, _| {
+            Box::pin(async move {
+                conn.execute("SET default_transaction_isolation TO 'repeatable read'")
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+
+    tracing::info!("Connected to database.");
+
+    // Init feeds with state
+    tracing::info!("Loading feeds.");
+    let mut state = ContractState::get_prev_state(&pool).await;
+    let mut volume = Volume::get_prev_state(&pool).await;
+    tracing::info!("Done loading feeds.");
+
+    let mut max_timestamp = state.timestamp + INTERVAL;
+    let mut start_blockchain_timestamp =
+        BlockchainTimestamp::from_transaction_version(state.transaction_version.clone());
+    start_blockchain_timestamp.bump_version();
+
+    tracing::info!(
+        from_timestamp = state.timestamp.to_string(),
+        form_blockchain_timestamp = start_blockchain_timestamp.to_string(),
+        "Start aggregating."
+    );
+
+    loop {
+        let timestamp_string = (max_timestamp - INTERVAL).to_string();
+        let blockchain_timestamp_string = start_blockchain_timestamp.to_string();
+        (state, volume) = aggregator_loop(&pool, state, volume, &mut max_timestamp, &mut start_blockchain_timestamp).await?;
+    }
+}
+
+#[instrument(skip(pool, state, volume))]
+async fn aggregator_loop(pool: &PgPool, mut state: ContractState, mut volume: Volume, max_timestamp: &mut DateTime<Utc>, start_blockchain_timestamp: &mut BlockchainTimestamp) -> anyhow::Result<(ContractState, Volume)> {
+    tracing::trace!("Aggregator loop start.");
+
+    // Intro
+    let mut transaction = pool.begin().await?;
+    let t = if let Some(t) = get_max_timestamp(&mut transaction).await {
+        t
+    } else {
+        return Ok((state, volume));
+    };
+    if &t < max_timestamp {
+        tracing::debug!(max_db_timestamp = t.to_string(), "Max timestamp in DB is lower than required to run an aggregator loop.");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        return Ok((state, volume));
+    }
+
+    // Get events
+    tracing::trace!("Getting events between start blockchain timestamp and max timestamp.");
+    let events =
+        get_event_batch(&start_blockchain_timestamp, max_timestamp, 100_000, &mut transaction).await;
+    tracing::debug!("Got {} events", events.len());
+    if events.len() == 0 {
+        state.save(state.timestamp, &mut transaction).await;
+        transaction.commit().await?;
+        state.update_timestamp(max_timestamp.clone());
+        *max_timestamp += INTERVAL;
+        return Ok((state, volume));
+    }
+    *start_blockchain_timestamp = events.last().unwrap().blockchain_timestamp();
+
+    // Run first layer
+    tracing::trace!("Start first layer.");
+    let events = Arc::new(events);
+    let events2 = events.clone();
+
+    let state_handle = tokio::task::spawn_blocking(move || {
+        let events2 = events2.clone();
+        tracing::trace!("Start calculating.");
+        state.update(&events2);
+        tracing::trace!("Done calculating.");
+        state
+    }).instrument(span!(Level::TRACE, "state"));
+    let events2 = events.clone();
+    let volume_handle = tokio::task::spawn_blocking(move || {
+        let events2 = events2.clone();
+        tracing::trace!("Start calculating.");
+        volume.update(&events2);
+        tracing::trace!("Done calculating.");
+        volume
+    }).instrument(span!(Level::TRACE, "volume"));
+    let (state_new, volume_new) = tokio::try_join!(state_handle, volume_handle)?;
+    volume = volume_new;
+    state = state_new;
+    tracing::trace!("Done first layer.");
+
+    // Run second layer
+    tracing::trace!("Start second layer.");
+    let arc_state = Arc::new(state);
+    let arc_state2 = arc_state.clone();
+
+    let spreads_handle = tokio::task::spawn_blocking(move || {
+        tracing::trace!("Start calculating.");
+        let spreads = Spread::from_feed(&arc_state2);
+        tracing::trace!("Done calculating.");
+        spreads
+    }).instrument(span!(Level::TRACE, "spreads"));
+    let arc_state2 = arc_state.clone();
+    let liquidity_handle = tokio::task::spawn_blocking(move || {
+        tracing::trace!("Start calculating.");
+        let liquidity = Liquidity::from_feed(&arc_state2);
+        tracing::trace!("Done calculating.");
+        liquidity
+    }).instrument(span!(Level::TRACE, "liquidity"));
+    let (spreads, liquidity) = tokio::try_join!(spreads_handle, liquidity_handle)?;
+    state = Arc::<ContractState>::into_inner(arc_state).unwrap();
+    tracing::trace!("Done second layer.");
+
+    // Save
+    tracing::trace!("Start saving.");
+    state.save(state.timestamp.clone(), &mut transaction).await;
+    volume.save(state.timestamp.clone(), &mut transaction).await;
+    spreads.save(state.timestamp.clone(), &mut transaction).await;
+    liquidity.save(state.timestamp.clone(), &mut transaction).await;
+    transaction.commit().await?;
+    tracing::trace!("Done saving.");
+
+    // Outro
+    state.update_timestamp(max_timestamp.clone());
+    *max_timestamp += INTERVAL;
+    start_blockchain_timestamp.bump_version();
+
+    Ok((state, volume))
+}

--- a/src/rust/aggv2/src/feed/liquidity.rs
+++ b/src/rust/aggv2/src/feed/liquidity.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+use bigdecimal::BigDecimal;
+use sqlx::Transaction;
+use sqlx_postgres::{Postgres, PgConnection};
+
+use crate::{feed::ContractState, numeric::*};
+
+use super::{FeedFromFeed, InsertableFeed};
+
+pub type Liquidity = HashMap<MarketId, HashMap<i32, MarketLiquidity>>;
+
+pub struct MarketLiquidity {
+    pub base: Tick,
+    pub quote: Tick,
+}
+
+impl MarketLiquidity {
+    pub fn new() -> Self {
+        Self {
+            base: Tick::new(0),
+            quote: Tick::new(0),
+        }
+    }
+}
+
+const BPS_TIMES_TEN_MULTIPILER: u64 = 10 * 100 * 100;
+
+impl FeedFromFeed<ContractState> for Liquidity {
+    fn from_feed(state: &ContractState) -> Self {
+        let mut liquidity = Self::default();
+        for (market_id, market) in state.markets.iter() {
+            if !market.last_price.is_some() {
+                continue;
+            }
+            let last_price = market.last_price.clone().unwrap();
+            let current_data = liquidity.entry(market_id.clone()).or_default();
+            for order in market.asks.values() {
+                let bps_times_ten = (order.price.clone() * BPS_TIMES_TEN_MULTIPILER / last_price.clone() - 100_000).inner();
+                for bps_times_ten_group in [25, 50, 100, 250, 500, 1000, 2000] {
+                    if bps_times_ten <= BigDecimal::from(bps_times_ten_group) {
+                        let market_liquidity = current_data
+                            .entry(bps_times_ten_group)
+                            .or_insert(MarketLiquidity::new());
+                        market_liquidity.base += &order.size * &last_price;
+                    }
+                }
+            }
+            for order in market.bids.values() {
+                let bps_times_ten = (order.price.clone() * BPS_TIMES_TEN_MULTIPILER / last_price.clone() - 100_000).inner();
+                for bps_times_ten_group in [25, 50, 100, 250, 500, 1000, 2000] {
+                    if bps_times_ten <= BigDecimal::from(bps_times_ten_group) {
+                        let market_liquidity = current_data
+                            .entry(bps_times_ten_group)
+                            .or_insert(MarketLiquidity::new());
+                        market_liquidity.quote += &order.size * &order.price;
+                    }
+                }
+            }
+        }
+        liquidity
+    }
+}
+
+impl InsertableFeed for Liquidity {
+    async fn save<'a>(&self, timestamp: chrono::prelude::DateTime<chrono::prelude::Utc>, transaction: &mut Transaction<'a, Postgres>) {
+        for (key, value) in self {
+            for (bps_times_ten, liquidity) in value {
+                sqlx::query!(
+                    "INSERT INTO aggv2.liquidity VALUES ($1, $2, $3, $4, $5)",
+                    timestamp,
+                    key.clone().inner(),
+                    liquidity.base.clone().inner(),
+                    liquidity.quote.clone().inner(),
+                    bps_times_ten,
+                ).execute(transaction as &mut PgConnection)
+                .await.unwrap();
+            }
+        }
+    }
+}

--- a/src/rust/aggv2/src/feed/spread.rs
+++ b/src/rust/aggv2/src/feed/spread.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use sqlx::Transaction;
+use sqlx_postgres::{Postgres, PgConnection};
+
+use crate::{numeric::{*}, feed::ContractState};
+
+use super::{FeedFromFeed, InsertableFeed};
+
+pub type Spread = HashMap<MarketId, MarketSpread>;
+
+#[derive(Clone)]
+pub struct MarketSpread {
+    pub min_ask: Option<Price>,
+    pub max_bid: Option<Price>,
+}
+
+impl FeedFromFeed<ContractState> for Spread {
+    fn from_feed(state: &ContractState) -> Self {
+        let mut spread = Self::default();
+        for (market_id, market) in state.markets.iter() {
+            let current_data = spread.entry(market_id.clone()).or_insert(MarketSpread {
+                min_ask: None,
+                max_bid: None,
+            });
+            let current_min_ask = current_data.min_ask.clone();
+            let current_max_bid = current_data.max_bid.clone();
+            let min_ask = market.asks.iter().map(|(_, order)| order.price.clone()).min();
+            let max_bid = market.bids.iter().map(|(_, order)| order.price.clone()).max();
+            current_data.min_ask = current_min_ask.min(min_ask);
+            current_data.max_bid = current_max_bid.min(max_bid);
+        }
+        spread
+    }
+}
+
+impl InsertableFeed for Spread {
+    async fn save<'a>(&self, timestamp: DateTime<Utc>, transaction: &mut Transaction<'a, Postgres>) {
+        for (key, value) in self {
+            sqlx::query!(
+                "INSERT INTO aggv2.spread VALUES ($1, $2, $3, $4)",
+                timestamp,
+                key.clone().inner(),
+                value.clone().min_ask.map(|o| o.inner()),
+                value.clone().max_bid.map(|o| o.inner())
+            ).execute(transaction as &mut PgConnection)
+            .await.unwrap();
+        }
+    }
+}

--- a/src/rust/aggv2/src/feed/state.rs
+++ b/src/rust/aggv2/src/feed/state.rs
@@ -1,0 +1,331 @@
+use std::collections::HashMap;
+
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
+use sqlx::Transaction;
+use sqlx_postgres::{PgPool, Postgres, PgConnection};
+
+use crate::{Direction, Event, numeric::*};
+
+use super::{FeedFromEventsAndPrevState, InsertableFeed};
+
+#[derive(Debug)]
+pub struct ContractState {
+    pub markets: HashMap<MarketId, MarketState>,
+    pub timestamp: DateTime<Utc>,
+    pub transaction_version: TxnVersion,
+}
+
+#[derive(Debug)]
+pub struct MarketState {
+    pub asks: HashMap<OrderId, LimitOrder>,
+    pub bids: HashMap<OrderId, LimitOrder>,
+    pub accounts: HashMap<String, Account>,
+    pub last_price: Option<Price>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Account {
+    pub base: BaseSubunit,
+    pub quote: QuoteSubunit,
+}
+
+#[derive(Clone, Debug)]
+pub struct LimitOrder {
+    pub last_changed: BlockchainTimestamp,
+    pub user: String,
+    pub custodian_id: BigDecimal,
+    pub direction: Direction,
+    pub integrator: String,
+    pub price: Price,
+    pub size: Lot,
+}
+
+impl ContractState {
+    pub fn update_timestamp(&mut self, timestamp: DateTime<Utc>) {
+        self.timestamp = timestamp;
+    }
+}
+
+impl FeedFromEventsAndPrevState for ContractState {
+    async fn get_prev_state(pool: &PgPool) -> Self {
+        let state_cache = sqlx::query!("SELECT * FROM aggv2.state_cache").fetch_optional(pool).await.unwrap();
+        if let Some(state_cache) = state_cache {
+            let orders_cache = sqlx::query!("SELECT * FROM aggv2.order_cache").fetch_all(pool).await.unwrap();
+            let accounts_cache = sqlx::query!("SELECT * FROM aggv2.account_cache").fetch_all(pool).await.unwrap();
+            let markets_cache = sqlx::query!("SELECT * FROM aggv2.market_cache").fetch_all(pool).await.unwrap();
+            let mut markets = HashMap::new();
+            for market_cache in markets_cache {
+                let market = MarketState {
+                    asks: Default::default(),
+                    bids: Default::default(),
+                    accounts: Default::default(),
+                    last_price: market_cache.last_price.map(|p| Price::new(p)),
+                };
+                markets.insert(MarketId::new(market_cache.market_id), market);
+            }
+
+            for account_cache in accounts_cache {
+                let account = Account {
+                    base: BaseSubunit::new(account_cache.base),
+                    quote: QuoteSubunit::new(account_cache.quote),
+                };
+                markets.get_mut(&MarketId::new(account_cache.market_id)).unwrap().accounts.insert(account_cache.user, account);
+            }
+
+            for order_cache in orders_cache {
+                let order = LimitOrder {
+                    last_changed: BlockchainTimestamp::from_raw_parts(TxnVersion::new(order_cache.last_changed_transaction_version), EventId::new(order_cache.last_changed_event_id)),
+                    user: order_cache.user,
+                    custodian_id: order_cache.custodian_id,
+                    direction: if order_cache.is_ask { Direction::Ask } else { Direction::Bid },
+                    integrator: order_cache.integrator,
+                    price: Price::new(order_cache.price),
+                    size: Lot::new(order_cache.size),
+                };
+                if order_cache.is_ask {
+                    markets.get_mut(&MarketId::new(order_cache.market_id)).unwrap().asks.insert(OrderId::new(order_cache.order_id), order);
+                } else {
+                    markets.get_mut(&MarketId::new(order_cache.market_id)).unwrap().bids.insert(OrderId::new(order_cache.order_id), order);
+                }
+            }
+
+            ContractState {
+                markets,
+                timestamp: state_cache.time,
+                transaction_version: TxnVersion::new(state_cache.transaction_version),
+            }
+        } else {
+            let timestamp = sqlx::query!(r#"
+WITH mins AS (
+    SELECT MIN("time") AS "time" FROM balance_updates_by_handle  UNION
+    SELECT MIN("time") AS "time" FROM cancel_order_events        UNION
+    SELECT MIN("time") AS "time" FROM change_order_size_events   UNION
+    SELECT MIN("time") AS "time" FROM fill_events                UNION
+    SELECT MIN("time") AS "time" FROM market_registration_events UNION
+    SELECT MIN("time") AS "time" FROM place_limit_order_events   UNION
+    SELECT MIN("time") AS "time" FROM place_market_order_events  UNION
+    SELECT MIN("time") AS "time" FROM place_swap_order_events    UNION
+    SELECT MIN("time") AS "time" FROM recognized_market_events
+)
+SELECT MIN("time") AS "time" FROM mins
+            "#).fetch_optional(pool)
+                .await
+                .unwrap()
+                .map(|r| r.time)
+                .flatten()
+                .unwrap_or(DateTime::UNIX_EPOCH);
+            let transaction_version = sqlx::query!(r#"
+WITH mins AS (
+    SELECT MIN(txn_version) AS txn_version FROM balance_updates_by_handle  UNION
+    SELECT MIN(txn_version) AS txn_version FROM cancel_order_events        UNION
+    SELECT MIN(txn_version) AS txn_version FROM change_order_size_events   UNION
+    SELECT MIN(txn_version) AS txn_version FROM fill_events                UNION
+    SELECT MIN(txn_version) AS txn_version FROM market_registration_events UNION
+    SELECT MIN(txn_version) AS txn_version FROM place_limit_order_events   UNION
+    SELECT MIN(txn_version) AS txn_version FROM place_market_order_events  UNION
+    SELECT MIN(txn_version) AS txn_version FROM place_swap_order_events    UNION
+    SELECT MIN(txn_version) AS txn_version FROM recognized_market_events
+)
+SELECT MIN(txn_version) AS txn_version FROM mins
+            "#).fetch_optional(pool)
+                .await
+                .unwrap()
+                .map(|r| r.txn_version)
+                .flatten()
+                .unwrap_or(BigDecimal::from(0));
+            ContractState {
+                markets: Default::default(),
+                timestamp,
+                transaction_version: TxnVersion::new(transaction_version),
+            }
+        }
+    }
+
+    fn update(&mut self, events: &Vec<Event>) {
+        for event in events {
+            match event.clone() {
+                Event::MarketRegistration { market_id, .. } => {
+                    self.markets.insert(
+                        MarketId::from(market_id),
+                        MarketState {
+                            asks: Default::default(),
+                            bids: Default::default(),
+                            accounts: Default::default(),
+                            last_price: None,
+                        },
+                    );
+                }
+                Event::PlaceLimitOrder {
+                    txn_version,
+                    event_idx,
+                    market_id,
+                    user,
+                    custodian_id,
+                    order_id,
+                    side,
+                    integrator,
+                    price,
+                    size,
+                    ..
+                } => {
+                    let market = self.markets.get_mut(&MarketId::from(market_id)).unwrap();
+                    if matches!(side, Direction::Ask) {
+                        market.asks.insert(
+                            OrderId::from(order_id),
+                            LimitOrder {
+                                last_changed: BlockchainTimestamp::from_raw_parts(txn_version, event_idx),
+                                user,
+                                custodian_id,
+                                direction: Direction::Ask,
+                                integrator,
+                                price,
+                                size,
+                            },
+                        );
+                    } else {
+                        market.bids.insert(
+                            OrderId::from(order_id),
+                            LimitOrder {
+                                last_changed: BlockchainTimestamp::from_raw_parts(txn_version, event_idx),
+                                user,
+                                custodian_id,
+                                direction: Direction::Bid,
+                                integrator,
+                                price,
+                                size,
+                            },
+                        );
+                    }
+                }
+                Event::Fill {
+                    emit_address,
+                    maker_address,
+                    maker_order_id,
+                    maker_side,
+                    market_id,
+                    size,
+                    taker_order_id,
+                    price,
+                    ..
+                } => {
+                    if maker_address == emit_address {
+                        let market = self.markets.get_mut(&MarketId::from(market_id)).unwrap();
+                        market.last_price = Some(price);
+                        let (maker_order, taker_order) = if matches!(maker_side, Direction::Ask) {
+                            (
+                                market.asks.get_mut(&OrderId::from(maker_order_id)),
+                                market.bids.get_mut(&OrderId::from(taker_order_id)),
+                            )
+                        } else {
+                            (
+                                market.bids.get_mut(&OrderId::from(maker_order_id)),
+                                market.asks.get_mut(&OrderId::from(taker_order_id)),
+                            )
+                        };
+                        if let Some(maker_order) = maker_order {
+                            maker_order.size -= size.clone();
+                        }
+                        if let Some(taker_order) = taker_order {
+                            taker_order.size -= size.clone();
+                        }
+                    }
+                }
+                Event::Cancel {
+                    market_id,
+                    order_id,
+                    ..
+                } => {
+                    let market = self.markets.get_mut(&MarketId::from(market_id)).unwrap();
+                    let order_id = OrderId::from(order_id);
+                    market.asks.remove(&order_id);
+                    market.bids.remove(&order_id);
+                }
+                Event::ChangeSize {
+                    txn_version,
+                    event_idx,
+                    market_id,
+                    order_id,
+                    side,
+                    new_size,
+                    ..
+                } => {
+                    let market = self.markets.get_mut(&MarketId::from(market_id)).unwrap();
+                    let order = if matches!(side, Direction::Ask) {
+                        market.asks.get_mut(&OrderId::from(order_id))
+                    } else {
+                        market.bids.get_mut(&OrderId::from(order_id))
+                    };
+                    if let Some(order) = order {
+                        order.size = new_size;
+                        order.last_changed =
+                            BlockchainTimestamp::from_raw_parts(txn_version, event_idx);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl InsertableFeed for ContractState {
+    async fn save<'a>(&self, _timestamp: DateTime<Utc>, transaction: &mut Transaction<'a, Postgres>) {
+        sqlx::query!("DELETE FROM aggv2.state_cache").execute(transaction as &mut PgConnection).await.unwrap();
+        sqlx::query!("DELETE FROM aggv2.account_cache").execute(transaction as &mut PgConnection).await.unwrap();
+        sqlx::query!("DELETE FROM aggv2.market_cache").execute(transaction as &mut PgConnection).await.unwrap();
+        sqlx::query!("DELETE FROM aggv2.order_cache").execute(transaction as &mut PgConnection).await.unwrap();
+        sqlx::query!(
+            "INSERT INTO aggv2.state_cache VALUES ($1, $2)",
+            self.timestamp,
+            self.transaction_version.clone().inner(),
+        ).execute(transaction as &mut PgConnection).await.unwrap();
+        for (market_id, market) in &self.markets {
+            sqlx::query!(
+                "INSERT INTO aggv2.market_cache VALUES ($1, $2)",
+                market_id.clone().inner(),
+                market.last_price.clone().map(|lp| lp.inner()),
+            ).execute(transaction as &mut PgConnection).await.unwrap();
+            for (order_id, order) in &market.asks {
+                let order = order.clone();
+                sqlx::query!(
+                    "INSERT INTO aggv2.order_cache VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+                    market_id.clone().inner(),
+                    true,
+                    order_id.clone().inner(),
+                    order.last_changed.get_transaction_version().clone().inner(),
+                    order.last_changed.get_event_id().clone().inner(),
+                    order.user,
+                    order.custodian_id,
+                    order.integrator,
+                    order.price.inner(),
+                    order.size.inner()
+                ).execute(transaction as &mut PgConnection).await.unwrap();
+            }
+            for (order_id, order) in &market.bids {
+                let order = order.clone();
+                sqlx::query!(
+                    "INSERT INTO aggv2.order_cache VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+                    market_id.clone().inner(),
+                    false,
+                    order_id.clone().inner(),
+                    order.last_changed.get_transaction_version().clone().inner(),
+                    order.last_changed.get_event_id().clone().inner(),
+                    order.user,
+                    order.custodian_id,
+                    order.integrator,
+                    order.price.inner(),
+                    order.size.inner()
+                ).execute(transaction as &mut PgConnection).await.unwrap();
+            }
+            for (account_id, account) in &market.accounts {
+                sqlx::query!(
+                    "INSERT INTO aggv2.account_cache VALUES ($1, $2, $3, $4)",
+                    market_id.clone().inner(),
+                    account_id,
+                    account.base.clone().inner(),
+                    account.quote.clone().inner(),
+                ).execute(transaction as &mut PgConnection).await.unwrap();
+            }
+        }
+    }
+}

--- a/src/rust/aggv2/src/feed/volume.rs
+++ b/src/rust/aggv2/src/feed/volume.rs
@@ -8,7 +8,7 @@ use crate::{numeric::*, Event};
 
 use super::{FeedFromEventsAndPrevState, InsertableFeed};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Volume {
     markets: HashMap<MarketId, MarketVolume>,
 }
@@ -20,11 +20,11 @@ pub struct MarketVolume {
 }
 
 impl FeedFromEventsAndPrevState for Volume {
-    fn update(&mut self, events: &Vec<Event>) {
+    fn update<'a>(&mut self, events: impl Iterator<Item = &'a Event>) {
         for prev_vol in self.markets.iter_mut() {
             prev_vol.1.period = Tick::new(0);
         }
-        for event in events.iter() {
+        for event in events {
             match event {
                 Event::MarketRegistration { market_id, .. } => {
                     self.markets.insert(MarketId::from(market_id.clone()), MarketVolume {

--- a/src/rust/aggv2/src/feed/volume.rs
+++ b/src/rust/aggv2/src/feed/volume.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use sqlx::Transaction;
+use sqlx_postgres::{PgPool, Postgres, PgConnection};
+
+use crate::{numeric::*, Event};
+
+use super::{FeedFromEventsAndPrevState, InsertableFeed};
+
+#[derive(Debug)]
+pub struct Volume {
+    markets: HashMap<MarketId, MarketVolume>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MarketVolume {
+    pub cumulative: Tick,
+    pub period: Tick,
+}
+
+impl FeedFromEventsAndPrevState for Volume {
+    fn update(&mut self, events: &Vec<Event>) {
+        for prev_vol in self.markets.iter_mut() {
+            prev_vol.1.period = Tick::new(0);
+        }
+        for event in events.iter() {
+            match event {
+                Event::MarketRegistration { market_id, .. } => {
+                    self.markets.insert(MarketId::from(market_id.clone()), MarketVolume {
+                        cumulative: Tick::new(0),
+                        period: Tick::new(0),
+                    });
+                }
+                Event::Fill { size, price, market_id, .. } => {
+                    let market_volume = self.markets.get_mut(&MarketId::from(market_id.clone())).unwrap();
+                    market_volume.cumulative += size * price;
+                    market_volume.period += size * price;
+                },
+                _ => {}
+            }
+        }
+    }
+
+    async fn get_prev_state(pool: &PgPool) -> Self {
+        let r = sqlx::query!(
+            r#"SELECT DISTINCT ON (market_id) * FROM aggv2.volume ORDER BY market_id, "time" DESC"#
+        ).fetch_all(pool)
+        .await.unwrap();
+        let mut volume = Volume {
+            markets: Default::default()
+        };
+        for row in r {
+            let market = volume.markets.entry(MarketId::new(row.market_id)).or_insert(MarketVolume {
+                cumulative: Tick::new(0),
+                period: Tick::new(0),
+            });
+            market.cumulative = Tick::new(row.cumulative);
+            market.period = Tick::new(row.period);
+        }
+        volume
+    }
+}
+
+impl InsertableFeed for Volume {
+    async fn save<'a>(&self, timestamp: DateTime<Utc>, transaction: &mut Transaction<'a, Postgres>) {
+        for (key, value) in &self.markets {
+            sqlx::query!(
+                "INSERT INTO aggv2.volume VALUES ($1, $2, $3, $4)",
+                timestamp,
+                key.clone().inner(),
+                value.clone().cumulative.inner(),
+                value.clone().period.inner()
+            ).execute(transaction as &mut PgConnection)
+            .await.unwrap();
+        }
+    }
+}

--- a/src/rust/aggv2/src/main.rs
+++ b/src/rust/aggv2/src/main.rs
@@ -1,0 +1,200 @@
+use bigdecimal::BigDecimal;
+use chrono::{Utc, DateTime};
+use numeric::{BlockchainTimestamp, OrderId, TxnVersion, EventId};
+
+mod feed;
+mod numeric;
+
+use numeric::*;
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    BalanceUpdatesByHandle {
+        txn_version: TxnVersion,
+        market_id: MarketId,
+        custodian_id: BigDecimal,
+        time: DateTime<Utc>,
+        base_total: BaseSubunit,
+        base_available: BaseSubunit,
+        base_ceiling: BaseSubunit,
+        quote_total: QuoteSubunit,
+        quote_available: QuoteSubunit,
+        quote_ceiling: QuoteSubunit,
+    },
+    MarketRegistration {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        market_id: MarketId,
+        time: DateTime<Utc>,
+        base_account_address: Option<String>,
+        base_module_name: Option<String>,
+        base_struct_name: Option<String>,
+        base_name_generic: Option<String>,
+        quote_account_address: String,
+        quote_module_name: String,
+        quote_struct_name: String,
+        lot_size: BigDecimal,
+        tick_size: BigDecimal,
+        min_size: Lot,
+        underwriter_id: BigDecimal,
+    },
+    MarketRecognition {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        market_id: MarketId,
+        time: DateTime<Utc>,
+        base_account_address: Option<String>,
+        base_module_name: Option<String>,
+        base_struct_name: Option<String>,
+        base_name_generic: Option<String>,
+        quote_account_address: String,
+        quote_module_name: String,
+        quote_struct_name: String,
+        lot_size: BigDecimal,
+        tick_size: BigDecimal,
+        min_size: Lot,
+        underwriter_id: BigDecimal,
+    },
+    PlaceLimitOrder {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        time: DateTime<Utc>,
+        market_id: MarketId,
+        user: String,
+        custodian_id: BigDecimal,
+        order_id: OrderId,
+        side: Direction,
+        integrator: String,
+        initial_size: Lot,
+        price: Price,
+        restriction: i16,
+        self_match_behavior: i16,
+        size: Lot,
+    },
+    PlaceMarketOrder {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        time: DateTime<Utc>,
+        market_id: MarketId,
+        user: String,
+        custodian_id: BigDecimal,
+        order_id: OrderId,
+        direction: Direction,
+        integrator: String,
+        self_match_behavior: i16,
+        size: Lot,
+    },
+    PlaceSwapOrder {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        time: DateTime<Utc>,
+        market_id: MarketId,
+        order_id: OrderId,
+        direction: Direction,
+        signing_account: String,
+        integrator: String,
+        min_base: BigDecimal,
+        max_base: BigDecimal,
+        min_quote: BigDecimal,
+        max_quote: BigDecimal,
+        limit_price: Price,
+    },
+    Fill {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        emit_address: String,
+        time: DateTime<Utc>,
+        maker_address: String,
+        maker_custodian_id: BigDecimal,
+        maker_order_id: OrderId,
+        maker_side: Direction,
+        market_id: MarketId,
+        price: Price,
+        sequence_number_for_trade: BigDecimal,
+        size: Lot,
+        taker_address: String,
+        taker_custodian_id: BigDecimal,
+        taker_order_id: OrderId,
+        taker_quote_fees_paid: BigDecimal,
+    },
+    Cancel {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        time: DateTime<Utc>,
+        market_id: MarketId,
+        user: String,
+        custodian_id: BigDecimal,
+        order_id: OrderId,
+        reason: i16,
+    },
+    ChangeSize {
+        txn_version: TxnVersion,
+        event_idx: EventId,
+        time: DateTime<Utc>,
+        market_id: MarketId,
+        user: String,
+        custodian_id: BigDecimal,
+        order_id: OrderId,
+        side: Direction,
+        new_size: Lot,
+    },
+}
+
+impl Event {
+    pub fn blockchain_timestamp(&self) -> BlockchainTimestamp {
+        match self.clone() {
+            Event::MarketRegistration { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::PlaceLimitOrder { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::PlaceMarketOrder { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::PlaceSwapOrder { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::Fill { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::Cancel { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::ChangeSize { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            },
+            Event::BalanceUpdatesByHandle { txn_version, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, EventId::new(0))
+            },
+            Event::MarketRecognition { txn_version, event_idx, .. } => {
+                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Direction {
+    Ask,
+    Bid,
+}
+
+impl From<bool> for Direction {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::Ask
+        } else {
+            Self::Bid
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("aggv2=TRACE")
+        .init();
+    feed::run().await?;
+    Ok(())
+}

--- a/src/rust/aggv2/src/main.rs
+++ b/src/rust/aggv2/src/main.rs
@@ -1,6 +1,6 @@
 use bigdecimal::BigDecimal;
 use chrono::{Utc, DateTime};
-use numeric::{BlockchainTimestamp, OrderId, TxnVersion, EventId};
+use numeric::{BlockStamp, OrderId, TransactionVersion, EventIndex};
 
 mod feed;
 mod numeric;
@@ -10,7 +10,7 @@ use numeric::*;
 #[derive(Clone, Debug)]
 pub enum Event {
     BalanceUpdatesByHandle {
-        txn_version: TxnVersion,
+        txn_version: TransactionVersion,
         market_id: MarketId,
         custodian_id: BigDecimal,
         time: DateTime<Utc>,
@@ -22,8 +22,8 @@ pub enum Event {
         quote_ceiling: QuoteSubunit,
     },
     MarketRegistration {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         market_id: MarketId,
         time: DateTime<Utc>,
         base_account_address: Option<String>,
@@ -39,8 +39,8 @@ pub enum Event {
         underwriter_id: BigDecimal,
     },
     MarketRecognition {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         market_id: MarketId,
         time: DateTime<Utc>,
         base_account_address: Option<String>,
@@ -56,8 +56,8 @@ pub enum Event {
         underwriter_id: BigDecimal,
     },
     PlaceLimitOrder {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         time: DateTime<Utc>,
         market_id: MarketId,
         user: String,
@@ -72,8 +72,8 @@ pub enum Event {
         size: Lot,
     },
     PlaceMarketOrder {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         time: DateTime<Utc>,
         market_id: MarketId,
         user: String,
@@ -85,8 +85,8 @@ pub enum Event {
         size: Lot,
     },
     PlaceSwapOrder {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         time: DateTime<Utc>,
         market_id: MarketId,
         order_id: OrderId,
@@ -100,8 +100,8 @@ pub enum Event {
         limit_price: Price,
     },
     Fill {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         emit_address: String,
         time: DateTime<Utc>,
         maker_address: String,
@@ -118,8 +118,8 @@ pub enum Event {
         taker_quote_fees_paid: BigDecimal,
     },
     Cancel {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         time: DateTime<Utc>,
         market_id: MarketId,
         user: String,
@@ -128,8 +128,8 @@ pub enum Event {
         reason: i16,
     },
     ChangeSize {
-        txn_version: TxnVersion,
-        event_idx: EventId,
+        txn_version: TransactionVersion,
+        event_idx: EventIndex,
         time: DateTime<Utc>,
         market_id: MarketId,
         user: String,
@@ -141,34 +141,34 @@ pub enum Event {
 }
 
 impl Event {
-    pub fn blockchain_timestamp(&self) -> BlockchainTimestamp {
+    pub fn blockstamp(&self) -> BlockStamp {
         match self.clone() {
             Event::MarketRegistration { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::PlaceLimitOrder { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::PlaceMarketOrder { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::PlaceSwapOrder { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::Fill { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::Cancel { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::ChangeSize { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             },
             Event::BalanceUpdatesByHandle { txn_version, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, EventId::new(0))
+                BlockStamp::from_raw_parts(txn_version, EventIndex::new(0))
             },
             Event::MarketRecognition { txn_version, event_idx, .. } => {
-                BlockchainTimestamp::from_raw_parts(txn_version, event_idx)
+                BlockStamp::from_raw_parts(txn_version, event_idx)
             }
         }
     }

--- a/src/rust/aggv2/src/numeric.rs
+++ b/src/rust/aggv2/src/numeric.rs
@@ -1,0 +1,229 @@
+use std::fmt::Display;
+
+use bigdecimal::BigDecimal;
+
+macro_rules! make_numeric_type {
+    ($name:ident) => {
+        #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone)]
+        pub struct $name(BigDecimal);
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}({})", stringify!($name), self.0)
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl $name {
+            pub fn new(value: impl Into<BigDecimal>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn inner(self) -> BigDecimal {
+                self.0
+            }
+        }
+
+        impl std::ops::Add for $name {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self::Output {
+                $name(self.0 + rhs.0)
+            }
+        }
+
+        impl std::ops::Sub for $name {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self::Output {
+                $name(self.0 - rhs.0)
+            }
+        }
+
+        impl std::ops::Add<u64> for $name {
+            type Output = Self;
+            fn add(self, rhs: u64) -> Self::Output {
+                $name(self.0 + bigdecimal::BigDecimal::from(rhs))
+            }
+        }
+
+        impl std::ops::Sub<u64> for $name {
+            type Output = Self;
+            fn sub(self, rhs: u64) -> Self::Output {
+                $name(self.0 - bigdecimal::BigDecimal::from(rhs))
+            }
+        }
+
+        impl std::ops::AddAssign for $name {
+            fn add_assign(&mut self, rhs: Self) {
+                self.0 += rhs.0;
+            }
+        }
+
+        impl std::ops::SubAssign for $name {
+            fn sub_assign(&mut self, rhs: Self) {
+                self.0 -= rhs.0;
+            }
+        }
+
+        impl std::ops::AddAssign<u64> for $name {
+            fn add_assign(&mut self, rhs: u64) {
+                self.0 += bigdecimal::BigDecimal::from(rhs);
+            }
+        }
+
+        impl std::ops::SubAssign<u64> for $name {
+            fn sub_assign(&mut self, rhs: u64) {
+                self.0 -= bigdecimal::BigDecimal::from(rhs);
+            }
+        }
+
+        impl std::ops::Mul for $name {
+            type Output = Self;
+            fn mul(self, rhs: Self) -> Self::Output {
+                $name(self.0 * rhs.0)
+            }
+        }
+
+        impl std::ops::Div for $name {
+            type Output = Self;
+            fn div(self, rhs: Self) -> Self::Output {
+                $name(self.0 / rhs.0)
+            }
+        }
+
+        impl std::ops::Mul<u64> for $name {
+            type Output = Self;
+            fn mul(self, rhs: u64) -> Self::Output {
+                $name(self.0 * bigdecimal::BigDecimal::from(rhs))
+            }
+        }
+
+        impl std::ops::Div<u64> for $name {
+            type Output = Self;
+            fn div(self, rhs: u64) -> Self::Output {
+                $name(self.0 / bigdecimal::BigDecimal::from(rhs))
+            }
+        }
+
+        impl std::ops::MulAssign for $name {
+            fn mul_assign(&mut self, rhs: Self) {
+                self.0 *= rhs.0;
+            }
+        }
+
+        impl std::ops::DivAssign for $name {
+            fn div_assign(&mut self, rhs: Self) {
+                self.0 = &self.0 / rhs.0;
+            }
+        }
+
+        impl std::ops::MulAssign<u64> for $name {
+            fn mul_assign(&mut self, rhs: u64) {
+                self.0 *= bigdecimal::BigDecimal::from(rhs);
+            }
+        }
+
+        impl std::ops::DivAssign<u64> for $name {
+            fn div_assign(&mut self, rhs: u64) {
+                self.0 = &self.0 / bigdecimal::BigDecimal::from(rhs);
+            }
+        }
+    };
+}
+
+make_numeric_type!(MarketId);
+make_numeric_type!(OrderId);
+make_numeric_type!(TxnVersion);
+make_numeric_type!(EventId);
+make_numeric_type!(Lot);
+make_numeric_type!(Tick);
+make_numeric_type!(BaseSubunit);
+make_numeric_type!(QuoteSubunit);
+make_numeric_type!(Price);
+
+#[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct BlockchainTimestamp(TxnVersion, EventId);
+
+impl Display for BlockchainTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({})", self.0, self.1)
+    }
+}
+
+impl std::fmt::Debug for BlockchainTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}({:?})", self.0, self.1)
+    }
+}
+
+impl BlockchainTimestamp {
+    pub fn from_raw_parts(transaction_version: impl Into<TxnVersion>, event_id: impl Into<EventId>) -> Self {
+        BlockchainTimestamp(transaction_version.into(), event_id.into())
+    }
+
+    pub fn from_transaction_version(transaction_version: TxnVersion) -> Self {
+        BlockchainTimestamp(transaction_version, EventId::new(0))
+    }
+
+    pub fn bump_version(&mut self) {
+        self.0 += 1;
+        self.1 = EventId::new(0);
+    }
+
+    pub fn bump_event(&mut self) {
+        self.1 += 1;
+    }
+
+    pub fn get_transaction_version(&self) -> &TxnVersion {
+        &self.0
+    }
+
+    pub fn get_event_id(&self) -> &EventId {
+        &self.1
+    }
+}
+
+impl std::ops::Mul<Price> for Lot {
+    type Output = Tick;
+    fn mul(self, rhs: Price) -> Self::Output {
+        Tick(self.0 * rhs.0)
+    }
+}
+
+impl std::ops::Mul<&Price> for &Lot {
+    type Output = Tick;
+    fn mul(self, rhs: &Price) -> Self::Output {
+        Tick(&self.0 * &rhs.0)
+    }
+}
+
+impl std::ops::Div<Price> for Tick {
+    type Output = Lot;
+    fn div(self, rhs: Price) -> Self::Output {
+        Lot(self.0 / rhs.0)
+    }
+}
+
+impl std::ops::Div<&Price> for &Tick {
+    type Output = Lot;
+    fn div(self, rhs: &Price) -> Self::Output {
+        Lot(&self.0 / &rhs.0)
+    }
+}
+
+impl Tick {
+    pub fn to_subunits(self, tick_size: impl Into<BigDecimal>) -> QuoteSubunit {
+        QuoteSubunit(self.0 * tick_size.into())
+    }
+}
+
+impl Lot {
+    pub fn to_subunits(self, lot_size: impl Into<BigDecimal>) -> BaseSubunit {
+        BaseSubunit(self.0 * lot_size.into())
+    }
+}
+

--- a/src/rust/aggv2/src/numeric.rs
+++ b/src/rust/aggv2/src/numeric.rs
@@ -5,7 +5,7 @@ use bigdecimal::BigDecimal;
 macro_rules! make_numeric_type {
     ($name:ident) => {
         #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone)]
-        pub struct $name(BigDecimal);
+        pub struct $name(pub BigDecimal);
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -137,8 +137,8 @@ macro_rules! make_numeric_type {
 
 make_numeric_type!(MarketId);
 make_numeric_type!(OrderId);
-make_numeric_type!(TxnVersion);
-make_numeric_type!(EventId);
+make_numeric_type!(TransactionVersion);
+make_numeric_type!(EventIndex);
 make_numeric_type!(Lot);
 make_numeric_type!(Tick);
 make_numeric_type!(BaseSubunit);
@@ -146,43 +146,43 @@ make_numeric_type!(QuoteSubunit);
 make_numeric_type!(Price);
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct BlockchainTimestamp(TxnVersion, EventId);
+pub struct BlockStamp(TransactionVersion, EventIndex);
 
-impl Display for BlockchainTimestamp {
+impl Display for BlockStamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}({})", self.0, self.1)
     }
 }
 
-impl std::fmt::Debug for BlockchainTimestamp {
+impl std::fmt::Debug for BlockStamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}({:?})", self.0, self.1)
     }
 }
 
-impl BlockchainTimestamp {
-    pub fn from_raw_parts(transaction_version: impl Into<TxnVersion>, event_id: impl Into<EventId>) -> Self {
-        BlockchainTimestamp(transaction_version.into(), event_id.into())
+impl BlockStamp {
+    pub fn from_raw_parts(transaction_version: impl Into<TransactionVersion>, event_id: impl Into<EventIndex>) -> Self {
+        BlockStamp(transaction_version.into(), event_id.into())
     }
 
-    pub fn from_transaction_version(transaction_version: TxnVersion) -> Self {
-        BlockchainTimestamp(transaction_version, EventId::new(0))
+    pub fn from_transaction_version(transaction_version: TransactionVersion) -> Self {
+        BlockStamp(transaction_version, EventIndex::new(0))
     }
 
     pub fn bump_version(&mut self) {
         self.0 += 1;
-        self.1 = EventId::new(0);
+        self.1 = EventIndex::new(0);
     }
 
     pub fn bump_event(&mut self) {
         self.1 += 1;
     }
 
-    pub fn get_transaction_version(&self) -> &TxnVersion {
+    pub fn transaction_version(&self) -> &TransactionVersion {
         &self.0
     }
 
-    pub fn get_event_id(&self) -> &EventId {
+    pub fn event_index(&self) -> &EventIndex {
         &self.1
     }
 }

--- a/src/rust/dbv2/migrations/2024-04-01-112425_add_pkey_to_rolling_volume_history/down.sql
+++ b/src/rust/dbv2/migrations/2024-04-01-112425_add_pkey_to_rolling_volume_history/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE aggregator.daily_rolling_volume_history DROP CONSTRAINT daily_rolling_volume_history_pkey;
+ALTER TABLE aggregator.spreads DROP CONSTRAINT spreads_pkey;

--- a/src/rust/dbv2/migrations/2024-04-01-112425_add_pkey_to_rolling_volume_history/up.sql
+++ b/src/rust/dbv2/migrations/2024-04-01-112425_add_pkey_to_rolling_volume_history/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE aggregator.daily_rolling_volume_history ADD PRIMARY KEY ("time", market_id);
+ALTER TABLE aggregator.spreads ADD PRIMARY KEY ("time", market_id);

--- a/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/down.sql
+++ b/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/down.sql
@@ -1,0 +1,10 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE aggv2.order_cache;
+DROP TABLE aggv2.account_cache;
+DROP TABLE aggv2.market_cache;
+DROP TABLE aggv2.state_cache;
+DROP TABLE aggv2.spread;
+DROP TABLE aggv2.volume;
+DROP TABLE aggv2.liquidity;
+
+DROP SCHEMA aggv2;

--- a/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/up.sql
+++ b/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/up.sql
@@ -59,3 +59,11 @@ CREATE TABLE aggv2.liquidity (
     bps_times_ten INT NOT NULL,
     PRIMARY KEY (time, market_id, bps_times_ten)
 );
+
+CREATE TABLE events (
+    transaction_verson NUMERIC NOT NULL,
+    event_index NUMERIC NOT NULL,
+    "time" TIMESTAMPTZ NOT NULL,
+);
+
+CREATE INDEX events_time ON events ("time");

--- a/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/up.sql
+++ b/src/rust/dbv2/migrations/2024-04-09-142800_aggv2/up.sql
@@ -1,0 +1,61 @@
+-- Your SQL goes here
+CREATE SCHEMA aggv2;
+
+CREATE TABLE aggv2.order_cache (
+    market_id NUMERIC NOT NULL,
+    is_ask BOOLEAN NOT NULL,
+    order_id NUMERIC NOT NULL,
+    last_changed_transaction_version NUMERIC NOT NULL,
+    last_changed_event_id NUMERIC NOT NULL,
+    "user" TEXT NOT NULL,
+    custodian_id NUMERIC NOT NULL,
+    integrator TEXT NOT NULL,
+    price NUMERIC NOT NULL,
+    size NUMERIC NOT NULL,
+    PRIMARY KEY (market_id, order_id)
+);
+
+CREATE TABLE aggv2.account_cache (
+    market_id NUMERIC NOT NULL,
+    "user" TEXT NOT NULL,
+    base NUMERIC NOT NULL,
+    quote NUMERIC NOT NULL,
+    PRIMARY KEY (market_id, "user")
+);
+
+CREATE TABLE aggv2.market_cache (
+    market_id NUMERIC NOT NULL,
+    last_price NUMERIC,
+    PRIMARY KEY (market_id)
+);
+
+CREATE TABLE aggv2.state_cache (
+    time TIMESTAMPTZ NOT NULL,
+    transaction_version NUMERIC NOT NULL,
+    PRIMARY KEY (time, transaction_version)
+);
+
+CREATE TABLE aggv2.spread (
+    time TIMESTAMPTZ NOT NULL,
+    market_id NUMERIC NOT NULL,
+    min_ask NUMERIC,
+    max_bid NUMERIC,
+    PRIMARY KEY (time, market_id)
+);
+
+CREATE TABLE aggv2.volume (
+    time TIMESTAMPTZ NOT NULL,
+    market_id NUMERIC NOT NULL,
+    cumulative NUMERIC NOT NULL,
+    period NUMERIC NOT NULL,
+    PRIMARY KEY (time, market_id)
+);
+
+CREATE TABLE aggv2.liquidity (
+    time TIMESTAMPTZ NOT NULL,
+    market_id NUMERIC NOT NULL,
+    base NUMERIC NOT NULL,
+    quote NUMERIC NOT NULL,
+    bps_times_ten INT NOT NULL,
+    PRIMARY KEY (time, market_id, bps_times_ten)
+);


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds an experimental aggregator build that should improve performance over the old one.

# Testing

To test this PR, spin up the DSS with just the DB and the processor (`docker compose -f compose.dss-core.yaml up -d postgres diesel processor`).

Once up, you can start the new aggregator by going to `src/rust` and running `cargo run -p aggv2`.

# Checklist

- [x] Did you update relevant documentation?
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
- [x] ~Did you check off all checkboxes from the linked Linear task?~
