### PR TITLE
[ECO-1597] improve preformance of api.markets

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -20,6 +20,10 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 
 ## [v2.2.0] (in progress)
 
+### Changed
+
+- Improve performance of `/markets` endpoint ([#760]).
+
 ### Fixed
 
 - `/tickers` endpoint `base_volume_nominal` field ([#761]).
@@ -237,6 +241,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#746]: https://github.com/econia-labs/econia/pull/746
 [#749]: https://github.com/econia-labs/econia/pull/749
 [#753]: https://github.com/econia-labs/econia/pull/753
+[#760]: https://github.com/econia-labs/econia/pull/760
 [#761]: https://github.com/econia-labs/econia/pull/761
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1

--- a/src/rust/dbv2/migrations/2024-04-26-152225_optimize_markets/down.sql
+++ b/src/rust/dbv2/migrations/2024-04-26-152225_optimize_markets/down.sql
@@ -1,0 +1,83 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE VIEW
+  api.markets AS
+WITH
+  last_fills AS (
+    SELECT DISTINCT
+      ON (market_id) *
+    FROM
+      fill_events
+    WHERE
+      "time" >= CURRENT_TIMESTAMP - '1 day'::INTERVAL
+    ORDER BY
+      market_id,
+      txn_version DESC,
+      event_idx DESC
+  ),
+  first_fills AS (
+    SELECT DISTINCT
+      ON (market_id) *
+    FROM
+      fill_events
+    WHERE
+      "time" >= CURRENT_TIMESTAMP - '1 day'::INTERVAL
+    ORDER BY
+      market_id,
+      txn_version ASC,
+      event_idx ASC
+  )
+SELECT
+  m.market_id,
+  m.time AS registration_time,
+  m.base_account_address,
+  m.base_module_name,
+  m.base_struct_name,
+  m.base_name_generic,
+  m.quote_account_address,
+  m.quote_module_name,
+  m.quote_struct_name,
+  m.lot_size,
+  m.tick_size,
+  m.min_size,
+  m.underwriter_id,
+  CASE
+    WHEN r.market_id = m.market_id THEN TRUE
+    ELSE FALSE
+  END AS is_recognized,
+  l.price AS last_fill_price_24hr,
+  (COALESCE(l.price, 1) - COALESCE(f.price, 1)) / COALESCE(f.price, 1) * 100 AS price_change_as_percent_24hr,
+  l.price - f.price AS price_change_24hr,
+  v.min_price_24h,
+  v.max_price_24h,
+  v.base_volume_24h,
+  v.quote_volume_24h,
+  base.name AS base_name,
+  base.decimals AS base_decimals,
+  base.symbol AS base_symbol,
+  "quote".name AS quote_name,
+  "quote".decimals AS quote_decimals,
+  "quote".symbol AS quote_symbol
+FROM
+  market_registration_events AS m
+  LEFT JOIN aggregator.recognized_markets AS r ON COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+  AND COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+  AND COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+  AND COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+  AND r.quote_account_address = m.quote_account_address
+  AND r.quote_module_name = m.quote_module_name
+  AND r.quote_struct_name = m.quote_struct_name
+  LEFT JOIN aggregator.coins AS base ON base.address = COALESCE(m.base_account_address, '')
+  AND base.module = COALESCE(m.base_module_name, '')
+  AND base.struct = COALESCE(m.base_struct_name, '')
+  LEFT JOIN aggregator.coins AS "quote" ON "quote".address = COALESCE(m.quote_account_address, '')
+  AND "quote".module = COALESCE(m.quote_module_name, '')
+  AND "quote".struct = COALESCE(m.quote_struct_name, '')
+  LEFT JOIN first_fills AS f ON f.market_id = m.market_id
+  LEFT JOIN last_fills AS l ON l.market_id = m.market_id
+  LEFT JOIN aggregator.markets_24h_data AS v ON v.market_id = m.market_id;
+
+
+DROP INDEX markets_market_id_txn_version_event_idx;
+
+
+GRANT SELECT ON api.markets TO web_anon;

--- a/src/rust/dbv2/migrations/2024-04-26-152225_optimize_markets/up.sql
+++ b/src/rust/dbv2/migrations/2024-04-26-152225_optimize_markets/up.sql
@@ -1,0 +1,101 @@
+-- Your SQL goes here
+CREATE INDEX markets_market_id_txn_version_event_idx ON fill_events (market_id, txn_version DESC, event_idx DESC);
+
+CREATE OR REPLACE VIEW api.markets AS
+WITH x AS (
+    SELECT
+        m.market_id,
+        m.time AS registration_time,
+        m.base_account_address,
+        m.base_module_name,
+        m.base_struct_name,
+        m.base_name_generic,
+        m.quote_account_address,
+        m.quote_module_name,
+        m.quote_struct_name,
+        m.lot_size,
+        m.tick_size,
+        m.min_size,
+        m.underwriter_id,
+        CASE
+            WHEN r.market_id = m.market_id THEN true
+            ELSE false
+        END AS is_recognized,
+	(SELECT price FROM api.prices WHERE prices.market_id = m.market_id AND "start_time_1m_period" < CURRENT_TIMESTAMP - interval '24 hours' ORDER BY "start_time_1m_period" DESC LIMIT 1) AS price_24h_ago,
+        (SELECT price FROM fill_events WHERE fill_events.market_id = m.market_id ORDER BY txn_version DESC, event_idx DESC LIMIT 1) AS last_fill_price_24hr,
+        v.min_price_24h,
+        v.max_price_24h,
+        v.base_volume_24h,
+        v.quote_volume_24h
+    FROM
+        market_registration_events AS m
+    LEFT JOIN
+        aggregator.recognized_markets AS r
+    ON
+        COALESCE(r.base_account_address, '') = COALESCE(m.base_account_address, '')
+    AND
+        COALESCE(r.base_module_name, '') = COALESCE(m.base_module_name, '')
+    AND
+        COALESCE(r.base_struct_name, '') = COALESCE(m.base_struct_name, '')
+    AND
+        COALESCE(r.base_name_generic, '') = COALESCE(m.base_name_generic, '')
+    AND
+        r.quote_account_address = m.quote_account_address
+    AND
+        r.quote_module_name = m.quote_module_name
+    AND
+        r.quote_struct_name = m.quote_struct_name
+    LEFT JOIN
+        aggregator.markets_24h_data AS v
+    ON
+        v.market_id = m.market_id
+)
+SELECT
+    market_id,
+    registration_time,
+    base_account_address,
+    base_module_name,
+    base_struct_name,
+    base_name_generic,
+    quote_account_address,
+    quote_module_name,
+    quote_struct_name,
+    lot_size,
+    tick_size,
+    min_size,
+    underwriter_id,
+    is_recognized,
+    last_fill_price_24hr,
+    CASE
+        WHEN last_fill_price_24hr IS NULL THEN NULL
+        ELSE (last_fill_price_24hr - price_24h_ago) / price_24h_ago * 100
+    END AS price_change_as_percent_24hr,
+    CASE
+        WHEN last_fill_price_24hr IS NULL THEN NULL
+        ELSE last_fill_price_24hr - price_24h_ago
+    END AS price_change_24hr,
+    min_price_24h,
+    max_price_24h,
+    base_volume_24h,
+    quote_volume_24h,
+    base.name AS base_name,
+    base.decimals AS base_decimals,
+    base.symbol AS base_symbol,
+    "quote".name AS quote_name,
+    "quote".decimals AS quote_decimals,
+    "quote".symbol AS quote_symbol
+FROM
+    x
+LEFT JOIN
+    aggregator.coins AS base
+    ON base.address = COALESCE(x.base_account_address, '')
+    AND base.module = COALESCE(x.base_module_name, '')
+    AND base.struct = COALESCE(x.base_struct_name, '')
+LEFT JOIN
+    aggregator.coins AS "quote"
+    ON "quote".address = COALESCE(x.quote_account_address, '')
+    AND "quote".module = COALESCE(x.quote_module_name, '')
+    AND "quote".struct = COALESCE(x.quote_struct_name, '');
+
+
+GRANT SELECT ON api.markets TO web_anon;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR vastly improves the performance of the `api.markets` SQL view. This
will help DSS providers lower their infrastructure costs, since this is a very
used endpoint, and will lower their CPU/disk usage.

Note that price 24h ago is now using the new `prices` table, which means it is
a weighted price over a 1 min period instead of an instant and quite random
fill price.

# Testing

- Spin up a DSS instance.
- Sync.
- `curl localhost:3000/markets` and compare with `curl https://aptos-mainnet-econia.nodeinfra.com/markets`
- Results should be the same within margin of error.

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
