### PR TITLE
[ECO-1624] fix nominal error in /tickers endpoint

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -18,6 +18,12 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
+## [v2.2.0] (in progress)
+
+### Fixed
+
+- `/tickers` endpoint `base_volume_nominal` field ([#761]).
+
 ## [v2.1.0] (hot upgradable)
 
 ### Added
@@ -231,6 +237,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#746]: https://github.com/econia-labs/econia/pull/746
 [#749]: https://github.com/econia-labs/econia/pull/749
 [#753]: https://github.com/econia-labs/econia/pull/753
+[#761]: https://github.com/econia-labs/econia/pull/761
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [processor #19]: https://github.com/econia-labs/aptos-indexer-processors/pull/19

--- a/src/rust/dbv2/migrations/2024-05-01-120043_fix_nominal/down.sql
+++ b/src/rust/dbv2/migrations/2024-05-01-120043_fix_nominal/down.sql
@@ -1,0 +1,33 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.tickers;
+
+
+CREATE VIEW api.tickers AS
+SELECT
+    market_id,
+    base_account_address || '::' || base_module_name || '::' || base_struct_name AS base_currency,
+    quote_account_address || '::' || quote_module_name || '::' || quote_struct_name AS quote_currency,
+    base_volume_24h AS base_volume,
+    quote_volume_24h AS quote_volume,
+    (
+        base_volume_24h *
+        (SELECT lot_size FROM market_registration_events AS x WHERE x.market_id = markets.market_id) /
+        POW(10,quote_decimals)
+    )
+    AS base_volume_nominal,
+    (
+        quote_volume_24h *
+        (SELECT tick_size FROM market_registration_events AS x WHERE x.market_id = markets.market_id) /
+        POW(10,quote_decimals)
+    )
+    AS quote_volume_nominal,
+    integer_price_to_quote_nominal(market_id, api.get_market_last_price(market_id)) AS last_price,
+    integer_price_to_quote_nominal(market_id, api.get_market_best_ask_price(market_id)) AS ask,
+    integer_price_to_quote_nominal(market_id, api.get_market_best_bid_price(market_id)) AS bid,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_high(market_id)) AS high,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_low(market_id)) AS low,
+    api.get_market_liquidity(market_id,200) / get_quote_volume_divisor_for_market(market_id) AS liquidity_in_quote
+FROM
+    api.markets;
+
+GRANT SELECT ON api.tickers TO web_anon;

--- a/src/rust/dbv2/migrations/2024-05-01-120043_fix_nominal/up.sql
+++ b/src/rust/dbv2/migrations/2024-05-01-120043_fix_nominal/up.sql
@@ -1,0 +1,33 @@
+-- Your SQL goes here
+DROP VIEW api.tickers;
+
+
+CREATE VIEW api.tickers AS
+SELECT
+    market_id,
+    base_account_address || '::' || base_module_name || '::' || base_struct_name AS base_currency,
+    quote_account_address || '::' || quote_module_name || '::' || quote_struct_name AS quote_currency,
+    base_volume_24h AS base_volume,
+    quote_volume_24h AS quote_volume,
+    (
+        base_volume_24h *
+        (SELECT lot_size FROM market_registration_events AS x WHERE x.market_id = markets.market_id) /
+        POW(10,base_decimals)
+    )
+    AS base_volume_nominal,
+    (
+        quote_volume_24h *
+        (SELECT tick_size FROM market_registration_events AS x WHERE x.market_id = markets.market_id) /
+        POW(10,quote_decimals)
+    )
+    AS quote_volume_nominal,
+    integer_price_to_quote_nominal(market_id, api.get_market_last_price(market_id)) AS last_price,
+    integer_price_to_quote_nominal(market_id, api.get_market_best_ask_price(market_id)) AS ask,
+    integer_price_to_quote_nominal(market_id, api.get_market_best_bid_price(market_id)) AS bid,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_high(market_id)) AS high,
+    integer_price_to_quote_nominal(market_id, api.get_market_24h_low(market_id)) AS low,
+    api.get_market_liquidity(market_id,200) / get_quote_volume_divisor_for_market(market_id) AS liquidity_in_quote
+FROM
+    api.markets;
+
+GRANT SELECT ON api.tickers TO web_anon;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes the `base_volume_nominal` field in the `/tickers` endpoint.

# Testing

## Easy way

- Connect to the SQL instance of `hot-208`
- Type `begin;`
- Paste the `up.sql` file and run
- `SELECT * FROM api.tickers` and triple check the data

## Hard way

- Spin up DSS
- Sync
- `SELECT * FROM api.tickers` and triple check the data

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
