### PR TITLE
[ECO-1643] fix and update deps

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -31,6 +31,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 ### Internal
 
 - Added dynamic batch sizing to avoid crashes during high usage ([#762]).
+- Updated Rust dependencies ([#764]).
 
 ## [v2.1.0] (hot upgradable)
 
@@ -248,6 +249,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#760]: https://github.com/econia-labs/econia/pull/760
 [#761]: https://github.com/econia-labs/econia/pull/761
 [#762]: https://github.com/econia-labs/econia/pull/762
+[#764]: https://github.com/econia-labs/econia/pull/764
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [processor #19]: https://github.com/econia-labs/aptos-indexer-processors/pull/19

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "anyhow",
  "aptos-sdk",
  "async-trait",
- "bigdecimal 0.3.0",
+ "bigdecimal 0.3.1",
  "chrono",
  "clap 4.4.6",
  "dotenvy",
@@ -99,7 +99,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal 0.3.0",
+ "bigdecimal 0.3.1",
  "chrono",
  "dotenvy",
  "serde",
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
@@ -2651,7 +2651,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 name = "dbv2"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.3.0",
+ "bigdecimal 0.4.3",
  "chrono",
  "diesel",
  "serde",
@@ -2717,11 +2717,11 @@ checksum = "d95203a6a50906215a502507c0f879a0ce7ff205a6111e2db2a5ef8e4bb92e43"
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
 dependencies = [
- "bigdecimal 0.3.0",
+ "bigdecimal 0.4.3",
  "bitflags 2.4.0",
  "byteorder",
  "chrono",
@@ -4218,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7202,9 +7202,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e50c216e3624ec8e7ecd14c6a6a6370aad6ee5d8cfc3ab30b5162eeeef2ed33"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7215,19 +7215,18 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6753e460c998bbd4cd8c6f0ed9a64346fcca0723d6e75e52fdc351c5d2169d"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash 0.8.11",
  "atoi",
- "bigdecimal 0.3.0",
+ "bigdecimal 0.3.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
- "dotenvy",
  "either",
  "event-listener",
  "futures-channel",
@@ -7260,9 +7259,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a793bb3ba331ec8359c1853bd39eed32cdd7baaf22c35ccf5c92a7e8d1189ec"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7273,9 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4ee1e104e00dedb6aa5ffdd1343107b0a4702e862a84320ee7cc74782d96fc"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
@@ -7299,13 +7298,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864b869fdf56263f4c95c45483191ea0af340f9f3e3e7b4d57a61c7c87a970db"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.4",
- "bigdecimal 0.3.0",
+ "bigdecimal 0.3.1",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -7343,13 +7342,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7ae0e6a97fb3ba33b23ac2671a5ce6e3cabe003f451abd5a56e7951d975624"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.4",
- "bigdecimal 0.3.0",
+ "bigdecimal 0.3.1",
  "bitflags 2.4.0",
  "byteorder",
  "chrono",
@@ -7373,7 +7372,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha1",
  "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
@@ -7385,9 +7383,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59dc83cf45d89c555a577694534fcd1b55c545a816c816ce51f20bbe56a4f3f"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -7404,6 +7402,7 @@ dependencies = [
  "sqlx-core",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -8327,6 +8326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8503,12 +8508,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.24.0"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
-dependencies = [
- "rustls-webpki",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,10 +34,10 @@ axum = "0.6.19"
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
-bigdecimal = { version = "0.4", features = ["serde"] }
+bigdecimal = { version = "=0.4.3", features = ["serde"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }
-diesel = { version = "=2.1.0", features = [
+diesel = { version = "=2.1.6", features = [
     "chrono",
     "postgres",
     "r2d2",
@@ -69,8 +69,8 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.8.24"
 sha2 = "0.9.3"
 sha3 = "0.9.1"
-sqlx = { version = "0.7.1", features = ["runtime-tokio-rustls"] }
-sqlx-postgres = "0.7.1"
+sqlx = { version = "0.7.4", features = ["runtime-tokio-rustls"] }
+sqlx-postgres = "0.7.4"
 tempfile = "3.3.0"
 toml = "0.7.4"
 thiserror = "1.0.44"

--- a/src/rust/aggregator/Cargo.toml
+++ b/src/rust/aggregator/Cargo.toml
@@ -8,7 +8,7 @@ aptos-sdk.workspace = true
 
 anyhow.workspace = true
 async-trait = "0.1.73"
-bigdecimal = { version = "=0.3.0", features = ["serde"] }
+bigdecimal = { version = "0.3.1", features = ["serde"] }
 chrono.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }
 dotenvy.workspace = true

--- a/src/rust/aggv2/Cargo.toml
+++ b/src/rust/aggv2/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.73"
-bigdecimal = { version = "=0.3.0", features = ["serde"] }
+bigdecimal = { version = "0.3.1", features = ["serde"] }
 chrono.workspace = true
 dotenvy.workspace = true
 serde.workspace = true

--- a/src/rust/dbv2/Cargo.toml
+++ b/src/rust/dbv2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bigdecimal = { version = "=0.3.0", features = ["serde"] }
+bigdecimal = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
 diesel = { workspace = true, features = ["chrono", "numeric", "postgres"] }
 serde = { workspace = true }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR updates the Rust deps (`bigdecimal`, `sqlx` and `diesel`) to be compatible with the Aptos processor repo.

# Testing

- Clone.
- Run `cargo check` inside `src/rust`.
- Run `cargo check` inside `src/rust/dependencies/aptos-indexer-processors/rust/processor`.

# Checklist

- [x] Did you update relevant documentation?
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)

