### PR TITLE
[ECO-1656] fix price when tick size isn't 1

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -28,6 +28,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 
 - `/tickers` endpoint `base_volume_nominal` field ([#761]).
 - `/tickers` endpoint `price` field ([#766]).
+- fixed nominal issues when tickers isn't 0 ([#767]).
 - fixed potential duplicates in `daily_rolling_volume_history`([#765]).
 
 ### Internal
@@ -254,6 +255,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#764]: https://github.com/econia-labs/econia/pull/764
 [#765]: https://github.com/econia-labs/econia/pull/765
 [#766]: https://github.com/econia-labs/econia/pull/766
+[#767]: https://github.com/econia-labs/econia/pull/767
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [processor #19]: https://github.com/econia-labs/aptos-indexer-processors/pull/19

--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -28,7 +28,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 
 - `/tickers` endpoint `base_volume_nominal` field ([#761]).
 - `/tickers` endpoint `price` field ([#766]).
-- fixed nominal issues when tickers isn't 0 ([#767]).
+- fixed nominal issues when tickers isn't 1 ([#767]).
 - fixed potential duplicates in `daily_rolling_volume_history`([#765]).
 
 ### Internal

--- a/src/rust/dbv2/migrations/2024-05-10-100712_fix_price_nominal/down.sql
+++ b/src/rust/dbv2/migrations/2024-05-10-100712_fix_price_nominal/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION integer_price_to_quote_nominal(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT integer_price_to_quote_indivisible_subunits(market_id, price) / get_quote_volume_divisor_for_market(market_id);
+$$ LANGUAGE sql;

--- a/src/rust/dbv2/migrations/2024-05-10-100712_fix_price_nominal/up.sql
+++ b/src/rust/dbv2/migrations/2024-05-10-100712_fix_price_nominal/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION integer_price_to_quote_nominal(market_id numeric, price numeric) RETURNS NUMERIC IMMUTABLE AS $$
+    SELECT integer_price_to_quote_indivisible_subunits($1, $2) / POW(10,decimals)
+    FROM market_registration_events AS m
+    INNER JOIN api.coins AS c
+    ON m.quote_account_address = c."address"
+    AND m.quote_module_name = c.module
+    AND m.quote_struct_name = c.struct
+    WHERE market_id = $1;
+$$ LANGUAGE sql;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a function that wrongly calculates nominal price when tick size is not 1.

# Testing

Spin up DSS, query `/tickers`.

# Checklist

- [x] Did you update relevant documentation?
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
