### PR TITLE
[ECO-1704] update aptos website to get api keys

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/ci-cd.md
+++ b/doc/doc-site/docs/off-chain/dss/ci-cd.md
@@ -45,7 +45,7 @@ This guide will help you set up continuous integration/continuous deployment (CI
    ```
 
    :::tip
-   [You can get a gRPC auth token from Aptos Labs](https://aptos-api-gateway-prod.firebaseapp.com/)
+   [You can get a gRPC auth token from Aptos Labs](https://developers.aptoslabs.com/)
    :::
 
 1. Initialize the CI/CD project runner, which on startup will run a script that installs dependencies:

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -37,7 +37,7 @@ The process is the same as running against testnet, just with a slightly differe
 ### Getting the API key
 
 Unless you are an infrastructure provider or want to run a fullnode yourself, the simplest way to get indexed transaction data is from the Aptos Labs gRPC endpoint (indexer v2 API).
-To connect to this service, you'll need to get an API key [here](https://aptos-api-gateway-prod.firebaseapp.com/).
+To connect to this service, you'll need to get an API key [here](https://developers.aptoslabs.com/).
 
 ### Generating a config
 

--- a/src/docker/example.env
+++ b/src/docker/example.env
@@ -24,7 +24,7 @@ ECONIA_ADDRESS="0xc0deb00c405f84c85dc13442e305df75d1288100cdd82675695f6148c7ece5
 # For a local end-to-end testing chain: http://streamer:50051
 GRPC_DATA_SERVICE_URL="https://grpc.mainnet.aptoslabs.com:443"
 
-# For a public chain you have to get this token from https://aptos-api-gateway-prod.firebaseapp.com/.
+# For a public chain you have to get this token from https://developers.aptoslabs.com/.
 # For a local end-to-end testing chain use: dummy_token
 GRPC_AUTH_TOKEN="<API_TOKEN>"
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR updates the documentation and replaces the link from the old Aptos API
key generator to the new one.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
