### PR TITLE
[ECO-1853] use candlesticks for instant volume

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -18,6 +18,12 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
+## [v2.2.1] (in progress)
+
+### Fixed
+
+- Fix inaccurate data in `/rpc/volume_history` endpoint ([#778]).
+
 ## [v2.2.0] (hot upgradable)
 
 ### Changed
@@ -261,6 +267,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#768]: https://github.com/econia-labs/econia/pull/768
 [#772]: https://github.com/econia-labs/econia/pull/772
 [#775]: https://github.com/econia-labs/econia/pull/775
+[#778]: https://github.com/econia-labs/econia/pull/778
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [processor #19]: https://github.com/econia-labs/aptos-indexer-processors/pull/19

--- a/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/down.sql
+++ b/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION api.volume_history (market_id numeric(20,0), "time" timestamptz) RETURNS TABLE(daily NUMERIC(20,0), total NUMERIC(20,0)) AS $$
+    SELECT
+        (SELECT volume_in_quote_subunits FROM api.daily_rolling_volume_history WHERE market_id = $1 AND $2 BETWEEN "time" AND "time" + interval '1 minute' ORDER BY "time" DESC LIMIT 1) AS daily,
+        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time < $2);
+$$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/up.sql
+++ b/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/up.sql
@@ -1,6 +1,24 @@
 -- Your SQL goes here
+
+-- Parameters:
+-- * `market_id`: The market ID that volume is queried for
+-- * `time`: The time up to which volume is measured
+--
+-- Returns:
+-- * `daily`: Market volume in the 24 hours before `time`, measured in indivisible quote subunits
+-- * `total`: All-time market volume before `time`, measured in indivisible quote subunits
 CREATE OR REPLACE FUNCTION api.volume_history (market_id numeric(20,0), "time" timestamptz) RETURNS TABLE(daily NUMERIC(20,0), total NUMERIC(20,0)) AS $$
-    SELECT
-        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time BETWEEN $2 - interval '1 day' AND $2) AS daily,
-        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time < $2) AS total;
+    SELECT (
+        SELECT COALESCE(SUM(volume), 0) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1)
+        FROM api.candlesticks
+        WHERE market_id = $1
+        AND resolution = 60
+        AND start_time BETWEEN $2 - interval '1 day' AND $2
+    ) AS daily, (
+        SELECT COALESCE(SUM(volume), 0) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1)
+        FROM api.candlesticks
+        WHERE market_id = $1
+        AND resolution = 60
+        AND start_time < $2
+    ) AS total;
 $$ LANGUAGE SQL;

--- a/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/up.sql
+++ b/src/rust/dbv2/migrations/2024-06-17-090914_fix_rpc_volume_history/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION api.volume_history (market_id numeric(20,0), "time" timestamptz) RETURNS TABLE(daily NUMERIC(20,0), total NUMERIC(20,0)) AS $$
+    SELECT
+        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time BETWEEN $2 - interval '1 day' AND $2) AS daily,
+        (SELECT SUM(volume) * (SELECT tick_size FROM market_registration_events WHERE market_id = $1) FROM api.candlesticks WHERE market_id = $1 AND resolution = 60 AND start_time < $2) AS total;
+$$ LANGUAGE SQL;


### PR DESCRIPTION
# Description

This PR fixes the `volume_history` endpoint.

Since the rolling volume pipeline was changed to not create an event when no activity is present on a market, that broke the `volume_history` endpoint.

It was now updated to use candlestick data rather than rolling volume.


# Checklist

- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
