### PR TITLE
[ECO-1909] update processor submodule (v1.15.1)

### DIFF
--- a/.github/workflows/verify-doc-site-build.yaml
+++ b/.github/workflows/verify-doc-site-build.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: 'actions/setup-node@v3'
       with:
         node-version: 20
-    - uses: 'pnpm/action-setup@v2'
+    - uses: 'pnpm/action-setup@v4'
       with:
         run_install: false
         version: '9.1.2'

--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -18,12 +18,16 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
-## [v2.2.1-rc.1][dss-v2.2.1-rc.1] (hot upgradeable)
+## [v2.3.0-rc.1][dss-v2.3.0-rc.1] (hot upgradeable)
 
 ### Fixed
 
 - Fix inaccurate data in `/rpc/volume_history` endpoint ([#778]).
 - Improve performance of daily rolling volume history indexing ([#780]).
+
+### Internal
+
+- Update processor submodule to include upstream updates ([#783], [Processor #31]).
 
 ## [v2.2.0] (hot upgradable)
 
@@ -270,9 +274,11 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#775]: https://github.com/econia-labs/econia/pull/775
 [#778]: https://github.com/econia-labs/econia/pull/778
 [#780]: https://github.com/econia-labs/econia/pull/780
+[#783]: https://github.com/econia-labs/econia/pull/783
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [dss-v2.2.1-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.2.1-rc.1
+[dss-v2.3.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.3.0-rc.1
 [processor #19]: https://github.com/econia-labs/aptos-indexer-processors/pull/19
 [processor #20]: https://github.com/econia-labs/aptos-indexer-processors/pull/20
 [processor #21]: https://github.com/econia-labs/aptos-indexer-processors/pull/21
@@ -281,6 +287,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [processor #24]: https://github.com/econia-labs/aptos-indexer-processors/pull/24
 [processor #25]: https://github.com/econia-labs/aptos-indexer-processors/pull/25
 [processor #27]: https://github.com/econia-labs/aptos-indexer-processors/pull/27
+[processor #31]: https://github.com/econia-labs/aptos-indexer-processors/pull/31
 [processor submodule]: https://github.com/econia-labs/aptos-indexer-processors/pulls?q=is%3Aclosed
 [v1.3.0]: https://github.com/econia-labs/econia/releases/tag/dss-v1.3.0
 [v1.4.0]: https://github.com/econia-labs/econia/compare/dss-v1.3.0...dss-v1.4.0


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Update submodule to use v1.15.1 of the aptos indexer.

# Testing

Spin up DSS.

# Checklist

- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
