### PR TITLE
[ECO-1962] fix crate versioning issue

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "anyhow",
  "aptos-sdk",
  "async-trait",
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "chrono",
  "clap 4.4.6",
  "dotenvy",
@@ -99,7 +99,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "chrono",
  "dotenvy",
  "serde",
@@ -1713,24 +1713,10 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
 dependencies = [
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "bigdecimal"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
-dependencies = [
- "autocfg",
- "libm",
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
@@ -2651,7 +2637,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 name = "dbv2"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.4.3",
+ "bigdecimal",
  "chrono",
  "diesel",
  "serde",
@@ -2717,11 +2703,11 @@ checksum = "d95203a6a50906215a502507c0f879a0ce7ff205a6111e2db2a5ef8e4bb92e43"
 
 [[package]]
 name = "diesel"
-version = "2.1.6"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bigdecimal 0.4.3",
+ "bigdecimal",
  "bitflags 2.4.0",
  "byteorder",
  "chrono",
@@ -5112,7 +5098,7 @@ name = "mqtt-publisher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bigdecimal 0.4.3",
+ "bigdecimal",
  "chrono",
  "rumqttc",
  "serde",
@@ -7221,7 +7207,7 @@ checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash 0.8.11",
  "atoi",
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
@@ -7304,7 +7290,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.4",
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -7348,7 +7334,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.4",
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "bitflags 2.4.0",
  "byteorder",
  "chrono",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,10 +34,10 @@ axum = "0.6.19"
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
-bigdecimal = { version = "=0.4.3", features = ["serde"] }
+bigdecimal = { version = "=0.3.0", features = ["serde"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }
-diesel = { version = "=2.1.6", features = [
+diesel = { version = "=2.1.0", features = [
     "chrono",
     "postgres",
     "r2d2",

--- a/src/rust/aggregator/Cargo.toml
+++ b/src/rust/aggregator/Cargo.toml
@@ -8,7 +8,7 @@ aptos-sdk.workspace = true
 
 anyhow.workspace = true
 async-trait = "0.1.73"
-bigdecimal = { version = "0.3.1", features = ["serde"] }
+bigdecimal = { version = "=0.3.0", features = ["serde"] }
 chrono.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }
 dotenvy.workspace = true

--- a/src/rust/aggv2/Cargo.toml
+++ b/src/rust/aggv2/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.73"
-bigdecimal = { version = "0.3.1", features = ["serde"] }
+bigdecimal = { version = "=0.3.0", features = ["serde"] }
 chrono.workspace = true
 dotenvy.workspace = true
 serde.workspace = true


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Fix crate versioning issue.

This happens quite often when incorporating processor upstream changes and is very annoying.
