### PR TITLE
Remove mut in Rust sdk submit_tx

### DIFF
--- a/src/rust/e2e/src/market_registration.rs
+++ b/src/rust/e2e/src/market_registration.rs
@@ -27,7 +27,7 @@ pub async fn test_market_registration<'a>(state: &'a State) -> Result<()> {
     )
     .unwrap();
 
-    let (_, mut econia_client) =
+    let (_, econia_client) =
         account(&state.faucet_client, &state.node_url, state.econia_address).await;
 
     econia_client.submit_tx(entry).await?;

--- a/src/rust/sdk/example/src/main.rs
+++ b/src/rust/sdk/example/src/main.rs
@@ -321,7 +321,7 @@ async fn main() -> EconiaResult<()> {
         faucet_address,
         faucet_client,
         econia_address,
-        mut econia_client,
+        econia_client,
     } = init(&args).await;
 
     print_title!("Create a market for eAPT/eUSDC");

--- a/src/rust/sdk/src/lib.rs
+++ b/src/rust/sdk/src/lib.rs
@@ -321,7 +321,7 @@ impl EconiaClient {
     }
 
     async fn submit_tx_internal(
-        &mut self,
+        &self,
         payload: &EntryFunction,
     ) -> EconiaResult<EconiaTransaction> {
         let addr = self.user_account.address();
@@ -382,7 +382,7 @@ impl EconiaClient {
     /// # Arguments:
     ///
     /// * `entry` - `EntryFunction` to be submitted as part of the transaction to the blockchain.
-    pub async fn submit_tx(&mut self, entry: EntryFunction) -> EconiaResult<EconiaTransaction> {
+    pub async fn submit_tx(&self, entry: EntryFunction) -> EconiaResult<EconiaTransaction> {
         for i in 0..(self.config.retry_count) {
             match self.submit_tx_internal(&entry).await {
                 Ok(lt) => return Ok(lt),


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

I want to use `Arc` share/clone Rust SDK EconiaClient, but submit_tx of EconiaClient is mutable can't used inside `Arc` by ref.

I notice that submit_tx mut sequence_number of account, but it is a **Atomic do not require mut ref** to modified it, So submit_tx do not need mutable and safely used inside Arc

# Testing

cargo build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)

> If a task does not apply to your PR, strike it through and mark it complete:

This change is compatible with previous usage of submit_tx no need to write changelog

```md
- [x] ~Did you update the changelog?~
```
