### PR TITLE
[ECO-1971] fix coins pipeline for coins starting with 0x0

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -18,12 +18,13 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
-## [v2.3.0-rc.1][dss-v2.3.0-rc.1] (hot upgradeable)
+## [v2.3.0][dss-v2.3.0] (hot upgradeable)
 
 ### Fixed
 
 - Fix inaccurate data in `/rpc/volume_history` endpoint ([#778]).
 - Improve performance of daily rolling volume history indexing ([#780]).
+- Fix coins pipeline not working for coins which have an address starting with `0x0` ([#788]).
 
 ### Internal
 
@@ -276,6 +277,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#780]: https://github.com/econia-labs/econia/pull/780
 [#783]: https://github.com/econia-labs/econia/pull/783
 [#786]: https://github.com/econia-labs/econia/pull/786
+[#788]: https://github.com/econia-labs/econia/pull/788
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [dss-v2.2.1-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.2.1-rc.1

--- a/src/rust/aggregator/src/pipelines/coins.rs
+++ b/src/rust/aggregator/src/pipelines/coins.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use anyhow::anyhow;
 use aptos_sdk::{
     rest_client::{AptosBaseUrl, Client},
@@ -134,7 +136,7 @@ async fn get_coin_info(
     let move_struct_tag_str: String = move_struct_tag_str.into();
     let client = Client::new(network.to_url());
     let ad = move_struct_tag_str.split("::").collect::<Vec<_>>()[0];
-    let ad = AccountAddress::from_str_strict(ad).map_err(map_other)?;
+    let ad = AccountAddress::from_str(ad).map_err(map_other)?;
     let res = client
         .get_account_resource(ad, &format!("0x1::coin::CoinInfo<{}>", move_struct_tag_str))
         .await;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Currently, the coins pipeline does not work for addresses that start with 0x0. This PR fixes that.

# Testing

Run DSS.

# Checklist

- [x] Did you update the changelog?
