### PR TITLE
[ECO-2045] Fix docker compose build by updating the time crate

### DIFF
--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -18,6 +18,12 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 1. Merge `main` into `dss-stable`.
 1. Push annotated tag to head of `dss-stable`.
 
+## [v2.4.0] (in progress)
+
+### Fixed
+
+- Updated the `time` crate to fix DSS docker compilation ([#793]).
+
 ## [v2.3.0] (hot upgradable)
 
 ### Fixed
@@ -278,6 +284,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#783]: https://github.com/econia-labs/econia/pull/783
 [#786]: https://github.com/econia-labs/econia/pull/786
 [#788]: https://github.com/econia-labs/econia/pull/788
+[#793]: https://github.com/econia-labs/econia/pull/793
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1
 [dss-v2.2.1-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.2.1-rc.1

--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -20,6 +20,10 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 
 ## [v2.4.0] (in progress)
 
+### Added
+
+- Transaction version field inside levels MQTT events ([#792]).
+
 ### Fixed
 
 - Updated the `time` crate to fix DSS docker compilation ([#793]).
@@ -284,6 +288,7 @@ Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-
 [#783]: https://github.com/econia-labs/econia/pull/783
 [#786]: https://github.com/econia-labs/econia/pull/786
 [#788]: https://github.com/econia-labs/econia/pull/788
+[#792]: https://github.com/econia-labs/econia/pull/792
 [#793]: https://github.com/econia-labs/econia/pull/793
 [docs site readme]: https://github.com/econia-labs/econia/blob/main/doc/doc-site/README.md
 [dss-v2.1.0-rc.1]: https://github.com/econia-labs/econia/releases/tag/dss-v2.1.0-rc.1

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2672,10 +2672,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -5289,6 +5290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5940,6 +5947,12 @@ dependencies = [
  "ark-ff",
  "ark-std",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -7687,12 +7700,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -7706,10 +7721,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The DSS wasn't building inside of docker compose.

This is due to the compilation of the aggregator, which depends on the `time` crate, which could not compile.

Updating the crate solved the issue.

# Testing

Delete this line and provide a description of how to test the changes in this
PR.

# Checklist

- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
