### PR TITLE
[ECO-2086] Add last_transaction_timestamp to data_status endpoint

### DIFF
--- a/src/rust/dbv2/migrations/2024-08-14-160622_add_last_transaction_timestamp_to_data_status/down.sql
+++ b/src/rust/dbv2/migrations/2024-08-14-160622_add_last_transaction_timestamp_to_data_status/down.sql
@@ -1,0 +1,23 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW api.data_status;
+
+CREATE VIEW api.data_status AS
+SELECT
+    CURRENT_TIMESTAMP AS current_time,
+    processor_status.last_success_version AS processor_last_txn_version_processed,
+    user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
+    array_agg(ARRAY[resolution, candlesticks_last_indexed_txn.txn_version]) AS aggregator_candlesticks_last_txn_version_processed
+FROM
+    processor_status,
+    aggregator.user_history_last_indexed_txn,
+    aggregator.candlesticks_last_indexed_txn
+WHERE
+    processor_status.processor = 'econia_processor'
+GROUP BY
+    user_history_last_indexed_txn.txn_version,
+    processor_status.last_success_version;
+
+
+GRANT
+SELECT
+  ON api.data_status TO web_anon;

--- a/src/rust/dbv2/migrations/2024-08-14-160622_add_last_transaction_timestamp_to_data_status/up.sql
+++ b/src/rust/dbv2/migrations/2024-08-14-160622_add_last_transaction_timestamp_to_data_status/up.sql
@@ -1,0 +1,25 @@
+-- Your SQL goes here
+DROP VIEW api.data_status;
+
+CREATE VIEW api.data_status AS
+SELECT
+    CURRENT_TIMESTAMP AS current_time,
+    processor_status.last_transaction_timestamp,
+    processor_status.last_success_version AS processor_last_txn_version_processed,
+    user_history_last_indexed_txn.txn_version AS aggregator_user_history_last_txn_version_processed,
+    array_agg(ARRAY[resolution, candlesticks_last_indexed_txn.txn_version]) AS aggregator_candlesticks_last_txn_version_processed
+FROM
+    processor_status,
+    aggregator.user_history_last_indexed_txn,
+    aggregator.candlesticks_last_indexed_txn
+WHERE
+    processor_status.processor = 'econia_processor'
+GROUP BY
+    user_history_last_indexed_txn.txn_version,
+    processor_status.last_success_version,
+    processor_status.last_transaction_timestamp;
+
+
+GRANT
+SELECT
+  ON api.data_status TO web_anon;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds the `last_transaction_timestamp` field to the `data_status` endpoint so that consumers can calculate lag easier.

# Testing

Depoly DSS, check `data_status` results.

# Checklist

- [ ] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
