### PR TITLE
[ECO-2123] Add index to speed up querying orders by order_id

### DIFF
--- a/src/rust/dbv2/migrations/2024-09-11-150020_optimize_querying_orders_by_order_id/down.sql
+++ b/src/rust/dbv2/migrations/2024-09-11-150020_optimize_querying_orders_by_order_id/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX aggregator.user_history_order_id;

--- a/src/rust/dbv2/migrations/2024-09-11-150020_optimize_querying_orders_by_order_id/up.sql
+++ b/src/rust/dbv2/migrations/2024-09-11-150020_optimize_querying_orders_by_order_id/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+CREATE INDEX user_history_order_id ON aggregator.user_history (order_id);


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds an index to speed up querying orders by order id.
