### PR TITLE
[ECO-2194] Add limit to query time

### DIFF
--- a/src/rust/dbv2/migrations/2024-09-20-111458_add_query_time_limit/down.sql
+++ b/src/rust/dbv2/migrations/2024-09-20-111458_add_query_time_limit/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER ROLE web_anon SET statement_timeout TO '0';

--- a/src/rust/dbv2/migrations/2024-09-20-111458_add_query_time_limit/up.sql
+++ b/src/rust/dbv2/migrations/2024-09-20-111458_add_query_time_limit/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER ROLE web_anon SET statement_timeout TO '1s';


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a maximum time to queries made by PostgREST.

This will prevent users hogging all DB connections.

Noting that all other roles can still make long queries, which means other tools like grafana can still use the DB like before.
