### PR TITLE
[ECO-2324] Add open order check to batch replace wrapper

### DIFF
--- a/src/move/econia-wrapper-demo/Move.toml
+++ b/src/move/econia-wrapper-demo/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "EconiaWrapperDemo"
-version = '0.1.0'
+version = '0.2.0'
 upgrade_policy = 'compatible'
 
 [addresses]
@@ -8,3 +8,7 @@ wrapper_publisher = "_"
 
 [dependencies.Econia]
 local = "../econia"
+
+[dev-addresses]
+econia = "0xc0de"
+wrapper_publisher = "0xace"

--- a/src/move/econia-wrapper-demo/README.md
+++ b/src/move/econia-wrapper-demo/README.md
@@ -25,7 +25,8 @@ aptos move publish \
 
 Results:
 
-- [Initial publication transaction]
+- [Initial publication transaction (`v0.1.0`)]
+- [Package `v0.2.0` re-publication]
 - [Package deployment]
 
 ## Invoking a transaction:
@@ -62,8 +63,13 @@ aptos move run \
 
 Results:
 
-- [Successful transaction (order IDs to cancel are for open orders)]
+- [Successful transaction (order IDs to cancel are for open orders, `v0.1.0`)]
+- [Successful transaction (order IDs to cancel are for closed orders), `v0.2.0`]
+- [Successful transaction (order IDs to cancel are for open orders, `v0.2.0`)]
 
-[Initial publication transaction]: https://explorer.aptoslabs.com/txn/789995990?network=testnet
+[Initial publication transaction (`v0.1.0`)]: https://explorer.aptoslabs.com/txn/789995990?network=testnet
 [Package deployment]: https://explorer.aptoslabs.com/account/0x6a8134d4a23c44b7b8f0db989568825c155ccc6d020cc85224a188cd9b9d37c1/modules/code/cancel_and_place?network=testnet
-[Successful transaction (order IDs to cancel are for open orders)]: https://explorer.aptoslabs.com/txn/790010705/events?network=testnet
+[Package `v0.2.0` re-publication]: https://explorer.aptoslabs.com/txn/6175261891?network=testnet
+[Successful transaction (order IDs to cancel are for open orders, `v0.1.0`)]: https://explorer.aptoslabs.com/txn/790010705/events?network=testnet
+[Successful transaction (order IDs to cancel are for closed orders), `v0.2.0`]: https://explorer.aptoslabs.com/txn/0x7dc56f6f46bf6ca06b5d94eb06cf2be7b865f000da63fd6398412fb889dcb95d/events?network=testnet
+[Successful transaction (order IDs to cancel are for open orders, `v0.2.0`)]: https://explorer.aptoslabs.com/txn/0x276adc25fecb975b51272a44d7f8596ba4fb4f4467178ac26a912e7f7086c595/events?network=testnet

--- a/src/move/econia-wrapper-demo/README.md
+++ b/src/move/econia-wrapper-demo/README.md
@@ -1,6 +1,7 @@
 # Econia wrapper demo
 
-This package contains a demo Move wrapper, useful for combining multiple Econia Move operations into one.
+This package contains a demo Move wrapper, useful for combining multiple Econia
+Move operations into one.
 
 ## Publishing the package
 
@@ -24,8 +25,8 @@ aptos move publish \
 
 Results:
 
-- [Publication transaction](https://explorer.aptoslabs.com/txn/789995990?network=testnet)
-- [Package deployment](https://explorer.aptoslabs.com/account/0x6a8134d4a23c44b7b8f0db989568825c155ccc6d020cc85224a188cd9b9d37c1/modules/code/cancel_and_place?network=testnet)
+- [Initial publication transaction]
+- [Package deployment]
 
 ## Invoking a transaction:
 
@@ -61,4 +62,8 @@ aptos move run \
 
 Results:
 
-- [Successful transaction](https://explorer.aptoslabs.com/txn/790010705/events?network=testnet)
+- [Successful transaction (order IDs to cancel are for open orders)]
+
+[Initial publication transaction]: https://explorer.aptoslabs.com/txn/789995990?network=testnet
+[Package deployment]: https://explorer.aptoslabs.com/account/0x6a8134d4a23c44b7b8f0db989568825c155ccc6d020cc85224a188cd9b9d37c1/modules/code/cancel_and_place?network=testnet
+[Successful transaction (order IDs to cancel are for open orders)]: https://explorer.aptoslabs.com/txn/790010705/events?network=testnet

--- a/src/move/econia-wrapper-demo/sources/cancel_and_place.move
+++ b/src/move/econia-wrapper-demo/sources/cancel_and_place.move
@@ -33,10 +33,14 @@ module wrapper_publisher::cancel_and_place {
         let ask_flag = market::get_ASK();
         let bid_flag = market::get_BID();
         vector::for_each_ref(&ask_order_ids_to_cancel, |order_id_ref| {
-            market::cancel_order_user(user, market_id, ask_flag, *order_id_ref)
+            let order_id = *order_id_ref;
+            if (market::has_open_order(market_id, order_id))
+                market::cancel_order_user(user, market_id, ask_flag, order_id)
         });
         vector::for_each_ref(&bid_order_ids_to_cancel, |order_id_ref| {
-            market::cancel_order_user(user, market_id, bid_flag, *order_id_ref)
+            let order_id = *order_id_ref;
+            if (market::has_open_order(market_id, order_id))
+                market::cancel_order_user(user, market_id, bid_flag, order_id)
         });
         let i = 0;
         while (i < n_ask_sizes) {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The wrapper for batch replace sometimes errors out when an order gets filled
just before the cancel instruction comes in.

1. Add a check to verify the market has an open order with the given order ID
   before trying to cancel it.
1. Bump version in `Move.toml`.
1. Add `dev-addresses` for easier checking with `aptos move compile --dev`.

# Testing

See successful testnet transactions added to README.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you update the changelog?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
