### PR TITLE
docs(ECO-3279): Document project deprecation

### DIFF
--- a/doc/doc-site/docs/apis/assets.md
+++ b/doc/doc-site/docs/apis/assets.md
@@ -1,5 +1,10 @@
 # Asset management
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Deposits
 
 - [`deposit_coins()`](https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/user.md#function-deposit_coins)

--- a/doc/doc-site/docs/apis/index.md
+++ b/doc/doc-site/docs/apis/index.md
@@ -1,5 +1,10 @@
 # Move APIs
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 The Move application programming interfaces (APIs) in this section are presented in an order representative of Econia's overall operational flow.
 Hence [registration] APIs come before [trading] APIs, etc.
 

--- a/doc/doc-site/docs/apis/integrators.md
+++ b/doc/doc-site/docs/apis/integrators.md
@@ -1,5 +1,10 @@
 # Integrator fee management
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Global parameter getters
 
 - [`get_fee_share_divisor()`](https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/incentives.md#function-get_fee_share_divisor)

--- a/doc/doc-site/docs/apis/registration.md
+++ b/doc/doc-site/docs/apis/registration.md
@@ -1,5 +1,10 @@
 # Registration
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Registration fee lookup
 
 - [`get_custodian_registration_fee()`](https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/incentives.md#function-get_custodian_registration_fee)

--- a/doc/doc-site/docs/apis/trading.md
+++ b/doc/doc-site/docs/apis/trading.md
@@ -1,5 +1,10 @@
 # Trading
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Limit orders
 
 - [`place_limit_order_custodian()`](https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-place_limit_order_custodian)

--- a/doc/doc-site/docs/apis/utility.md
+++ b/doc/doc-site/docs/apis/utility.md
@@ -1,5 +1,10 @@
 # Utility functions
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Market order ID getters
 
 - [`did_order_post()`](https://github.com/econia-labs/econia/blob/main/src/move/econia/doc/market.md#function-did_order_post)

--- a/doc/doc-site/docs/glossary.md
+++ b/doc/doc-site/docs/glossary.md
@@ -1,5 +1,10 @@
 # Econia glossary
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 More to come!
 
 ## C

--- a/doc/doc-site/docs/integrators/bridges.md
+++ b/doc/doc-site/docs/integrators/bridges.md
@@ -1,5 +1,10 @@
 # Bridges
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Bridging USDC (LayerZero)
 
 ### What is Stargate and why is it relevant?

--- a/doc/doc-site/docs/integrators/econia-labs.md
+++ b/doc/doc-site/docs/integrators/econia-labs.md
@@ -1,5 +1,10 @@
 # From Econia Labs
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Check out the following resources from Econia Labs:
 
 1. [Teach yourself Move]

--- a/doc/doc-site/docs/integrators/notifications.md
+++ b/doc/doc-site/docs/integrators/notifications.md
@@ -1,3 +1,8 @@
 # Notifications
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Stay tuned for more resources about notification systems to integrate with Econia!

--- a/doc/doc-site/docs/integrators/pyth.md
+++ b/doc/doc-site/docs/integrators/pyth.md
@@ -1,5 +1,10 @@
 # Pyth Network
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Consume Pyth Network prices on Aptos
 
 Aptos contracts can update and fetch Pyth prices using the Pyth Aptos package, which has been deployed on Mainnet.

--- a/doc/doc-site/docs/integrators/reference-frontend.md
+++ b/doc/doc-site/docs/integrators/reference-frontend.md
@@ -1,5 +1,10 @@
 # Reference frontend
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Background
 
 The Econia [reference frontend](https://reference.econia.exchange/) is designed to streamline the challenges encountered during the initial phases of DeFi product development.

--- a/doc/doc-site/docs/logo.md
+++ b/doc/doc-site/docs/logo.md
@@ -1,5 +1,10 @@
 # Logo guidelines
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Thank you for being part of the Econia ecosystem!
 If you are using Econia as a back-end settlement engine and would like to incorporate the Econia logo in your project, please use the **_secondary logo_** ([found here](https://www.econialabs.com/brand)).
 

--- a/doc/doc-site/docs/logo.md
+++ b/doc/doc-site/docs/logo.md
@@ -6,7 +6,7 @@ Aptos, see: https://x.com/AveryChing/status/1907866088186196417
 :::
 
 Thank you for being part of the Econia ecosystem!
-If you are using Econia as a back-end settlement engine and would like to incorporate the Econia logo in your project, please use the **_secondary logo_** ([found here](https://www.econialabs.com/brand)).
+If you are using Econia as a back-end settlement engine and would like to incorporate the Econia logo in your project, please use the **_secondary logo_** ([previously found at this now-dead link](https://www.econialabs.com/brand)).
 
 <br />
 

--- a/doc/doc-site/docs/move/changelog.md
+++ b/doc/doc-site/docs/move/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Econia Move source code adheres to [Semantic Versioning] and [Keep a Changelog] standards.
 
 ## [v4.3.0]

--- a/doc/doc-site/docs/move/modules.md
+++ b/doc/doc-site/docs/move/modules.md
@@ -1,5 +1,11 @@
 # Move modules
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
+
 | Module             | Source code             | Documentation         |
 | ------------------ | ----------------------- | --------------------- |
 | `assets`           | [assets.move]           | [assets.md]           |

--- a/doc/doc-site/docs/off-chain/dss/changelog.md
+++ b/doc/doc-site/docs/off-chain/dss/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Stable DSS builds are tracked on the [`dss-stable`] branch with tags like [`dss-v1.3.0`][v1.3.0].
 
 ## Release procedure

--- a/doc/doc-site/docs/off-chain/dss/ci-cd.md
+++ b/doc/doc-site/docs/off-chain/dss/ci-cd.md
@@ -4,6 +4,11 @@ title: CI/CD
 
 # Continuous integration and deployment
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 This guide will help you set up continuous integration/continuous deployment (CI/CD) workflows for a DSS deployment on Google Cloud Platform (GCP).
 
 ## Dependencies

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -1,5 +1,10 @@
 # Data service stack
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 The Econia data service stack (DSS) is a collection of services that provide assorted data endpoints for integration purposes.
 It exposes a REST API and an MQTT server, which are powered internally by an aggregator, a database, and an indexer.
 To ensure composability, portability, and ease of use, each component is represented as a Docker service inside of a Docker compose environment.

--- a/doc/doc-site/docs/off-chain/dss/data-service-stack.md
+++ b/doc/doc-site/docs/off-chain/dss/data-service-stack.md
@@ -12,6 +12,12 @@ For more on Docker, see [the official docs](https://docs.docker.com/).
 
 This page will show you how to run the DSS locally.
 
+:::tip
+If you still want to use the DSS even though Econia is not maintained, you may
+need to fork and update the processor to use Aptos indexer SDK per:
+https://github.com/econia-labs/econia/pull/808
+:::
+
 ## How it works
 
 The DSS exposes a REST API and an MQTT server.

--- a/doc/doc-site/docs/off-chain/dss/gcp.md
+++ b/doc/doc-site/docs/off-chain/dss/gcp.md
@@ -1,5 +1,10 @@
 # Deploying on GCP
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 :::danger
 Manual deployment is not recommended, and this guide is not actively maintained.
 See the [DSS CI/CD guide](./ci-cd.md) for the most up-to-date deployment steps.

--- a/doc/doc-site/docs/off-chain/dss/mqtt.md
+++ b/doc/doc-site/docs/off-chain/dss/mqtt.md
@@ -1,5 +1,10 @@
 # MQTT
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Econia's [DSS](./data-service-stack.md) provides an MQTT server for real-time notifications.
 It uses Mosquitto as the MQTT server, and a custom Rust program to publish PostgreSQL events to MQTT.
 

--- a/doc/doc-site/docs/off-chain/dss/rest-api.md
+++ b/doc/doc-site/docs/off-chain/dss/rest-api.md
@@ -3,6 +3,11 @@ title: REST API
 hide_table_of_contents: true
 ---
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 import ApiDocMdx from "@theme/ApiDocMdx"
 
 <ApiDocMdx id="dss-rest-api"/>

--- a/doc/doc-site/docs/off-chain/dss/terraform.md
+++ b/doc/doc-site/docs/off-chain/dss/terraform.md
@@ -1,5 +1,10 @@
 # Using Terraform
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 :::danger
 This guide is not actively maintained.
 See the [DSS CI/CD guide](./ci-cd.md) for the most up-to-date deployment steps.

--- a/doc/doc-site/docs/off-chain/events.md
+++ b/doc/doc-site/docs/off-chain/events.md
@@ -1,5 +1,10 @@
 # Events
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## Registry events
 
 Econia emits two types of registry events:

--- a/doc/doc-site/docs/off-chain/python-sdk.md
+++ b/doc/doc-site/docs/off-chain/python-sdk.md
@@ -1,5 +1,10 @@
 # Python SDK
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 The code for the Python SDK lives in [`/econia/src/python/sdk/econia_sdk`](https://github.com/econia-labs/econia/tree/main/src/python/sdk/econia_sdk).
 There are 2 primary packages ([`econia_sdk.entry`](https://github.com/econia-labs/econia/tree/main/src/python/sdk/econia_sdk/entry) and [`econia_sdk.view`](https://github.com/econia-labs/econia/tree/main/src/python/sdk/econia_sdk/view)) complemented by two secondary imports.
 This code provides programmatic access to Econia exchanges, in addition to offering an example of how to put it all together shown later in this document.

--- a/doc/doc-site/docs/off-chain/rust-sdk.md
+++ b/doc/doc-site/docs/off-chain/rust-sdk.md
@@ -1,5 +1,10 @@
 # Rust SDK
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 The code for the Rust SDK lives in [`/econia/src/rust/sdk`](https://github.com/econia-labs/econia/tree/main/src/rust/sdk/example).
 The SDK provides direct access to the Econia protocol, and comes with an example script described below.
 

--- a/doc/doc-site/docs/overview/incentives.md
+++ b/doc/doc-site/docs/overview/incentives.md
@@ -1,5 +1,10 @@
 # Incentives
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## General
 
 As described in the [incentives module documentation], Econia is a permissionless system that mitigates denial-of-service (DoS) attacks by charging utility coins for assorted operations.

--- a/doc/doc-site/docs/overview/index.md
+++ b/doc/doc-site/docs/overview/index.md
@@ -1,5 +1,10 @@
 # Design overview
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 ## General
 
 As an [Aptos]-native project, Econia is designed from the ground up to leverage [Block-STM] and the [Move] programming language.

--- a/doc/doc-site/docs/overview/market-accounts.md
+++ b/doc/doc-site/docs/overview/market-accounts.md
@@ -1,5 +1,10 @@
 # Market accounts
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 When an Econia user places a limit order or a market order (or if a custodian places one on their behalf), the user's assets and orders are tracked in a [`MarketAccount`] that is specific to the given [market] and [custodian].
 
 As explained in the [user module documentation], the concatenated result of market and custodian IDs is known as a "market account ID", which is used for [`MarketAccount`] lookup inside a user's [`MarketAccounts`] as well as inside of a [`Collateral`] resource for any relevant coin types.

--- a/doc/doc-site/docs/overview/matching.md
+++ b/doc/doc-site/docs/overview/matching.md
@@ -1,5 +1,10 @@
 # Matching
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Econia's matching engine is atomic and crankless, which means that taker orders either fill against maker orders during the transaction in which they are placed, or do not fill at all.
 This fully-autonomous process eliminates the need for a so-called "crank" sometimes required by other on-chain order books, which rely on third parties to trigger the matching process via external transactions.
 In practice, this means that Econia matching operations can be stacked back-to-back within a single transaction, for maximum composability.

--- a/doc/doc-site/docs/overview/orders.md
+++ b/doc/doc-site/docs/overview/orders.md
@@ -1,5 +1,10 @@
 # Orders
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 For each market, Econia tracks bids and asks in two places:
 
 1. A global [`OrderBook`] resource for the market.

--- a/doc/doc-site/docs/overview/registry.md
+++ b/doc/doc-site/docs/overview/registry.md
@@ -1,5 +1,10 @@
 # The registry
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Econia contains a global [`Registry`] that tracks information about [markets], [custodians], and [underwriters], all of which can be registered permissionlessly.
 An additional [recognized markets] registry provides additional functionality for certain markets that are recognized as following best practices for [market size parameters].
 

--- a/doc/doc-site/docs/security.md
+++ b/doc/doc-site/docs/security.md
@@ -1,5 +1,10 @@
 # Security
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 Econia has been independently audited by three firms, and all [audit reports] are public:
 Move source code is audited through commit [`f974e80`] (tag [`v4.3.0-audited`]), via three initial audits and six followup audits.
 

--- a/doc/doc-site/docs/welcome.md
+++ b/doc/doc-site/docs/welcome.md
@@ -5,6 +5,11 @@ hide_title: true
 description: Documentation for the Econia Protocol
 ---
 
+:::note
+Econia is no longer actively maintained. If you want an onchain order book for
+Aptos, see: https://x.com/AveryChing/status/1907866088186196417
+:::
+
 <div className="welcome-heading">
     <div>
         <h2 style={{ marginBottom: "40px" }}>Welcome</h2>


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add `note` admonition to each page explaining that Econia isn't maintained, with a link to `AptosBook` announcement
1. Link to DSS processor overhaul draft PR on DSS landing page
1. Flag link rot on a known dead link

# Testing

1. Docs site local clickthrough per `doc/doc-site/README.me`
1. CI docs build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
